### PR TITLE
fix: harden packaged dashboard build/start/serve path

### DIFF
--- a/dashboard/.npmrc
+++ b/dashboard/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/dashboard/next.config.ts
+++ b/dashboard/next.config.ts
@@ -1,12 +1,11 @@
 import type { NextConfig } from "next";
-import path from "path";
 
 const apiProxyTarget =
   process.env.DHARMA_API_PROXY_URL ?? "http://127.0.0.1:8420";
 
 const nextConfig: NextConfig = {
   turbopack: {
-    root: path.resolve(__dirname),
+    root: __dirname,
   },
   async rewrites() {
     return [

--- a/scripts/com.dharma.dashboard-api.plist
+++ b/scripts/com.dharma.dashboard-api.plist
@@ -32,6 +32,12 @@
     <key>WorkingDirectory</key>
     <string>__REPO_ROOT__</string>
 
+    <key>SoftResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>10240</integer>
+    </dict>
+
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>

--- a/scripts/com.dharma.dashboard-web.plist
+++ b/scripts/com.dharma.dashboard-web.plist
@@ -32,6 +32,12 @@
     <key>WorkingDirectory</key>
     <string>__REPO_ROOT__/dashboard</string>
 
+    <key>SoftResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>10240</integer>
+    </dict>
+
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>

--- a/scripts/install_dashboard_launch_agents.sh
+++ b/scripts/install_dashboard_launch_agents.sh
@@ -47,6 +47,12 @@ ensure_dashboard_build() {
     if [[ -f "${REPO_ROOT}/dashboard/.next/BUILD_ID" ]]; then
         return 0
     fi
+
+    # Remove stale .next output (preserve cache for faster rebuilds)
+    rm -rf "${REPO_ROOT}/dashboard/.next/static" \
+           "${REPO_ROOT}/dashboard/.next/server" \
+           "${REPO_ROOT}/dashboard/.next/build-manifest.json"
+
     (
         cd "${REPO_ROOT}/dashboard"
         npm run build

--- a/scripts/run_dashboard_ui.sh
+++ b/scripts/run_dashboard_ui.sh
@@ -86,6 +86,13 @@ ensure_dashboard_build() {
     else
         echo "Dashboard build missing; running npm run build..."
     fi
+
+    # Remove stale .next output (preserve cache for faster rebuilds)
+    rm -rf "${DASHBOARD_DIR}/.next/static" \
+           "${DASHBOARD_DIR}/.next/server" \
+           "${DASHBOARD_DIR}/.next/BUILD_ID" \
+           "${DASHBOARD_DIR}/.next/build-manifest.json"
+
     (
         cd "${DASHBOARD_DIR}"
         "${NPM_BIN}" run build


### PR DESCRIPTION
## Packaged operations hardening

The packaged dashboard build (`:3420`) had broken CSS/JS — assets returned 500. This PR fixes the build/start/serve path.

### Root causes
1. **npm install fails** — `@visx/heatmap` has a peer dep on React 16/17/18, but the project uses React 19. Fresh `npm install` fails without `--legacy-peer-deps`.
2. **Stale `.next` artifacts** — `next build` doesn't fully clean `.next/`. If dev-mode artifacts remain from `next dev`, the production server can reference mismatched chunks, causing 500 on CSS/JS.
3. **Plist fd limits** — Launch agents inherit macOS default fd limit (256), too low for Node.js under load.

### Changes
- **`dashboard/.npmrc`** — Add `legacy-peer-deps=true` so `npm install` works without manual flags.
- **`dashboard/next.config.ts`** — Remove unnecessary `path` import; use `__dirname` directly for `turbopack.root`.
- **`scripts/run_dashboard_ui.sh`** — Clean stale `.next/static`, `.next/server`, `BUILD_ID`, and `build-manifest.json` before production rebuilds. Preserves `.next/cache` for faster incremental builds.
- **`scripts/install_dashboard_launch_agents.sh`** — Same stale-artifact cleanup before builds.
- **`scripts/com.dharma.dashboard-web.plist`** — Add `SoftResourceLimits` with `NumberOfFiles: 10240`.
- **`scripts/com.dharma.dashboard-api.plist`** — Same fd limit increase.

### Verified
- `npm run build` succeeds (30 routes, all static/dynamic as expected)
- `npm run start -- -p 3420` serves all CSS/JS with HTTP 200 and correct `Content-Type: text/css`
- API proxy rewrites `/api/*` to `:8420` correctly (confirmed via ECONNREFUSED when backend is down)
- No route hierarchy changes; no new features

---
_Conversation: https://app.warp.dev/conversation/d66bcfea-8447-46a9-9bed-39792a5ad8bd_
_Run: https://oz.warp.dev/runs/019d563f-6132-78f9-81be-f00e50728a9b_
_This PR was generated with [Oz](https://warp.dev/oz)._
