### PR TITLE
[codex] Add opt-in LLM intake for S4 zeitgeist scanning

### DIFF
--- a/dharma_swarm/zeitgeist.py
+++ b/dharma_swarm/zeitgeist.py
@@ -10,10 +10,12 @@ Orchestrated cadence: every 600 s (ZEITGEIST_INTERVAL in orchestrate_live).
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
 import re
+import shlex
 import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
@@ -24,6 +26,12 @@ from pydantic import BaseModel, Field
 from dharma_swarm.models import _new_id, _utc_now
 
 logger = logging.getLogger(__name__)
+
+LLM_SCAN_ENABLED_ENV = "DHARMA_ZEITGEIST_LLM_SCAN"
+LLM_SCAN_CMD_ENV = "DHARMA_ZEITGEIST_LLM_CMD"
+LLM_SCAN_SOURCE_ENV = "DHARMA_ZEITGEIST_LLM_SOURCE"
+LLM_SCAN_TIMEOUT_ENV = "DHARMA_ZEITGEIST_LLM_TIMEOUT_S"
+LLM_SCAN_TIMEOUT_S = 45.0
 
 
 # ---------------------------------------------------------------------------
@@ -134,8 +142,9 @@ class ZeitgeistScanner:
         local_signals = await self._scan_local()
         self._signals.extend(local_signals)
 
-        # Try claude scan if not in Claude Code session
-        if not os.environ.get("CLAUDECODE"):
+        # Try an LLM scan only when explicitly enabled. S4 should be able to
+        # run unattended without surprise network/model calls.
+        if os.environ.get(LLM_SCAN_ENABLED_ENV) == "1":
             try:
                 claude_signals = await self._scan_claude()
                 self._signals.extend(claude_signals)
@@ -321,13 +330,47 @@ class ZeitgeistScanner:
         return signals
 
     async def _scan_claude(self) -> list[ZeitgeistSignal]:
-        """Use ``claude -p`` for AI landscape scan.
+        """Use an opt-in LLM command for AI landscape scanning."""
+        prompt = (
+            "Return only compact JSON for DHARMA SWARM S4. Produce 3 current "
+            "frontier signals about agentic AI/autonomous coding agents, AI "
+            "governance, mechanistic interpretability, or self-improving tool "
+            "use. Schema: {\"signals\":[{\"category\":\"competing_research|"
+            "tool_release|methodology|threat|opportunity\",\"title\":\"...\","
+            "\"relevance_score\":0.0,\"keywords\":[\"...\"],"
+            "\"description\":\"...\"}]}"
+        )
+        cmd = shlex.split(os.environ.get(LLM_SCAN_CMD_ENV, "claude -p"))
+        if "{prompt}" in cmd:
+            cmd = [prompt if part == "{prompt}" else part for part in cmd]
+        else:
+            cmd.append(prompt)
 
-        Currently a stub that returns no signals.  A real implementation
-        would invoke ``claude -p`` with a structured prompt and parse the
-        JSON response.
-        """
-        return []
+        try:
+            timeout_s = float(os.environ.get(LLM_SCAN_TIMEOUT_ENV, LLM_SCAN_TIMEOUT_S))
+        except ValueError:
+            timeout_s = LLM_SCAN_TIMEOUT_S
+
+        def _run() -> subprocess.CompletedProcess[str]:
+            return subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=timeout_s,
+                check=False,
+            )
+
+        try:
+            proc = await asyncio.to_thread(_run)
+        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+            logger.debug("LLM zeitgeist scan unavailable: %s", exc)
+            return []
+
+        if proc.returncode != 0:
+            logger.debug("LLM zeitgeist scan failed: %s", proc.stderr.strip())
+            return []
+
+        return _parse_llm_signals(proc.stdout)
 
     # -- persistence --------------------------------------------------------
 
@@ -375,3 +418,85 @@ class ZeitgeistScanner:
     def clear(self) -> None:
         """Reset in-memory signal list (does not delete persisted files)."""
         self._signals = []
+
+
+def _parse_llm_signals(raw: str) -> list[ZeitgeistSignal]:
+    """Parse strict JSON, or a CLI transcript containing a final JSON payload."""
+    text = raw.strip()
+    if not text:
+        return []
+
+    if not text.startswith(("{", "[")):
+        for line in reversed(text.splitlines()):
+            candidate = line.strip()
+            if (
+                candidate.startswith(("{", "["))
+                and _loads_signal_payload(candidate) is not None
+            ):
+                text = candidate
+                break
+        else:
+            match = re.search(r"(\{.*\}|\[.*\])", text, flags=re.S)
+            if not match:
+                return []
+            text = match.group(1)
+
+    payload = _loads_signal_payload(text)
+    if payload is None:
+        return []
+
+    rows = payload.get("signals", payload) if isinstance(payload, dict) else payload
+    if not isinstance(rows, list):
+        return []
+
+    signals: list[ZeitgeistSignal] = []
+    allowed_categories = {
+        "competing_research",
+        "tool_release",
+        "methodology",
+        "threat",
+        "opportunity",
+    }
+    for row in rows[:5]:
+        if not isinstance(row, dict):
+            continue
+        category = str(row.get("category") or "methodology").strip()
+        if category not in allowed_categories:
+            category = "methodology"
+        title = str(row.get("title") or "").strip()
+        if not title:
+            continue
+        try:
+            relevance = float(row.get("relevance_score", 0.0))
+        except (TypeError, ValueError):
+            relevance = 0.0
+        keywords_raw = row.get("keywords", [])
+        keywords = (
+            [str(k).strip() for k in keywords_raw if str(k).strip()]
+            if isinstance(keywords_raw, list)
+            else []
+        )
+        signals.append(
+            ZeitgeistSignal(
+                source=os.environ.get(LLM_SCAN_SOURCE_ENV, "llm_scan"),
+                category=category,
+                title=title[:140],
+                relevance_score=max(0.0, min(1.0, relevance)),
+                keywords=keywords[:8],
+                description=str(row.get("description") or "").strip()[:800],
+            )
+        )
+    return signals
+
+
+def _loads_signal_payload(text: str) -> Any | None:
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as exc:
+        logger.debug("LLM zeitgeist JSON parse failed: %s", exc)
+        return None
+    if isinstance(payload, list):
+        return payload
+    if isinstance(payload, dict) and "signals" in payload:
+        return payload
+    return None

--- a/dharma_swarm/zeitgeist.py
+++ b/dharma_swarm/zeitgeist.py
@@ -1,8 +1,8 @@
 """S4 Environmental Intelligence -- zeitgeist awareness.
 
 Beer's Viable System Model System 4: outside-and-future awareness.
-Scans local files for research-relevant signals and optionally uses
-``claude -p`` subprocess for AI landscape scanning (when available).
+Scans local files for research-relevant signals and optionally uses a
+configured LLM subprocess for AI landscape scanning when enabled.
 
 Output: ``~/.dharma/meta/zeitgeist.md`` + ``zeitgeist.jsonl``
 Orchestrated cadence: every 600 s (ZEITGEIST_INTERVAL in orchestrate_live).
@@ -113,7 +113,8 @@ class ZeitgeistScanner:
     """S4 scanner that detects research-relevant environmental signals.
 
     The scanner inspects local state (shared notes, stigmergy density) and
-    optionally delegates to ``claude -p`` for broader landscape awareness.
+    optionally delegates to a configured LLM command for broader landscape
+    awareness.
     Results are persisted as a Markdown summary and a JSONL log.
 
     Args:
@@ -146,10 +147,10 @@ class ZeitgeistScanner:
         # run unattended without surprise network/model calls.
         if os.environ.get(LLM_SCAN_ENABLED_ENV) == "1":
             try:
-                claude_signals = await self._scan_claude()
-                self._signals.extend(claude_signals)
+                llm_signals = await self._scan_llm()
+                self._signals.extend(llm_signals)
             except Exception as exc:
-                logger.debug("Claude scan unavailable: %s", exc)
+                logger.debug("LLM scan unavailable: %s", exc)
 
         # Persist
         self._save()
@@ -329,7 +330,7 @@ class ZeitgeistScanner:
 
         return signals
 
-    async def _scan_claude(self) -> list[ZeitgeistSignal]:
+    async def _scan_llm(self) -> list[ZeitgeistSignal]:
         """Use an opt-in LLM command for AI landscape scanning."""
         prompt = (
             "Return only compact JSON for DHARMA SWARM S4. Produce 3 current "

--- a/tests/test_zeitgeist.py
+++ b/tests/test_zeitgeist.py
@@ -16,6 +16,7 @@ from dharma_swarm.zeitgeist import (
     THREAT_KEYWORDS,
     ZeitgeistScanner,
     ZeitgeistSignal,
+    _parse_llm_signals,
 )
 
 
@@ -97,6 +98,68 @@ class TestDetectThreats:
         text = "Normal research progress on transformer architecture."
         threats = scanner.detect_threats(text)
         assert threats == []
+
+
+# -- LLM scan parsing tests -------------------------------------------------
+
+
+class TestLLMSignalParsing:
+    def test_parse_llm_signal_payload(self) -> None:
+        raw = json.dumps(
+            {
+                "signals": [
+                    {
+                        "category": "threat",
+                        "title": "Agent eval pressure is rising",
+                        "relevance_score": 0.9,
+                        "keywords": ["agentic AI", "governance"],
+                        "description": "Frontier agent systems need stronger action gates.",
+                    }
+                ]
+            }
+        )
+
+        signals = _parse_llm_signals(raw)
+
+        assert len(signals) == 1
+        assert signals[0].source == "llm_scan"
+        assert signals[0].category == "threat"
+        assert signals[0].relevance_score == 0.9
+
+    def test_parse_cli_transcript_uses_last_json_payload(self) -> None:
+        raw = "\n".join(
+            [
+                "user",
+                '{"signals":[{"category":"opportunity","title":"prompt echo"}]}',
+                "assistant",
+                '{"signals":[{"category":"methodology","title":"parsed result","relevance_score":0.7}]}',
+            ]
+        )
+
+        signals = _parse_llm_signals(raw)
+
+        assert len(signals) == 1
+        assert signals[0].category == "methodology"
+        assert signals[0].title == "parsed result"
+
+    def test_parse_unknown_category_as_methodology(self) -> None:
+        raw = json.dumps(
+            {
+                "signals": [
+                    {
+                        "category": "signal",
+                        "title": "Governance pressure",
+                        "relevance_score": 1.5,
+                    }
+                ]
+            }
+        )
+
+        signals = _parse_llm_signals(raw)
+
+        assert len(signals) == 1
+        assert signals[0].category == "methodology"
+        assert signals[0].relevance_score == 1.0
 
 
 # -- Local scan tests ------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds a default-off LLM intake path to `ZeitgeistScanner` so S4 can ingest current frontier signals from a configured model/tool command without pulling in the LF5 executive substrate.

Scope is intentionally small:

- `dharma_swarm/zeitgeist.py`: opt-in LLM subprocess scan with command/source/timeout env vars.
- `tests/test_zeitgeist.py`: parser coverage for strict JSON, CLI transcript JSON, unknown category normalization, and relevance clamping.

No `ShaktiZeitgeistExecutive`, `executive_substrates.py`, LF5 runtime spine, dashboard changes, or dispatch authority are included.

## Operator Impact

Default runtime behavior remains local-only. LLM scanning only runs when explicitly enabled:

```bash
DHARMA_ZEITGEIST_LLM_SCAN=1
DHARMA_ZEITGEIST_LLM_CMD='codex exec --model gpt-5.4-mini'
DHARMA_ZEITGEIST_LLM_SOURCE=codex_scan
DHARMA_ZEITGEIST_LLM_TIMEOUT_S=180
```

The configured command may include `{prompt}` as a placeholder. If omitted, the prompt is appended to the command.

## Real Smoke

Run from `/Users/dhyana/dharma_swarm_s4_zeitgeist_llm` with Codex as the LLM command:

```text
SMOKE_SIGNAL_COUNT 7
SMOKE_SIGNAL local_scan methodology 0.2 Keywords in conductor_codex_notes.md
SMOKE_SIGNAL local_scan threat 1.0 Keywords in cyber-codex_notes.md
SMOKE_SIGNAL local_scan threat 1.0 High gate block rate (S3→S4 channel)
SMOKE_SIGNAL local_scan opportunity 0.3 High stigmergy density
SMOKE_SIGNAL codex_scan tool_release 0.98 GPT-5.5 pushes agentic coding into longer self-directed work loops
SMOKE_SIGNAL codex_scan methodology 0.95 A3 turns safety governance into an agentic remediation pipeline
SMOKE_SIGNAL codex_scan methodology 0.93 Anthropic's emotion vectors make interpretability more causal
```

## Verification

```text
25 passed: tests/test_zeitgeist.py
compileall passed for dharma_swarm/zeitgeist.py and tests/test_zeitgeist.py
git diff --check passed
pre-commit run --files dharma_swarm/zeitgeist.py tests/test_zeitgeist.py passed
commit hooks passed
```

## Governance Note

This PR is the Stage 1 sensing seam only. Stage 2 should separately evaluate whether and how to bring `ShaktiZeitgeistExecutive` into main after this S4 input path exists on main.