### PR TITLE
[codex] fix Guardian warning cases

### DIFF
--- a/dharma_swarm/guardian_crew.py
+++ b/dharma_swarm/guardian_crew.py
@@ -67,9 +67,11 @@ import sqlite3
 import subprocess
 import time
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
+
+from dharma_swarm.guardian_runtime_checks import run_guardian_warning_checks
 
 logger = logging.getLogger(__name__)
 
@@ -342,6 +344,11 @@ async def run_loop_watcher(state_dir: Path) -> list[GuardianFinding]:
 # ---------------------------------------------------------------------------
 
 _STRUCTURED_RUNTIME_TABLES = ("task_claims", "delegation_runs", "artifact_records")
+_STRUCTURED_RUNTIME_TABLE_TIMESTAMPS = {
+    "task_claims": "claimed_at",
+    "delegation_runs": "started_at",
+    "artifact_records": "created_at",
+}
 
 
 def _runtime_db_candidates(state_dir: Path) -> list[Path]:
@@ -363,19 +370,67 @@ def _runtime_table_count(db: sqlite3.Connection, table: str) -> int:
     return int(row[0] if row else 0)
 
 
-async def run_ledger_watcher(state_dir: Path) -> list[GuardianFinding]:
+def _runtime_table_count_since(
+    db: sqlite3.Connection,
+    table: str,
+    timestamp_column: str,
+    since_iso: str,
+) -> int:
+    exists = db.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+        (table,),
+    ).fetchone()
+    if exists is None:
+        return 0
+    columns = {
+        str(row[1])
+        for row in db.execute(f"PRAGMA table_info({table})").fetchall()
+    }
+    if timestamp_column not in columns:
+        return 0
+    row = db.execute(
+        f"SELECT COUNT(*) FROM {table} WHERE {timestamp_column} >= ?",
+        (since_iso,),
+    ).fetchone()
+    return int(row[0] if row else 0)
+
+
+async def run_ledger_watcher(
+    state_dir: Path,
+    *,
+    now: datetime | None = None,
+) -> list[GuardianFinding]:
     """LEDGER_WATCHER: detect event growth with empty structured runtime tables."""
     findings: list[GuardianFinding] = []
     runtime_db = next((path for path in _runtime_db_candidates(state_dir) if path.exists()), None)
     if runtime_db is None:
         return findings
 
+    resolved_now = now or datetime.now(timezone.utc)
+    since_iso = (resolved_now - timedelta(hours=24)).isoformat()
     try:
         with sqlite3.connect(f"file:{runtime_db}?mode=ro", uri=True) as db:
             counts = {
                 "session_events": _runtime_table_count(db, "session_events"),
                 **{
                     table: _runtime_table_count(db, table)
+                    for table in _STRUCTURED_RUNTIME_TABLES
+                },
+            }
+            recent_counts = {
+                "session_events": _runtime_table_count_since(
+                    db,
+                    "session_events",
+                    "created_at",
+                    since_iso,
+                ),
+                **{
+                    table: _runtime_table_count_since(
+                        db,
+                        table,
+                        _STRUCTURED_RUNTIME_TABLE_TIMESTAMPS[table],
+                        since_iso,
+                    )
                     for table in _STRUCTURED_RUNTIME_TABLES
                 },
             }
@@ -393,32 +448,58 @@ async def run_ledger_watcher(state_dir: Path) -> list[GuardianFinding]:
 
     session_events = counts["session_events"]
     structured_zero = all(counts[table] == 0 for table in _STRUCTURED_RUNTIME_TABLES)
-    if not structured_zero or session_events <= 100:
+    if structured_zero and session_events > 100:
+        severity = "BLOCKER" if session_events > 1000 else "DEGRADED"
+        threshold = "> 1000" if severity == "BLOCKER" else "> 100"
+        findings.append(
+            GuardianFinding(
+                severity=severity,
+                check="LEDGER_WATCHER:structured_runtime_counts",
+                title="Session events are growing while structured runtime tables are empty",
+                detail=(
+                    f"{runtime_db} has session_events={session_events}, "
+                    f"task_claims={counts['task_claims']}, "
+                    f"delegation_runs={counts['delegation_runs']}, "
+                    f"artifact_records={counts['artifact_records']}. "
+                    f"Threshold {threshold} was crossed with all structured producer "
+                    "tables empty, so lifecycle state is not inspectable from the "
+                    "canonical RuntimeStateStore tables."
+                ),
+                file=str(runtime_db),
+                fix_hint=(
+                    "Wire existing RuntimeStateStore producers for task claims, "
+                    "delegation runs, and artifacts; do not create a new ledger."
+                ),
+            )
+        )
         return findings
 
-    severity = "BLOCKER" if session_events > 1000 else "DEGRADED"
-    threshold = "> 1000" if severity == "BLOCKER" else "> 100"
-    findings.append(
-        GuardianFinding(
-            severity=severity,
-            check="LEDGER_WATCHER:structured_runtime_counts",
-            title="Session events are growing while structured runtime tables are empty",
-            detail=(
-                f"{runtime_db} has session_events={session_events}, "
-                f"task_claims={counts['task_claims']}, "
-                f"delegation_runs={counts['delegation_runs']}, "
-                f"artifact_records={counts['artifact_records']}. "
-                f"Threshold {threshold} was crossed with all structured producer "
-                "tables empty, so lifecycle state is not inspectable from the "
-                "canonical RuntimeStateStore tables."
-            ),
-            file=str(runtime_db),
-            fix_hint=(
-                "Wire existing RuntimeStateStore producers for task claims, "
-                "delegation runs, and artifacts; do not create a new ledger."
-            ),
-        )
+    recent_session_events = recent_counts["session_events"]
+    recent_structured_zero = all(
+        recent_counts[table] == 0 for table in _STRUCTURED_RUNTIME_TABLES
     )
+    if recent_session_events > 0 and recent_structured_zero:
+        findings.append(
+            GuardianFinding(
+                severity="WARNING",
+                check="LEDGER_WATCHER:delta_window",
+                title="Session events grew in 24h while structured runtime rows did not",
+                detail=(
+                    f"{runtime_db} has 24h deltas: "
+                    f"session_events={recent_session_events}, "
+                    f"task_claims={recent_counts['task_claims']}, "
+                    f"delegation_runs={recent_counts['delegation_runs']}, "
+                    f"artifact_records={recent_counts['artifact_records']}. "
+                    "Recent runtime activity is not producing structured "
+                    "RuntimeStateStore rows."
+                ),
+                file=str(runtime_db),
+                fix_hint=(
+                    "Check existing RuntimeStateStore producers for recent task "
+                    "claims, delegation runs, and artifacts."
+                ),
+            )
+        )
     return findings
 
 
@@ -523,9 +604,17 @@ def synthesize_report(
     generated_at: str,
     src_root: Path,
     ledger_findings: list[GuardianFinding] | None = None,
+    warning_findings: list[GuardianFinding] | None = None,
 ) -> str:
     ledger_findings = ledger_findings or []
-    all_findings = auditor_findings + loop_findings + router_findings + ledger_findings
+    warning_findings = warning_findings or []
+    all_findings = (
+        auditor_findings
+        + loop_findings
+        + router_findings
+        + ledger_findings
+        + warning_findings
+    )
     all_findings.sort(key=lambda f: _severity_rank(f.severity))
 
     blockers = [f for f in all_findings if f.severity == "BLOCKER"]
@@ -573,6 +662,7 @@ def synthesize_report(
         "- **AUDITOR**: Import chains, method existence, syntax errors across all modules",
         "- **LOOP_WATCHER**: Cybernetic loop artifact existence + freshness + evolution quality",
         "- **LEDGER_WATCHER**: RuntimeStateStore row counts for session events and structured producers",
+        "- **GUARDIAN_WARNINGS**: Repo report freshness and registered .dharma top-level directories",
         "- **ROUTER_PROBE**: Circuit breaker state, log error patterns, missing API keys",
         "",
         "---",
@@ -650,11 +740,18 @@ async def run_guardian_cycle(
     logger.info("Guardian Crew: starting cycle (src=%s)", src_root)
 
     # Run all Guardian checks in parallel.
-    auditor_findings, loop_findings, router_findings, ledger_findings = await asyncio.gather(
+    (
+        auditor_findings,
+        loop_findings,
+        router_findings,
+        ledger_findings,
+        warning_findings,
+    ) = await asyncio.gather(
         run_auditor(src_root),
         run_loop_watcher(state_dir),
         run_router_probe(state_dir),
         run_ledger_watcher(state_dir),
+        run_guardian_warning_checks(src_root, state_dir),
         return_exceptions=False,
     )
 
@@ -666,6 +763,7 @@ async def run_guardian_cycle(
         generated_at=generated_at,
         src_root=src_root,
         ledger_findings=ledger_findings,
+        warning_findings=warning_findings,
     )
 
     # Write report to disk
@@ -683,7 +781,13 @@ async def run_guardian_cycle(
 
     # Create GitHub issues for BLOCKERs
     issues_created = 0
-    all_findings = auditor_findings + loop_findings + router_findings + ledger_findings
+    all_findings = (
+        auditor_findings
+        + loop_findings
+        + router_findings
+        + ledger_findings
+        + warning_findings
+    )
     blockers = [f for f in all_findings if f.severity == "BLOCKER"]
 
     if create_issues and blockers:

--- a/dharma_swarm/guardian_runtime_checks.py
+++ b/dharma_swarm/guardian_runtime_checks.py
@@ -1,0 +1,151 @@
+"""Read-only Guardian runtime warning checks.
+
+This module keeps repo/state warning probes out of ``guardian_crew.py`` so the
+main Guardian module remains an orchestrator and report synthesizer.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+@dataclass
+class GuardianRuntimeFinding:
+    severity: str
+    check: str
+    title: str
+    detail: str
+    file: str = ""
+    line: int = 0
+    fix_hint: str = ""
+
+
+_REGISTERED_DHARMA_TOP_LEVEL_DIRS = frozenset(
+    {
+        "a2a",
+        "agent_memory",
+        "agent_runs",
+        "agents",
+        "ai_reciprocity_ledger",
+        "alerts",
+        "api",
+        "assurance",
+        "autonomous_cleanup",
+        "build_loop",
+        "checkpoints",
+        "constitution",
+        "conversation_log",
+        "conversations",
+        "corpus",
+        "cron",
+        "dashboard",
+        "db",
+        "distilled",
+        "env",
+        "events",
+        "evolution",
+        "ginko",
+        "graphs",
+        "guardian",
+        "interrupts",
+        "jikoku",
+        "jk",
+        "logs",
+        "memory",
+        "merge",
+        "meta",
+        "models",
+        "onboarding",
+        "overnight",
+        "pulse",
+        "reading_program",
+        "reflexion",
+        "replication",
+        "router",
+        "scouts",
+        "shared",
+        "state",
+        "stigmergy",
+        "subconscious",
+        "tasks",
+        "telos",
+        "terminal_supervisor",
+        "terminal_tui",
+        "trajectories",
+        "verify",
+        "witness",
+        "workspace",
+        "world_model",
+    }
+)
+
+
+def _repo_root_from_src_root(src_root: Path) -> Path:
+    if src_root.name == "dharma_swarm" and (src_root / "__init__.py").exists():
+        return src_root.parent
+    return src_root
+
+
+async def run_guardian_warning_checks(
+    src_root: Path,
+    state_dir: Path,
+    *,
+    now: datetime | None = None,
+) -> list[GuardianRuntimeFinding]:
+    """Read-only warnings for stale repo reports and unregistered state dirs."""
+    findings: list[GuardianRuntimeFinding] = []
+    resolved_now = now or datetime.now(timezone.utc)
+    repo_root = _repo_root_from_src_root(src_root)
+    repo_report = repo_root / "GUARDIAN_REPORT.md"
+
+    if repo_report.exists():
+        age_seconds = resolved_now.timestamp() - repo_report.stat().st_mtime
+        if age_seconds > 24 * 3600:
+            age_hours = age_seconds / 3600
+            findings.append(
+                GuardianRuntimeFinding(
+                    severity="WARNING",
+                    check="GUARDIAN_WARNINGS:stale_repo_report",
+                    title="Repo-root GUARDIAN_REPORT.md is stale",
+                    detail=(
+                        f"{repo_report} is {age_hours:.1f}h old "
+                        "(threshold: 24h). Guardian output may not reflect "
+                        "current repository health."
+                    ),
+                    file=str(repo_report),
+                    fix_hint="Run a fresh Guardian cycle before relying on repo-root report state.",
+                )
+            )
+
+    if state_dir.exists():
+        unregistered = [
+            child.name
+            for child in sorted(state_dir.iterdir())
+            if child.is_dir()
+            and not child.name.startswith(".")
+            and child.name not in _REGISTERED_DHARMA_TOP_LEVEL_DIRS
+        ]
+        if unregistered:
+            names = ", ".join(unregistered)
+            findings.append(
+                GuardianRuntimeFinding(
+                    severity="WARNING",
+                    check="GUARDIAN_WARNINGS:unregistered_state_dir",
+                    title="Unregistered top-level .dharma state directory",
+                    detail=(
+                        f"{state_dir} contains unregistered top-level "
+                        f"directories: {names}. New state roots should be "
+                        "registered before becoming durable runtime surface area."
+                    ),
+                    file=str(state_dir),
+                    fix_hint=(
+                        "Either route writes through an existing registered state "
+                        "directory or add the directory to Guardian's registered "
+                        ".dharma top-level set with tests."
+                    ),
+                )
+            )
+
+    return findings

--- a/reports/ops/GUARDIAN_WARNING_RESULT.md
+++ b/reports/ops/GUARDIAN_WARNING_RESULT.md
@@ -1,0 +1,73 @@
+# Guardian Warning Result
+
+Date: 2026-04-27
+Branch: `fix/guardian-warning-cases`
+Issue: #29 Slice 3.1 Guardian warnings
+
+## Summary
+
+Extended Guardian with read-only warning checks beyond the existing `LEDGER_WATCHER` blocker/degraded thresholds.
+
+Implemented:
+
+- Warning when repo-root `GUARDIAN_REPORT.md` exists and is older than 24 hours.
+- Warning when the configured `.dharma` state dir contains an unregistered top-level feature directory.
+- Warning when `session_events` has 24h growth but `task_claims`, `delegation_runs`, and `artifact_records` have no 24h growth.
+
+No new substrate was added. The new state-directory registration boundary is an in-code allowlist used only for read-only warning detection.
+
+Post-PR #46 maintenance:
+
+- Rebased `fix/guardian-warning-cases` onto `origin/main` at `70230e4f89e4e4a3e1bec6bddd6760b9ffc59313`.
+- Reproduced the `module-budget` failure locally: `dharma_swarm/guardian_crew.py` crossed `778 -> 1012` lines.
+- Narrowly extracted Guardian repo/state warning helpers to `dharma_swarm/guardian_runtime_checks.py`.
+- Kept `guardian_crew.py` as the Guardian orchestrator/report synthesizer; it is now 881 lines.
+- Did not touch `orchestrator.py` or `runtime_lifecycle.py`.
+
+## Files Changed
+
+- `dharma_swarm/guardian_crew.py`
+- `dharma_swarm/guardian_runtime_checks.py`
+- `tests/test_guardian_crew.py`
+- `reports/ops/GUARDIAN_WARNING_RESULT.md`
+
+No `orchestrator.py` or `runtime_lifecycle.py` changes.
+
+## Tests
+
+Passed:
+
+```bash
+python -m compileall dharma_swarm tests
+```
+
+Passed:
+
+```bash
+python -m pytest tests/test_guardian_crew.py -q --tb=short
+```
+
+Result: `8 passed, 1 warning`.
+
+Passed:
+
+```bash
+python -m pytest tests/test_runtime_lifecycle.py tests/test_bootstrap_loops.py tests/test_runtime_state.py -q --tb=short
+```
+
+Result: `20 passed, 1 warning`.
+
+Passed:
+
+```bash
+python scripts/governance/check_module_budget.py --base-ref origin/main --head-ref HEAD
+```
+
+Result: `Module line-budget check OK.`
+
+## Notes
+
+- Tests use temp state dirs only.
+- Warning tests monkeypatch `Path.home()` where relevant to guard against live `~/.dharma` reads.
+- Existing `LEDGER_WATCHER` blocker and degraded cases continue to assert one finding each.
+- Local pre-commit hooks were not usable in this worktree: the hook Python lacked `pytest`, `scripts/uplift_guards/run_pre_commit.py` was absent on this baseline, and Semgrep hit a local CA trust-store error. The focused pytest and compileall checks above passed.

--- a/tests/test_guardian_crew.py
+++ b/tests/test_guardian_crew.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+import os
 import sqlite3
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
 
-from dharma_swarm.guardian_crew import run_ledger_watcher
+from dharma_swarm.guardian_crew import run_guardian_warning_checks, run_ledger_watcher
 from dharma_swarm.runtime_state import RuntimeStateStore
 
 
@@ -17,8 +18,13 @@ def _runtime_db(tmp_path: Path) -> tuple[Path, Path]:
     return state_dir, db_path
 
 
-def _seed_session_events(db_path: Path, count: int) -> None:
-    now = datetime.now(timezone.utc).isoformat()
+def _seed_session_events(
+    db_path: Path,
+    count: int,
+    *,
+    created_at: datetime | None = None,
+) -> None:
+    now = (created_at or datetime.now(timezone.utc)).isoformat()
     rows = [
         (
             f"sevt_guardian_{idx}",
@@ -88,6 +94,14 @@ def _seed_structured_rows(db_path: Path) -> None:
         db.commit()
 
 
+def _repo_src_root(tmp_path: Path) -> Path:
+    repo_root = tmp_path / "repo"
+    src_root = repo_root / "dharma_swarm"
+    src_root.mkdir(parents=True)
+    (src_root / "__init__.py").write_text("", encoding="utf-8")
+    return src_root
+
+
 @pytest.mark.asyncio
 async def test_ledger_watcher_degraded_threshold(tmp_path: Path) -> None:
     state_dir, db_path = _runtime_db(tmp_path)
@@ -127,6 +141,84 @@ async def test_ledger_watcher_ok_when_structured_rows_exist(tmp_path: Path) -> N
     _seed_structured_rows(db_path)
 
     findings = await run_ledger_watcher(state_dir)
+
+    assert findings == []
+
+
+@pytest.mark.asyncio
+async def test_ledger_watcher_warning_on_24h_delta_without_structured_rows(tmp_path: Path) -> None:
+    state_dir, db_path = _runtime_db(tmp_path)
+    _seed_session_events(db_path, 3)
+
+    findings = await run_ledger_watcher(state_dir)
+
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding.severity == "WARNING"
+    assert finding.check == "LEDGER_WATCHER:delta_window"
+    assert "24h deltas" in finding.detail
+    assert "session_events=3" in finding.detail
+    assert "task_claims=0" in finding.detail
+    assert "delegation_runs=0" in finding.detail
+    assert "artifact_records=0" in finding.detail
+
+
+@pytest.mark.asyncio
+async def test_guardian_warning_stale_repo_root_report(tmp_path: Path) -> None:
+    src_root = _repo_src_root(tmp_path)
+    state_dir = tmp_path / ".dharma"
+    state_dir.mkdir()
+    report_path = src_root.parent / "GUARDIAN_REPORT.md"
+    report_path.write_text("# old report\n", encoding="utf-8")
+    old = (datetime.now(timezone.utc) - timedelta(hours=25)).timestamp()
+    os.utime(report_path, (old, old))
+
+    findings = await run_guardian_warning_checks(src_root, state_dir)
+
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding.severity == "WARNING"
+    assert finding.check == "GUARDIAN_WARNINGS:stale_repo_report"
+    assert "GUARDIAN_REPORT.md is stale" in finding.title
+    assert "threshold: 24h" in finding.detail
+
+
+@pytest.mark.asyncio
+async def test_guardian_warning_unregistered_state_dir(tmp_path: Path) -> None:
+    src_root = _repo_src_root(tmp_path)
+    (src_root.parent / "GUARDIAN_REPORT.md").write_text("# fresh\n", encoding="utf-8")
+    state_dir = tmp_path / ".dharma"
+    (state_dir / "state").mkdir(parents=True)
+    (state_dir / "guardian").mkdir()
+    (state_dir / "novel_feature").mkdir()
+
+    findings = await run_guardian_warning_checks(src_root, state_dir)
+
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding.severity == "WARNING"
+    assert finding.check == "GUARDIAN_WARNINGS:unregistered_state_dir"
+    assert "novel_feature" in finding.detail
+    assert "directories: novel_feature" in finding.detail
+
+
+@pytest.mark.asyncio
+async def test_guardian_warning_checks_ok_on_healthy_temp_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    src_root = _repo_src_root(tmp_path)
+    (src_root.parent / "GUARDIAN_REPORT.md").write_text("# fresh\n", encoding="utf-8")
+    state_dir = tmp_path / ".dharma"
+    for name in ("state", "guardian", "logs"):
+        (state_dir / name).mkdir(parents=True)
+
+    def _fail_home(cls: type[Path]) -> Path:
+        raise AssertionError("warning checks must not read live ~/.dharma")
+
+    monkeypatch.setattr(Path, "home", classmethod(_fail_home))
+
+    findings = await run_guardian_warning_checks(src_root, state_dir)
 
     assert findings == []
 


### PR DESCRIPTION
## Summary

Implements Slice 3.1 Guardian warning coverage for issue #29:

- Warns when repo-root `GUARDIAN_REPORT.md` exists and is older than 24h.
- Warns when the configured `.dharma` state dir contains an unregistered top-level feature directory.
- Warns when `session_events` has 24h growth but `task_claims`, `delegation_runs`, and `artifact_records` do not.
- Wires the new warning pass into Guardian report synthesis without adding a new substrate.

## Validation

- `python -m pytest tests/test_guardian_crew.py -q --tb=short` -> 8 passed, 1 pytest config warning
- `python -m compileall dharma_swarm/guardian_crew.py tests/test_guardian_crew.py`
- `git diff --check`

## Notes

Local pre-commit hooks were not usable in this worktree: the hook Python lacked `pytest`, `scripts/uplift_guards/run_pre_commit.py` was absent on this baseline, and Semgrep hit a local CA trust-store error. The focused checks above passed.

Fixes #29