### PR TITLE
Implement Dharma Control Loop v0.1

### DIFF
--- a/dharma_swarm/agent_runner.py
+++ b/dharma_swarm/agent_runner.py
@@ -1044,6 +1044,54 @@ def _resolve_prompt_state_dir(task: Task, config: AgentConfig) -> Path | None:
     return _resolve_config_state_dir(config)
 
 
+def _resolve_context_bundle_db_path(task: Task, config: AgentConfig) -> Path | None:
+    metadata = task.metadata if isinstance(task.metadata, dict) else {}
+    config_meta = config.metadata if isinstance(config.metadata, dict) else {}
+    for candidate in (
+        metadata.get("runtime_db_path"),
+        config_meta.get("runtime_db_path"),
+    ):
+        if isinstance(candidate, str) and candidate.strip():
+            return Path(candidate).expanduser()
+        if isinstance(candidate, Path):
+            return candidate
+
+    state_dir = _resolve_prompt_state_dir(task, config)
+    if state_dir is None:
+        return None
+    for candidate in (
+        state_dir / "state" / "runtime.db",
+        state_dir / "runtime.db",
+    ):
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _read_persisted_context_bundle(task: Task, config: AgentConfig) -> str:
+    metadata = task.metadata if isinstance(task.metadata, dict) else {}
+    bundle_id = str(metadata.get("context_bundle_id", "") or "").strip()
+    if not bundle_id:
+        return ""
+    db_path = _resolve_context_bundle_db_path(task, config)
+    if db_path is None:
+        logger.debug("Context bundle %s has no resolvable runtime DB", bundle_id)
+        return ""
+    if not db_path.exists():
+        logger.debug("Context bundle %s runtime DB does not exist: %s", bundle_id, db_path)
+        return ""
+    try:
+        from dharma_swarm.runtime_state import RuntimeStateStore
+
+        bundle = RuntimeStateStore(db_path).get_context_bundle_sync(bundle_id)
+    except Exception:
+        logger.debug("Context bundle %s could not be loaded", bundle_id, exc_info=True)
+        return ""
+    if bundle is None or not bundle.rendered_text.strip():
+        return ""
+    return bundle.rendered_text.strip()
+
+
 def _resolve_agent_registry_dir(task: Task, config: AgentConfig) -> Path | None:
     """Resolve the per-run AgentRegistry directory, if one is configured."""
     state_dir = _resolve_prompt_state_dir(task, config)
@@ -1114,6 +1162,9 @@ def _build_prompt(
             user_parts.append("\n\n" + render_completion_contract_brief(completion_contract))
     except Exception:
         logger.debug("Completion contract prompt injection failed", exc_info=True)
+    runtime_context_bundle = _read_persisted_context_bundle(task, config)
+    if runtime_context_bundle:
+        user_parts.append(f"\n\n## Runtime Context Bundle\n{runtime_context_bundle}")
     prompt_state_dir = _resolve_prompt_state_dir(task, config)
     memory_query = "\n".join(
         part.strip()

--- a/dharma_swarm/dgm_loop.py
+++ b/dharma_swarm/dgm_loop.py
@@ -227,16 +227,28 @@ def _get_source_file_from_entry(entry: Any, src_root: Path) -> Path | None:
 # DGM Loop class
 # ---------------------------------------------------------------------------
 
-# Source files that are valid evolution targets (in priority order)
-# These are the files where improvement has the highest leverage on swarm performance
+# Source files that DGM may not mutate directly.  This mirrors the
+# identity-layer precedent in self_improve.py and verify/scorer.py.
+DGM_PROTECTED_FILES = frozenset({
+    "telos_gates.py",
+    "dharma_kernel.py",
+    "evolution.py",
+    "config.py",
+})
+
+
+def _is_protected_dgm_target(path: Path | str) -> bool:
+    return Path(path).name in DGM_PROTECTED_FILES
+
+
+# Source files that are valid evolution targets (in priority order).
+# These are the files where improvement has the highest leverage on swarm performance.
 DGM_TARGET_FILES = [
     "agent_runner.py",         # task execution — most direct impact on completion rate
     "autonomous_agent.py",     # tool use, LLM calls — quality of agent cognition
     "orchestrator.py",         # task routing and lifecycle — affects all agents
     "swarm.py",                # boot, coordination — foundational
-    "telos_gates.py",          # constraint enforcement — safety-critical
     "providers.py",            # LLM provider routing — reliability
-    "evolution.py",            # self-improvement loop — recursive
     "task_board.py",           # task management — throughput
     "stigmergy.py",            # agent coordination memory
     "thinkodynamic_director.py",  # mission seeding
@@ -334,6 +346,14 @@ class DGMLoop:
         source_path = Path(source_file) if not isinstance(source_file, Path) else source_file
         if not source_path.is_absolute():
             source_path = self._src_root / source_path
+
+        if _is_protected_dgm_target(source_path):
+            result.error = (
+                f"Protected DGM target rejected: {source_path.name}. "
+                "Telos/Dharma/Governance boundary files require explicit human review."
+            )
+            result.duration_seconds = time.monotonic() - start
+            return result
 
         if not source_path.exists():
             result.error = f"Source file not found: {source_path}"

--- a/dharma_swarm/guardian_crew.py
+++ b/dharma_swarm/guardian_crew.py
@@ -395,6 +395,59 @@ def _runtime_table_count_since(
     return int(row[0] if row else 0)
 
 
+def _runtime_rows_missing_context(
+    db: sqlite3.Connection,
+    table: str,
+    timestamp_column: str,
+    since_iso: str,
+) -> int:
+    existing = {
+        str(row[0])
+        for row in db.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table'"
+        ).fetchall()
+    }
+    if table not in existing or "context_bundles" not in existing:
+        return 0
+    columns = {
+        str(row[1])
+        for row in db.execute(f"PRAGMA table_info({table})").fetchall()
+    }
+    if timestamp_column not in columns:
+        return 0
+
+    metadata_bundle = (
+        "CASE WHEN json_valid(t.metadata_json) "
+        "THEN COALESCE(json_extract(t.metadata_json, '$.context_bundle_id'), '') "
+        "ELSE '' END"
+    )
+    if table == "delegation_runs":
+        join_clause = (
+            f"cb.bundle_id = {metadata_bundle} "
+            "OR (t.run_id != '' AND cb.run_id = t.run_id) "
+            "OR (t.session_id != '' AND t.task_id != '' "
+            "AND cb.session_id = t.session_id AND cb.task_id = t.task_id)"
+        )
+    elif table == "task_claims":
+        join_clause = (
+            f"cb.bundle_id = {metadata_bundle} "
+            "OR (t.session_id != '' AND t.task_id != '' "
+            "AND cb.session_id = t.session_id AND cb.task_id = t.task_id)"
+        )
+    else:
+        return 0
+
+    row = db.execute(
+        f"SELECT COUNT(*) FROM {table} t "
+        f"LEFT JOIN context_bundles cb ON {join_clause} "
+        f"WHERE t.{timestamp_column} >= ? "
+        "AND t.status IN ('claimed', 'running', 'completed', 'failed') "
+        "AND cb.bundle_id IS NULL",
+        (since_iso,),
+    ).fetchone()
+    return int(row[0] if row else 0)
+
+
 async def run_ledger_watcher(
     state_dir: Path,
     *,
@@ -433,6 +486,20 @@ async def run_ledger_watcher(
                     )
                     for table in _STRUCTURED_RUNTIME_TABLES
                 },
+            }
+            missing_context_counts = {
+                "task_claims": _runtime_rows_missing_context(
+                    db,
+                    "task_claims",
+                    "claimed_at",
+                    since_iso,
+                ),
+                "delegation_runs": _runtime_rows_missing_context(
+                    db,
+                    "delegation_runs",
+                    "started_at",
+                    since_iso,
+                ),
             }
     except sqlite3.Error as exc:
         return [
@@ -497,6 +564,27 @@ async def run_ledger_watcher(
                 fix_hint=(
                     "Check existing RuntimeStateStore producers for recent task "
                     "claims, delegation runs, and artifacts."
+                ),
+            )
+        )
+    missing_context_total = sum(missing_context_counts.values())
+    if missing_context_total > 0:
+        findings.append(
+            GuardianFinding(
+                severity="WARNING",
+                check="LEDGER_WATCHER:missing_context_bundle",
+                title="Recent runtime claims or runs have no persisted context bundle",
+                detail=(
+                    f"{runtime_db} has recent rows without matching context_bundles: "
+                    f"task_claims={missing_context_counts['task_claims']}, "
+                    f"delegation_runs={missing_context_counts['delegation_runs']}. "
+                    "Canonical action is occurring without a persisted pre-action "
+                    "context bundle linked by metadata, run_id, or task/session."
+                ),
+                file=str(runtime_db),
+                fix_hint=(
+                    "Attach context_bundle_id during Orchestrator dispatch and ensure "
+                    "AgentRunner consumes the persisted bundle before action."
                 ),
             )
         )

--- a/dharma_swarm/orchestrator.py
+++ b/dharma_swarm/orchestrator.py
@@ -816,6 +816,108 @@ class Orchestrator:
         meta["latent_gold_refreshed_at"] = datetime.now(timezone.utc).isoformat()
         return meta
 
+    def _operator_intent_for_task(self, task: Task, meta: dict[str, Any]) -> str:
+        for key in (
+            "operator_intent",
+            "user_intent",
+            "mission_intent",
+            "intent",
+            "operator_directive",
+        ):
+            raw = meta.get(key)
+            if isinstance(raw, str) and raw.strip():
+                return raw.strip()
+        return str(task.title or "").strip()
+
+    async def _attach_context_bundle(
+        self,
+        task: Task | None,
+        td: TaskDispatch,
+        meta: dict[str, Any],
+    ) -> dict[str, Any]:
+        if task is None:
+            meta["context_bundle_status"] = "missing_task"
+            td.metadata["context_bundle_status"] = "missing_task"
+            return meta
+
+        store = self._runtime_lifecycle._runtime_state_store()
+        if store is None:
+            meta["context_bundle_status"] = "missing_runtime_state"
+            td.metadata["context_bundle_status"] = "missing_runtime_state"
+            return meta
+
+        run_id = self._runtime_lifecycle.ensure_runtime_run_id(td)
+        runtime_root = self._runtime_root()
+        operator_intent = self._operator_intent_for_task(task, meta)
+        task_description = "\n\n".join(
+            part.strip()
+            for part in (task.title, task.description)
+            if isinstance(part, str) and part.strip()
+        )
+        token_budget = max(200, self._coerce_int(meta.get("context_token_budget"), 1200))
+        lattice = None
+        try:
+            from dharma_swarm.context_compiler import ContextCompiler
+            from dharma_swarm.memory_lattice import MemoryLattice
+
+            lattice = MemoryLattice(
+                db_path=store.db_path,
+                event_log_dir=runtime_root / "events",
+            )
+            compiler = ContextCompiler(
+                runtime_state=store,
+                memory_lattice=lattice,
+            )
+            bundle = await compiler.compile_bundle(
+                session_id=self._ledger.session_id,
+                task_id=td.task_id,
+                run_id=run_id,
+                operator_intent=operator_intent,
+                task_description=task_description,
+                query=str(meta.get("context_query") or task.description or task.title or ""),
+                token_budget=token_budget,
+                metadata={
+                    "source": "orchestrator._assign_dispatch",
+                    "agent_id": td.agent_id,
+                    "topology": td.topology.value if td.topology else "dispatch",
+                },
+                workspace_root=runtime_root,
+            )
+        except Exception as exc:
+            error = str(exc)[:300]
+            meta["context_bundle_status"] = "failed"
+            meta["context_bundle_error"] = error
+            td.metadata["context_bundle_status"] = "failed"
+            td.metadata["context_bundle_error"] = error
+            self._record_progress_event(
+                "context_bundle_failed",
+                task_id=td.task_id,
+                agent_id=td.agent_id,
+                error=error,
+            )
+            logger.debug("Context bundle compilation failed", exc_info=True)
+            return meta
+        finally:
+            if lattice is not None:
+                try:
+                    await lattice.close()
+                except Exception:
+                    logger.debug("Memory lattice close failed", exc_info=True)
+
+        bundle_id = bundle.bundle_id
+        runtime_db_path = str(store.db_path)
+        state_dir = str(runtime_root)
+        meta["context_bundle_id"] = bundle_id
+        meta["context_bundle_status"] = "attached"
+        meta["runtime_run_id"] = run_id
+        meta["runtime_db_path"] = runtime_db_path
+        meta.setdefault("state_dir", state_dir)
+        td.metadata["context_bundle_id"] = bundle_id
+        td.metadata["context_bundle_status"] = "attached"
+        td.metadata["runtime_db_path"] = runtime_db_path
+        td.metadata.setdefault("state_dir", state_dir)
+        return meta
+
     @staticmethod
     def _dedupe_strings(values: list[str]) -> list[str]:
         ordered: list[str] = []
@@ -1822,6 +1924,8 @@ class Orchestrator:
             td.metadata["witness_reroutes"] = gate.attempts
 
         claim_meta = self._prepare_claim(task_for_gate, td)
+        self._runtime_lifecycle.ensure_runtime_run_id(td)
+        claim_meta = await self._attach_context_bundle(task_for_gate, td, claim_meta)
         claim_meta = self._attach_latent_gold(task_for_gate, claim_meta)
         if task_for_gate is not None:
             task_for_gate.metadata = dict(claim_meta)

--- a/dharma_swarm/runtime_lifecycle.py
+++ b/dharma_swarm/runtime_lifecycle.py
@@ -91,6 +91,15 @@ class RuntimeLifecycle:
             metadata["error"] = error[:500]
         if result is not None:
             metadata["result_chars"] = len(result or "")
+        for key in (
+            "context_bundle_id",
+            "context_bundle_status",
+            "context_bundle_error",
+            "runtime_db_path",
+        ):
+            value = td.metadata.get(key)
+            if value:
+                metadata[key] = value
         return metadata
 
     async def record_task_claim(

--- a/dharma_swarm/runtime_state.py
+++ b/dharma_swarm/runtime_state.py
@@ -1710,6 +1710,18 @@ class RuntimeStateStore:
             ).fetchone()
         return _row_to_context_bundle(row) if row is not None else None
 
+    def get_context_bundle_sync(self, bundle_id: str) -> ContextBundleRecord | None:
+        self.init_db_sync()
+        with sqlite3.connect(self.db_path) as db:
+            db.row_factory = sqlite3.Row
+            row = db.execute(
+                "SELECT bundle_id, session_id, task_id, run_id, token_budget,"
+                " rendered_text, sections_json, source_refs_json, checksum,"
+                " created_at, metadata_json FROM context_bundles WHERE bundle_id = ?",
+                (bundle_id,),
+            ).fetchone()
+        return _row_to_context_bundle(row) if row is not None else None
+
     async def list_context_bundles(
         self,
         *,

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -234,6 +234,41 @@ def test_build_prompt_prefers_local_state_dir_when_available(config, monkeypatch
     assert recorded["state_dir"] == tmp_path / ".dharma"
 
 
+@pytest.mark.asyncio
+async def test_build_prompt_injects_persisted_context_bundle(config, tmp_path):
+    from dharma_swarm.runtime_state import ContextBundleRecord, RuntimeStateStore
+
+    runtime_db_path = tmp_path / "runtime.db"
+    runtime_state = RuntimeStateStore(runtime_db_path)
+    await runtime_state.init_db()
+    await runtime_state.record_context_bundle(
+        ContextBundleRecord(
+            bundle_id="bundle_prompt_test",
+            session_id="sess-prompt",
+            task_id="task-prompt",
+            run_id="run-prompt",
+            token_budget=200,
+            rendered_text="Persisted runtime context: use the structured spine.",
+            checksum="checksum",
+        )
+    )
+    task = Task(
+        id="task-prompt",
+        title="Build prompt",
+        description="Consume persisted context",
+        metadata={
+            "context_bundle_id": "bundle_prompt_test",
+            "runtime_db_path": str(runtime_db_path),
+        },
+    )
+
+    request = _build_prompt(task, config)
+
+    content = request.messages[0]["content"]
+    assert "## Runtime Context Bundle" in content
+    assert "Persisted runtime context: use the structured spine." in content
+
+
 def test_build_prompt_handles_memory_context_import_failure(config, monkeypatch):
     original_import = builtins.__import__
 

--- a/tests/test_bootstrap_loops.py
+++ b/tests/test_bootstrap_loops.py
@@ -46,6 +46,7 @@ def _runtime_table_count(db_path: Path, table: str) -> int:
         "task_claims",
         "delegation_runs",
         "artifact_records",
+        "context_bundles",
     }
     if not db_path.exists():
         return 0
@@ -378,10 +379,12 @@ async def test_task_lifecycle(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -
     assert _runtime_table_count(runtime_db_path, "task_claims") == 0
     assert _runtime_table_count(runtime_db_path, "delegation_runs") == 0
     assert _runtime_table_count(runtime_db_path, "artifact_records") == 0
+    assert _runtime_table_count(runtime_db_path, "context_bundles") == 0
 
     # Tick 1: should dispatch the task
     result = await orch.tick()
     assert result["dispatched"] >= 1, "Tick must dispatch the pending task"
+    assert _runtime_table_count(runtime_db_path, "context_bundles") == 1
     assert _runtime_table_count(runtime_db_path, "task_claims") == 1
 
     # The background _execute_task coroutine runs async — yield to let it complete.
@@ -396,6 +399,8 @@ async def test_task_lifecycle(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -
         f"result={completed.result!r}"
     )
     assert completed.result == MOCK_RESULT
+    context_bundle_id = str(completed.metadata.get("context_bundle_id", "") or "")
+    assert context_bundle_id
     assert _runtime_table_count(runtime_db_path, "session_events") >= 3
     assert _runtime_table_count(runtime_db_path, "task_claims") == 1
     assert _runtime_table_count(runtime_db_path, "delegation_runs") == 1
@@ -411,6 +416,15 @@ async def test_task_lifecycle(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -
     assert artifact_task_id == task.id
     assert Path(payload_path).exists()
     assert checksum
+    with sqlite3.connect(runtime_db_path) as db:
+        claim_meta_json, run_meta_json = db.execute(
+            "SELECT c.metadata_json, r.metadata_json"
+            " FROM task_claims c JOIN delegation_runs r ON r.claim_id = c.claim_id"
+            " WHERE c.task_id = ?",
+            (task.id,),
+        ).fetchone()
+    assert context_bundle_id in claim_meta_json
+    assert context_bundle_id in run_meta_json
 
     # A settle-only follow-up tick must not duplicate structured runtime rows.
     result2 = await orch.tick()
@@ -418,6 +432,7 @@ async def test_task_lifecycle(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -
     assert _runtime_table_count(runtime_db_path, "task_claims") == 1
     assert _runtime_table_count(runtime_db_path, "delegation_runs") == 1
     assert _runtime_table_count(runtime_db_path, "artifact_records") == artifact_count
+    assert _runtime_table_count(runtime_db_path, "context_bundles") == 1
 
 
 async def test_task_failure_records_runtime_run(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_dgm_loop.py
+++ b/tests/test_dgm_loop.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from dharma_swarm.dgm_loop import (
+    DGM_PROTECTED_FILES,
+    DGM_TARGET_FILES,
+    DGMLoop,
+    _is_protected_dgm_target,
+)
+
+
+def test_dgm_targets_exclude_dharma_boundary_files() -> None:
+    assert DGM_PROTECTED_FILES.isdisjoint(set(DGM_TARGET_FILES))
+    assert _is_protected_dgm_target("telos_gates.py")
+    assert _is_protected_dgm_target(Path("dharma_swarm") / "dharma_kernel.py")
+
+
+@pytest.mark.asyncio
+async def test_dgm_rejects_explicit_protected_source_file_before_evolution() -> None:
+    class ExplodingEngine:
+        async def auto_evolve(self, **_kwargs):
+            raise AssertionError("auto_evolve must not run for protected targets")
+
+    loop = DGMLoop(engine=ExplodingEngine(), shadow_mode=True)
+
+    result = await loop.run_one_generation(source_file="telos_gates.py")
+
+    assert result.error is not None
+    assert "Protected DGM target rejected" in result.error
+    assert result.source_file == ""

--- a/tests/test_guardian_crew.py
+++ b/tests/test_guardian_crew.py
@@ -51,14 +51,24 @@ def _seed_session_events(
         db.commit()
 
 
-def _seed_structured_rows(db_path: Path) -> None:
+def _seed_structured_rows(db_path: Path, *, with_context: bool = True) -> None:
     now = datetime.now(timezone.utc).isoformat()
+    metadata_json = '{"context_bundle_id": "bundle_guardian"}' if with_context else "{}"
     with sqlite3.connect(db_path) as db:
         db.execute(
             "INSERT INTO task_claims (claim_id, task_id, session_id, agent_id,"
             " status, claimed_at, retry_count, metadata_json)"
             " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-            ("claim_guardian", "task_guardian", "sess_guardian", "agent_guardian", "completed", now, 0, "{}"),
+            (
+                "claim_guardian",
+                "task_guardian",
+                "sess_guardian",
+                "agent_guardian",
+                "completed",
+                now,
+                0,
+                metadata_json,
+            ),
         )
         db.execute(
             "INSERT INTO delegation_runs (run_id, session_id, task_id, claim_id,"
@@ -72,9 +82,29 @@ def _seed_structured_rows(db_path: Path) -> None:
                 "agent_guardian",
                 "completed",
                 now,
-                "{}",
+                metadata_json,
             ),
         )
+        if with_context:
+            db.execute(
+                "INSERT INTO context_bundles (bundle_id, session_id, task_id,"
+                " run_id, token_budget, rendered_text, sections_json,"
+                " source_refs_json, checksum, created_at, metadata_json)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    "bundle_guardian",
+                    "sess_guardian",
+                    "task_guardian",
+                    "run_guardian",
+                    200,
+                    "guardian context",
+                    "[]",
+                    "[]",
+                    "checksum",
+                    now,
+                    "{}",
+                ),
+            )
         db.execute(
             "INSERT INTO artifact_records (artifact_id, session_id, task_id,"
             " run_id, artifact_kind, payload_path, checksum, created_at, metadata_json)"
@@ -143,6 +173,22 @@ async def test_ledger_watcher_ok_when_structured_rows_exist(tmp_path: Path) -> N
     findings = await run_ledger_watcher(state_dir)
 
     assert findings == []
+
+
+@pytest.mark.asyncio
+async def test_ledger_watcher_warns_on_recent_rows_without_context_bundle(tmp_path: Path) -> None:
+    state_dir, db_path = _runtime_db(tmp_path)
+    _seed_session_events(db_path, 3)
+    _seed_structured_rows(db_path, with_context=False)
+
+    findings = await run_ledger_watcher(state_dir)
+
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding.severity == "WARNING"
+    assert finding.check == "LEDGER_WATCHER:missing_context_bundle"
+    assert "task_claims=1" in finding.detail
+    assert "delegation_runs=1" in finding.detail
 
 
 @pytest.mark.asyncio

--- a/tests/test_runtime_state.py
+++ b/tests/test_runtime_state.py
@@ -57,6 +57,9 @@ async def test_runtime_state_initializes_wal_and_core_tables(tmp_path) -> None:
     assert fact.fact_id == "fact-1"
     assert bundle.bundle_id == "ctx-1"
     assert (await store.get_session("sess-1")) is not None
+    loaded_bundle = store.get_context_bundle_sync("ctx-1")
+    assert loaded_bundle is not None
+    assert loaded_bundle.rendered_text == "# Context"
 
     with sqlite3.connect(db_path) as db:
         tables = {


### PR DESCRIPTION
## Summary

This PR implements Dharma Control Loop v0.1: canonical task execution now becomes context-bearing, AgentRunner consumes persisted runtime context, Guardian detects contextless runtime activity, and DGM can no longer mutate protected dharma/evolution boundary files.

This is intentionally narrow. It does not implement memory promotion, dashboard changes, operator action enforcement, provider routing changes, or Darwin redesign.

## What changed

### Protected dharma boundary

- Removes protected files from `DGM_TARGET_FILES`.
- Rejects explicit protected `source_file` mutation attempts.
- Protects:
  - `telos_gates.py`
  - `dharma_kernel.py`
  - `evolution.py`
  - `config.py`

### Context-bearing canonical dispatch

- `orchestrator.py` soft-compiles a persisted `context_bundle` during canonical dispatch.
- The resulting `context_bundle_id` is attached to task and dispatch metadata.
- `runtime_lifecycle.py` carries the bundle id into structured `task_claims` / `delegation_runs` metadata.
- `agent_runner.py` injects persisted bundle text under `## Runtime Context Bundle`.
- `guardian_crew.py` warns on recent claims/runs without matching context bundles.
- `runtime_state.py` adds sync `get_context_bundle_sync()` helper for prompt-time reads.

## Why this matters

Before this PR, `ContextCompiler` and `context_bundles` existed, but canonical agent execution did not require or consume them. This meant the system had a pre-action context substrate that was not yet load-bearing.

After this PR, the main execution path begins carrying inherited runtime context into action, and Guardian can detect when that context is missing.

This PR also prevents DGM from mutating the boundary files that define and enforce dharmic/evolutionary constraints.

## Tests

Passing focused v0.1 checks:

```bash
python -m compileall dharma_swarm tests
python -m pytest tests/test_bootstrap_loops.py tests/test_runtime_state.py tests/test_agent_runner.py::test_build_prompt_injects_persisted_context_bundle tests/test_guardian_crew.py tests/test_dgm_loop.py tests/test_telos_gates.py tests/test_dharma_kernel.py -q --tb=short
```

Focused result:

```text
110 passed, 3 warnings
```

Broader requested suite:

```bash
python -m pytest tests/test_bootstrap_loops.py tests/test_agent_runner.py tests/test_guardian_crew.py tests/test_dgm_loop.py tests/test_telos_gates.py tests/test_dharma_kernel.py tests/test_runtime_state.py -q
```

Result:

```text
133 passed, 1 failed, 3 warnings
```

Evolution suite:

```bash
python -m pytest tests/test_evolution.py -q
```

Result:

```text
91 passed, 1 failed, 1 warning
```

Known broader baseline failures are documented below.

## Known baseline failures

Two failures were present on `origin/main@9931d16` before this branch:

1. `tests/test_agent_runner.py::test_runner_fails_closed_for_tooling_task_on_api_only_provider`
   - Expected: local-tooling/API-only provider failure.
   - Actual: completion contract failure.
   - Reproduced on clean baseline.
   - Not caused by this PR.

2. `tests/test_evolution.py::test_run_cycle_triggers_periodic_meta_evolution`
   - Cause: `MetaArchiveEntry` rejects old fitness dimensions:
     - `economic_savings`
     - `paper_profit`
     - `verified_revenue`
   - Reproduced on clean baseline.
   - Not caused by this PR.

If CI requires full green, these should be fixed in a separate baseline-stabilization PR.

## Risk

- Context compilation is soft-gated in v0.1. Dispatch continues if bundle compilation fails.
- Prompt injection changes prompt content, not provider/tooling control flow.
- Guardian missing-context checks are warning-level and may have some false positives around noncanonical/manual rows.
- DGM autonomy is intentionally reduced by protecting dharma/evolution boundary files.
- `evolution.py` is protected in v0.1 because it currently contains evaluation/gating/archive machinery that mutation depends on.

## Rollback

Rollback is straightforward: revert the two commits or revert this PR.

No DB schema changes are introduced. Metadata additions are additive. Existing `context_bundles` rows can remain safely.