### PR TITLE
fix(ci): repair tests workflow yaml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -167,24 +167,24 @@ jobs:
         run: |
           # Only run deterministic telos gate + internal correctness checks
           python3 -c "
-import asyncio, json, sys
-sys.path.insert(0, '.')
-sys.path.insert(0, 'benchmarks')
+          import asyncio, json, sys
+          sys.path.insert(0, '.')
+          sys.path.insert(0, 'benchmarks')
 
-async def main():
-    from gauntlet import _t1_telos_gate_enforced, _t1_stigmergy_roundtrip
-    results = await asyncio.gather(_t1_telos_gate_enforced(), _t1_stigmergy_roundtrip())
-    failed = [r for r in results if not r.passed]
-    for r in results:
-        status = 'PASS' if r.passed else 'FAIL'
-        print(f'  [{status}] {r.name}: {r.composite:.2f}')
-        if r.failure_mode:
-            print(f'    Failure: {r.failure_mode}')
-    if failed:
-        print(f'GAUNTLET TIER 1 FAILED: {len(failed)}/{len(results)} tasks')
-        sys.exit(1)
-    else:
-        print(f'GAUNTLET TIER 1 PASSED: {len(results)}/{len(results)} tasks')
+          async def main():
+              from gauntlet import _t1_telos_gate_enforced, _t1_stigmergy_roundtrip
+              results = await asyncio.gather(_t1_telos_gate_enforced(), _t1_stigmergy_roundtrip())
+              failed = [r for r in results if not r.passed]
+              for r in results:
+                  status = 'PASS' if r.passed else 'FAIL'
+                  print(f'  [{status}] {r.name}: {r.composite:.2f}')
+                  if r.failure_mode:
+                      print(f'    Failure: {r.failure_mode}')
+              if failed:
+                  print(f'GAUNTLET TIER 1 FAILED: {len(failed)}/{len(results)} tasks')
+                  sys.exit(1)
+              else:
+                  print(f'GAUNTLET TIER 1 PASSED: {len(results)}/{len(results)} tasks')
 
-asyncio.run(main())
-"
+          asyncio.run(main())
+          "

--- a/reports/audit/runtime_truth/13_CI_WORKFLOW_REPAIR.md
+++ b/reports/audit/runtime_truth/13_CI_WORKFLOW_REPAIR.md
@@ -1,0 +1,40 @@
+# 13_CI_WORKFLOW_REPAIR
+
+## Scope
+
+Branch: `fix/ci-tests-yaml`
+
+Base: `origin/main` at `da6a4fad8fae677627449e190880839b59e1e3a3`
+
+Goal: restore GitHub Actions check registration by fixing YAML validity only.
+
+## Files Changed
+
+- `.github/workflows/tests.yml`
+- `reports/audit/runtime_truth/13_CI_WORKFLOW_REPAIR.md`
+
+## Finding
+
+`.github/workflows/tests.yml` was not valid YAML. The inline Python block in the `gauntlet-tier1` job was not indented under the `run: |` scalar, so YAML parsers treated `import asyncio, json, sys` as a top-level simple key and failed with:
+
+`could not find expected ':'`
+
+## Repair
+
+Indented the inline Python block under the existing `run: |` section.
+
+No workflow jobs were added or removed. No governance/tier-1 install logic was imported. No runtime code was touched.
+
+## Validation
+
+Local YAML parser checks passed:
+
+- `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/tests.yml').read_text()); print('pyyaml ok')"`
+- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/tests.yml'); puts 'ruby yaml ok'"`
+
+`actionlint` and `yq` were not available locally.
+
+## Deferred
+
+Semgrep, Gitleaks, CodeQL, and broader CI hardening are intentionally deferred. This branch fixes only the workflow YAML validity needed for GitHub Actions to register checks again.
+


### PR DESCRIPTION
## Summary

Fixes YAML validity in `.github/workflows/tests.yml` so GitHub Actions can register the tests workflow again.

## Root Cause

The inline Python block in the `gauntlet-tier1` job was not indented under the existing `run: |` scalar. YAML parsers treated `import asyncio, json, sys` as a top-level simple key and failed with `could not find expected ':'`.

## Changes

- Indented the existing inline Python block under `run: |`.
- Added `reports/audit/runtime_truth/13_CI_WORKFLOW_REPAIR.md` with the repair evidence.

## Validation

- `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/tests.yml').read_text()); print('pyyaml ok')"`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/tests.yml'); puts 'ruby yaml ok'"`

## Deferred

No governance/tier-1 install import, runtime changes, Semgrep, Gitleaks, or CodeQL additions in this PR.