### PR TITLE
Fix local pre-commit missing hook references

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,11 @@
 # Pre-commit hook orchestration for dharma_swarm.
 #
-# Wraps the existing `scripts/uplift_guards/run_pre_commit.py` (kernel
-# integrity, secrets, autonomous-destruction, hotpath, mismatch registry)
-# alongside new gitleaks and semgrep gates.
+# Keep this file limited to checks whose entrypoints exist on origin/main.
+# Legacy contract/private-access tests and uplift guards are deferred until
+# their referenced files are promoted:
+#   - tests/test_contracts.py
+#   - tests/test_private_access.py
+#   - scripts/uplift_guards/run_pre_commit.py
 #
 # Install:   pre-commit install
 # Run all:   pre-commit run --all-files
@@ -12,35 +15,6 @@ minimum_pre_commit_version: "3.6.0"
 fail_fast: false
 
 repos:
-  # ---------------------------------------------------------------------------
-  # Contract tests — verify the interface mismatch registry stays green.
-  # Was previously the first step of the legacy bash pre-commit; pulled into
-  # the framework so we don't run it twice via migration mode.
-  # ---------------------------------------------------------------------------
-  - repo: local
-    hooks:
-      - id: dharma-contract-tests
-        name: dharma contract + private-access tests
-        entry: python3 -m pytest tests/test_contracts.py tests/test_private_access.py -q --tb=line
-        language: system
-        pass_filenames: false
-        always_run: true
-        stages: [pre-commit]
-
-  # ---------------------------------------------------------------------------
-  # Existing dharma_swarm uplift guards — single Python entrypoint covers
-  # kernel SHA, secrets scan, autonomous tripwires, hotpath ack, mismatch reg.
-  # ---------------------------------------------------------------------------
-  - repo: local
-    hooks:
-      - id: dharma-uplift-guards
-        name: dharma uplift guards (kernel, secrets, hotpath, mismatch)
-        entry: python3 scripts/uplift_guards/run_pre_commit.py
-        language: system
-        pass_filenames: false
-        always_run: true
-        stages: [pre-commit]
-
   # ---------------------------------------------------------------------------
   # Test hygiene gate (Rules 3 + 5) — Semgrep can't scan tests/ so we
   # use a small Python script instead. Currently warn-only because the
@@ -77,7 +51,7 @@ repos:
         # Phase 1 is warn-only so the install does not block on the 4
         # pre-existing real findings. CI (Phase 2) runs in strict mode;
         # Phase 4 promotes anti-slop rules to ERROR locally as well.
-        entry: semgrep --config .semgrep --quiet --metrics=off
+        entry: bash -c 'semgrep --config .semgrep --quiet --metrics=off || true'
         language: system
         pass_filenames: false
         types: [python]

--- a/reports/ops/PRECOMMIT_HOTFIX_RESULT.md
+++ b/reports/ops/PRECOMMIT_HOTFIX_RESULT.md
@@ -1,0 +1,106 @@
+# Pre-commit Missing Hook Hotfix Result
+
+## Scope
+
+Branch: `fix/precommit-missing-hooks`
+
+Issue: `#31 Tooling pre-commit env mismatch / missing hook refs`
+
+This hotfix only changes local pre-commit wiring. It does not touch runtime code,
+dashboard code, provider/routing code, LF5, or live state.
+
+## Changed Files
+
+- `.pre-commit-config.yaml`
+- `reports/ops/PRECOMMIT_HOTFIX_RESULT.md`
+
+## Root Cause
+
+Fresh `origin/main` contained pre-commit hooks that referenced files which are
+not present on `main`:
+
+- `tests/test_contracts.py`
+- `tests/test_private_access.py`
+- `scripts/uplift_guards/run_pre_commit.py`
+
+Because the two hooks were marked `always_run: true`, local commits could fail
+before reaching the active governance hooks.
+
+## Patch
+
+- Removed the two missing legacy hooks from `.pre-commit-config.yaml`.
+- Documented the deferred hook entrypoints in the config header so they can be
+  restored only after the referenced files are actually promoted.
+- Kept the active governance hooks:
+  - `dharma-test-hygiene`
+  - `gitleaks`
+  - `semgrep-local`
+  - standard pre-commit hygiene hooks
+- Made `semgrep-local` match its existing comment and local Phase 1 policy by
+  running in warn-only mode:
+
+```yaml
+entry: bash -c 'semgrep --config .semgrep --quiet --metrics=off || true'
+```
+
+This is not a new weakening of an enforcing gate: the hook was already documented
+as "warn-only in Phase 1" because CI owns strict Semgrep enforcement.
+
+## Validation
+
+YAML parse:
+
+```bash
+python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.pre-commit-config.yaml').read_text())"
+```
+
+Result: passed.
+
+Compileall:
+
+```bash
+python -m compileall dharma_swarm tests scripts
+```
+
+Result: passed.
+
+Governance scan tests:
+
+```bash
+python -m pytest tests/test_governance_scan.py -q --tb=short
+```
+
+Result: `2 passed, 1 warning`.
+
+Pre-commit missing-reference verification:
+
+```bash
+pre-commit run --all-files
+```
+
+Result: no failure from missing `tests/test_contracts.py`,
+`tests/test_private_access.py`, or `scripts/uplift_guards/run_pre_commit.py`.
+The run did surface an unrelated existing repository hygiene issue: the generic
+`trailing-whitespace` and `end-of-file-fixer` hooks rewrote many legacy files on
+`main`. Those out-of-scope rewrites were reverted.
+
+Non-mutating pre-commit verification:
+
+```bash
+SKIP=trailing-whitespace,end-of-file-fixer pre-commit run --all-files
+```
+
+Result: passed.
+
+## Remaining Risk
+
+`pre-commit run --all-files` still performs a broad whitespace/EOF formatter
+sweep against existing files on `main`. That is unrelated to the missing hook
+references and should be handled as a separate repository hygiene cleanup if the
+team wants all-files pre-commit to be clean without skips.
+
+## PR Recommendation
+
+Merge this hotfix before asking contributors to rely on local pre-commit from a
+fresh `origin/main` checkout. After merge, restore the deferred legacy hooks only
+in the same PR that promotes their actual files.


### PR DESCRIPTION
## Summary

Fixes local pre-commit on fresh `origin/main` by removing hook entries that referenced files which are not present on `main`:

- `tests/test_contracts.py`
- `tests/test_private_access.py`
- `scripts/uplift_guards/run_pre_commit.py`

The active governance hooks remain in place: test hygiene, gitleaks, local Semgrep, and standard pre-commit hygiene hooks. The Semgrep local hook now matches its documented Phase 1 warn-only behavior; CI remains responsible for strict Semgrep enforcement.

Fixes #31.

## Scope

- No runtime code changes.
- No dashboard changes.
- No provider/routing changes.
- No LF5 or live-state changes.

## Validation

```bash
python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.pre-commit-config.yaml').read_text())"
python -m compileall dharma_swarm tests scripts
python -m pytest tests/test_governance_scan.py -q --tb=short
pre-commit run --files .pre-commit-config.yaml reports/ops/PRECOMMIT_HOTFIX_RESULT.md
SKIP=trailing-whitespace,end-of-file-fixer pre-commit run --all-files
```

Results:

- YAML parse passed.
- Compileall passed.
- Governance scan tests: `2 passed, 1 warning`.
- Commit-file pre-commit passed.
- Non-mutating all-files pre-commit passed.

## Residual note

A plain `pre-commit run --all-files` no longer fails on missing hook paths, but it still rewrites unrelated legacy files through `trailing-whitespace` and `end-of-file-fixer`. Those broad formatter changes were reverted and should be handled separately if desired.