### PR TITLE
Stabilize baseline-red tests

### DIFF
--- a/dharma_swarm/agent_runner.py
+++ b/dharma_swarm/agent_runner.py
@@ -1414,6 +1414,8 @@ def _provider_supports_local_tool_loop(
     supports_tools = getattr(capabilities, "supports_tools", None)
     if isinstance(supports_tools, bool):
         return supports_tools
+    if provider is not None and not _is_routed_provider(provider):
+        return False
     # Routed provider (ModelRouter): check the agent's config provider type
     # The ModelRouter wraps all providers and doesn't have capabilities itself
     if _is_routed_provider(provider):

--- a/dharma_swarm/meta_evolution.py
+++ b/dharma_swarm/meta_evolution.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import math
 import random
 from pathlib import Path
@@ -13,6 +14,13 @@ from pydantic import BaseModel, Field, field_validator
 from dharma_swarm.archive import FITNESS_DIMENSIONS, normalize_fitness_weights
 from dharma_swarm.evolution import CycleResult, DarwinEngine, Proposal
 from dharma_swarm.models import _new_id, _utc_now
+
+
+_LEGACY_FITNESS_DIMENSION_ALIASES: dict[str, str] = {
+    "economic_savings": "economic_value",
+    "paper_profit": "economic_value",
+    "verified_revenue": "economic_value",
+}
 
 
 class MetaParameters(BaseModel):
@@ -236,7 +244,48 @@ class MetaEvolutionEngine:
                 stripped = line.strip()
                 if not stripped:
                     continue
-                self.meta_archive.append(MetaArchiveEntry.model_validate_json(stripped))
+                payload = json.loads(stripped)
+                self.meta_archive.append(
+                    MetaArchiveEntry.model_validate(
+                        self._normalize_meta_archive_payload(payload)
+                    )
+                )
+
+    @classmethod
+    def _normalize_meta_archive_payload(cls, payload: Any) -> Any:
+        """Map legacy archive-only fitness dimensions onto canonical weights."""
+        if not isinstance(payload, dict):
+            return payload
+        normalized_payload = dict(payload)
+        meta_parameters = normalized_payload.get("meta_parameters")
+        if not isinstance(meta_parameters, dict):
+            return normalized_payload
+
+        normalized_meta = dict(meta_parameters)
+        weights = normalized_meta.get("fitness_weights")
+        if not isinstance(weights, dict):
+            normalized_payload["meta_parameters"] = normalized_meta
+            return normalized_payload
+
+        normalized_weights: dict[str, Any] = {}
+        for raw_key, raw_value in weights.items():
+            key = cls._legacy_fitness_dimension(str(raw_key))
+            try:
+                value = float(raw_value)
+            except (TypeError, ValueError):
+                value = raw_value
+            if isinstance(value, float):
+                normalized_weights[key] = normalized_weights.get(key, 0.0) + value
+            else:
+                normalized_weights[key] = value
+
+        normalized_meta["fitness_weights"] = normalized_weights
+        normalized_payload["meta_parameters"] = normalized_meta
+        return normalized_payload
+
+    @staticmethod
+    def _legacy_fitness_dimension(key: str) -> str:
+        return _LEGACY_FITNESS_DIMENSION_ALIASES.get(key, key)
 
     def _archive_meta_entry(self, entry: MetaArchiveEntry) -> None:
         """Append a meta result to the JSONL archive."""

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -9,6 +9,7 @@ import sqlite3
 import pytest
 from unittest.mock import AsyncMock
 
+from dharma_swarm.base_provider import ProviderCapabilities
 from dharma_swarm.models import AgentConfig, AgentRole, AgentStatus, LLMResponse, ProviderType, Task
 from dharma_swarm.agent_runner import AgentPool, AgentRunner, _build_prompt
 from dharma_swarm.lineage import LineageGraph
@@ -439,6 +440,7 @@ async def test_runner_auto_executes_tool_loop_for_api_provider_shell_task(
     )
     target = tmp_path / "report.md"
     provider = AsyncMock()
+    provider.capabilities = ProviderCapabilities(supports_tools=True)
 
     async def _complete(request):
         call_index = provider.complete.await_count

--- a/tests/test_meta_evolution.py
+++ b/tests/test_meta_evolution.py
@@ -1,5 +1,7 @@
 """Tests for persisted Darwin meta-evolution."""
 
+import json
+
 import pytest
 
 from dharma_swarm.archive import FITNESS_DIMENSIONS
@@ -55,6 +57,53 @@ async def test_meta_cycle_archives_and_evolves_when_poor(engine_paths, tmp_path,
     assert len(meta.meta_archive) == 1
     assert meta.meta_params != initial
     assert engine.get_fitness_weights() == meta.meta_params.fitness_weights
+
+
+def test_meta_archive_loads_legacy_economic_fitness_dimensions(
+    engine_paths,
+    tmp_path,
+):
+    archive_path = tmp_path / "meta_archive_legacy.jsonl"
+    archive_path.write_text(
+        json.dumps(
+            {
+                "meta_parameters": {
+                    "fitness_weights": {
+                        "correctness": 0.18,
+                        "dharmic_alignment": 0.13,
+                        "swabhaav_alignment": 0.08,
+                        "performance": 0.11,
+                        "utilization": 0.11,
+                        "economic_savings": 0.04,
+                        "paper_profit": 0.04,
+                        "verified_revenue": 0.05,
+                        "elegance": 0.10,
+                        "efficiency": 0.10,
+                        "safety": 0.06,
+                    },
+                    "mutation_rate": 0.2,
+                    "exploration_coeff": 0.5,
+                    "circuit_breaker_limit": 4,
+                    "map_elites_n_bins": 6,
+                },
+                "meta_fitness": 0.7,
+                "n_object_cycles": 3,
+                "fitness_trajectory": [0.5, 0.6, 0.7],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    engine = DarwinEngine(**engine_paths)
+    meta = MetaEvolutionEngine(engine, meta_archive_path=archive_path)
+
+    assert len(meta.meta_archive) == 1
+    weights = meta.meta_archive[0].meta_parameters.fitness_weights
+    assert "economic_savings" not in weights
+    assert "paper_profit" not in weights
+    assert "verified_revenue" not in weights
+    assert weights["economic_value"] > 0.0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes the two known baseline-red failures reproduced on clean `origin/main`:

- `tests/test_agent_runner.py::test_runner_fails_closed_for_tooling_task_on_api_only_provider`
- `tests/test_evolution.py::test_run_cycle_triggers_periodic_meta_evolution`

## Changes

- AgentRunner now fails closed for direct local-tooling providers unless the provider explicitly declares `capabilities.supports_tools = True`.
- The API-provider tool-loop test now declares tool capability on its mock provider, preserving the intended positive path.
- Meta-evolution archive loading now normalizes legacy archive-only economic fitness dimensions into the canonical `economic_value` dimension:
  - `economic_savings`
  - `paper_profit`
  - `verified_revenue`
- Added focused coverage for legacy meta-archive loading.

## Non-goals

- No dashboard changes.
- No docs branch changes.
- No memory promotion changes.
- No operator/control-loop feature work.
- No Telos/Guardian/rollback/dharma-boundary weakening.
- No unrelated test fixes.

## Verification

```bash
python -m pytest tests/test_agent_runner.py tests/test_meta_evolution.py tests/test_evolution.py -q --tb=short
python -m compileall dharma_swarm tests
```

Results:

- `129 passed, 3 warnings`
- compileall passed
- pre-commit hooks passed on commit

## Scope

Changed files:

- `dharma_swarm/agent_runner.py`
- `dharma_swarm/meta_evolution.py`
- `tests/test_agent_runner.py`
- `tests/test_meta_evolution.py`