### PR TITLE
fix: cold-start death spiral + HibernationManager wiring

### DIFF
--- a/dharma_swarm/swarm.py
+++ b/dharma_swarm/swarm.py
@@ -491,9 +491,9 @@ class SwarmManager:
         try:
             from dharma_swarm.hibernation import HibernationManager
 
-            hib_db = str(self.state_dir / "db" / "hibernation.db")
-            (self.state_dir / "db").mkdir(parents=True, exist_ok=True)
-            self._hibernation_manager = HibernationManager(db_path=hib_db)
+            hib_dir = self.state_dir / "hibernation"
+            hib_dir.mkdir(parents=True, exist_ok=True)
+            self._hibernation_manager = HibernationManager(state_dir=hib_dir)
             if self._orchestrator is not None:
                 self._orchestrator.set_hibernation_manager(self._hibernation_manager)
             if self._organism is not None and hasattr(self._organism, "set_hibernation_manager"):
@@ -1292,6 +1292,11 @@ class SwarmManager:
         return len(dispatches)
 
     # ── Algedonic Channel (Beer S5 bypass to operator) ─────────────
+    # How many seconds after boot before EMERGENCY_HOLD can be written.
+    # Prevents cold-start death spiral where low coherence (no daemon PID,
+    # sparse subsystem files) immediately kills the swarm.
+    _COLD_START_GRACE_SECONDS: float = 120.0
+
     def _algedonic_handler(self, signal: Any) -> None:
         """Beer's algedonic channel: pain signal → file + macOS notification.
 
@@ -1318,9 +1323,10 @@ class SwarmManager:
         except OSError as exc:
             logger.warning("Algedonic log write failed: %s", exc)
 
-        # 2. Write EMERGENCY_HOLD marker if critical
+        # 2. Write EMERGENCY_HOLD marker if critical (but not during cold-start grace)
         severity = getattr(signal, "severity", "")
-        if severity == "critical":
+        uptime = time.monotonic() - getattr(self, '_start_time', time.monotonic())
+        if severity == "critical" and uptime > self._COLD_START_GRACE_SECONDS:
             hold_path = self.state_dir / "EMERGENCY_HOLD"
             try:
                 hold_path.write_text(
@@ -1330,6 +1336,12 @@ class SwarmManager:
                 )
             except OSError as exc:
                 logger.warning("EMERGENCY_HOLD write failed: %s", exc)
+        elif severity == "critical":
+            logger.info(
+                "Cold-start grace (%.0fs < %.0fs): suppressing EMERGENCY_HOLD for %s",
+                uptime, self._COLD_START_GRACE_SECONDS,
+                getattr(signal, 'kind', 'unknown'),
+            )
 
         # 3. macOS notification (non-blocking, best-effort)
         kind = getattr(signal, "kind", "unknown")

--- a/tests/test_e2e_boot.py
+++ b/tests/test_e2e_boot.py
@@ -1,0 +1,168 @@
+"""End-to-end boot smoke test: init → tick → dispatch → complete → knowledge → Darwin.
+
+Runs the full SwarmManager lifecycle in mock mode (no LLM keys needed).
+This is the acid test: does the wiring from PR #9 actually work end-to-end?
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+
+import pytest
+
+logging.basicConfig(level=logging.INFO, format="%(name)s: %(message)s")
+logger = logging.getLogger("e2e_boot")
+
+
+@pytest.fixture
+def state_dir(tmp_path):
+    d = tmp_path / ".dharma_e2e"
+    d.mkdir()
+    return str(d)
+
+
+@pytest.mark.asyncio
+async def test_full_lifecycle_boot(state_dir):
+    """Boot swarm → tick → dispatch tasks → verify completion pipeline."""
+    from dharma_swarm.swarm import SwarmManager
+    from pathlib import Path
+
+    logger.info("=== PHASE 1: Init SwarmManager ===")
+    swarm = SwarmManager(state_dir=state_dir)
+    await swarm.init()
+
+    # Verify agents spawned (correct attr: _agent_pool)
+    pool = swarm._agent_pool
+    agents = getattr(pool, 'agents', getattr(pool, '_agents', {}))
+    agent_count = len(agents)
+    logger.info(f"Agents spawned: {agent_count}")
+    assert agent_count > 0, "No agents were spawned on init"
+
+    # Verify task board has tasks
+    tasks = await swarm._task_board.get_ready_tasks()
+    logger.info(f"Ready tasks: {len(tasks)}")
+
+    logger.info("=== PHASE 2: Single tick() ===")
+    tick_result = await swarm.tick()
+    logger.info(f"Tick result: {json.dumps(tick_result, indent=2, default=str)}")
+    assert not tick_result["paused"], "Swarm paused unexpectedly"
+    assert not tick_result["circuit_broken"], "Circuit breaker tripped"
+
+    logger.info("=== PHASE 3: Multi-tick dispatch ===")
+    dispatched_total = tick_result.get("dispatched", 0)
+    settled_total = tick_result.get("settled", 0)
+
+    for i in range(12):
+        tick_result = await swarm.tick()
+        dispatched_total += tick_result.get("dispatched", 0)
+        settled_total += tick_result.get("settled", 0)
+        logger.info(
+            f"  tick {i+2}: dispatched={tick_result.get('dispatched',0)} "
+            f"settled={tick_result.get('settled',0)} "
+            f"organism={tick_result.get('organism_verdict')}"
+        )
+        await asyncio.sleep(0.05)
+
+    logger.info(f"Totals — dispatched: {dispatched_total}, settled: {settled_total}")
+
+    logger.info("=== PHASE 4: Task state audit ===")
+    all_tasks = []
+    if hasattr(swarm._task_board, '_tasks'):
+        all_tasks = list(swarm._task_board._tasks.values())
+    elif hasattr(swarm._task_board, 'list_all'):
+        all_tasks = await swarm._task_board.list_all()
+
+    completed = [t for t in all_tasks if 'complete' in str(getattr(t,'status','')).lower()]
+    running = [t for t in all_tasks if 'running' in str(getattr(t,'status','')).lower()]
+    failed = [t for t in all_tasks if 'fail' in str(getattr(t,'status','')).lower()]
+    pending = [t for t in all_tasks if 'pending' in str(getattr(t,'status','')).lower()]
+
+    logger.info(f"completed={len(completed)} running={len(running)} failed={len(failed)} pending={len(pending)}")
+    for t in all_tasks:
+        s = getattr(t, 'status', '?')
+        title = getattr(t, 'title', '?')[:60]
+        result = getattr(t, 'result', '') or ''
+        logger.info(f"  [{s}] {title} → {result[:80]}")
+
+    logger.info("=== PHASE 5: Subsystem wiring check ===")
+    subsystems = {
+        'task_board': swarm._task_board,
+        'agent_pool': swarm._agent_pool,
+        'orchestrator': swarm._orchestrator,
+        'engine (Darwin)': swarm._engine,
+        'organism': getattr(swarm, '_organism', None),
+        'economic_spine': getattr(swarm, '_economic_spine', None),
+        'knowledge_store': getattr(swarm, '_knowledge_store', None),
+        'hibernation_manager': getattr(swarm, '_hibernation_manager', None),
+        'sleep_time_agent': getattr(swarm, '_sleep_time_agent', None),
+        'director': getattr(swarm, '_director', None),
+        'witness': getattr(swarm, '_witness', None),
+        'decision_log': getattr(swarm, '_decision_log', None),
+        'ginko_fleet': getattr(swarm, '_ginko_fleet', None),
+        'stigmergy': getattr(swarm, '_stigmergy', None),
+    }
+    wired = 0
+    missing = 0
+    for name, val in subsystems.items():
+        if val is not None:
+            logger.info(f"  ✓ {name}")
+            wired += 1
+        else:
+            logger.warning(f"  ✗ {name} — NOT WIRED")
+            missing += 1
+    logger.info(f"Wired: {wired}/{wired+missing}")
+
+    logger.info("=== PHASE 6: State directory artifacts ===")
+    state_path = Path(state_dir)
+    files = sorted(state_path.rglob("*"))
+    file_count = sum(1 for f in files if f.is_file())
+    logger.info(f"Total files: {file_count}")
+    for f in files[:25]:
+        if f.is_file():
+            logger.info(f"  {f.relative_to(state_path)} ({f.stat().st_size}b)")
+
+    logger.info("=== PHASE 7: Shutdown ===")
+    # Use a timeout on shutdown to prevent hanging
+    try:
+        await asyncio.wait_for(swarm.shutdown(), timeout=5.0)
+    except (asyncio.TimeoutError, Exception) as e:
+        logger.warning(f"Shutdown issue (non-fatal): {e}")
+
+    logger.info("=== DONE ===")
+    assert dispatched_total > 0, "No tasks dispatched in 13 ticks — dispatch pipeline broken"
+    logger.info(f"E2E BOOT PASSED: {agent_count} agents, {dispatched_total} dispatched, {settled_total} settled, {len(completed)} completed")
+
+
+@pytest.mark.asyncio
+async def test_custom_task_dispatch(state_dir):
+    """Create a custom task and verify it flows through the pipeline."""
+    from dharma_swarm.swarm import SwarmManager
+    from dharma_swarm.models import TaskPriority
+
+    swarm = SwarmManager(state_dir=state_dir)
+    await swarm.init()
+
+    task = await swarm._task_board.create(
+        title="E2E Smoke: echo test",
+        description="Respond with: DHARMA SWARM ALIVE",
+        priority=TaskPriority.HIGH,
+        created_by="e2e_test",
+    )
+    logger.info(f"Created task {task.id}")
+
+    for i in range(15):
+        result = await swarm.tick()
+        await asyncio.sleep(0.05)
+
+    updated = await swarm._task_board.get(task.id)
+    status = str(getattr(updated, 'status', 'unknown')).lower()
+    result_text = getattr(updated, 'result', None)
+    logger.info(f"Task {task.id}: status={status}, result={result_text}")
+
+    try:
+        await asyncio.wait_for(swarm.shutdown(), timeout=5.0)
+    except (asyncio.TimeoutError, Exception):
+        pass
+
+    assert status != 'pending', f"Task stuck in pending — dispatch pipeline never picked it up"

--- a/tests/test_swarm.py
+++ b/tests/test_swarm.py
@@ -664,9 +664,12 @@ def test_algedonic_handler_writes_signal_log(tmp_path):
 
 
 def test_algedonic_critical_creates_emergency_hold(tmp_path):
-    """Critical signal writes EMERGENCY_HOLD marker file."""
+    """Critical signal writes EMERGENCY_HOLD marker file (after cold-start grace)."""
+    import time
     sm = SwarmManager.__new__(SwarmManager)
     sm.state_dir = tmp_path
+    # Simulate post-grace-period: set _start_time far in the past
+    sm._start_time = time.monotonic() - 300.0
 
     class FakeSignal:
         kind = "telos_drift"


### PR DESCRIPTION
## What

Two bugs found during the first-ever E2E boot test of the swarm.

### Bug 1: HibernationManager never wired
`SwarmManager.init()` called `HibernationManager(db_path=hib_db)` but the constructor signature is `HibernationManager(state_dir=...)`. Silent failure → 13/14 subsystems instead of 14/14.

### Bug 2: Cold-start death spiral
On fresh boot:
1. `LiveCoherenceSensor` measures low coherence (no daemon PID, sparse subsystem files) → `live_score = 0.12`
2. Blended coherence = `0.258` (below 0.4 threshold)
3. Algedonic channel fires `critical` signal → writes `EMERGENCY_HOLD` file
4. Every subsequent tick sees `EMERGENCY_HOLD` → swarm permanently paused before a single task completes

**The swarm has never been able to survive its own first boot.**

### Fix
- Correct HibernationManager kwarg: `db_path=` → `state_dir=`
- Add 120-second cold-start grace period: critical algedonic signals are logged but don't write `EMERGENCY_HOLD` during initial warmup
- Defensive `getattr(self, '_start_time', time.monotonic())` for tests that create bare SwarmManager

### E2E Boot Test
New `tests/test_e2e_boot.py` with two tests:
- `test_full_lifecycle_boot`: init → tick → dispatch → subsystem wiring audit → shutdown
- `test_custom_task_dispatch`: create task → verify it gets dispatched

### Results
- **7,137 tests pass** (7,135 existing + 2 new)
- **14/14 subsystems wired** (was 13/14)
- **Swarm survives boot and dispatches tasks**