### PR TITLE
[codex] Add read-only Shakti zeitgeist executive

### DIFF
--- a/dharma_swarm/fourfold_action_warrant.py
+++ b/dharma_swarm/fourfold_action_warrant.py
@@ -1,0 +1,263 @@
+"""Fourfold Action Warrant gate.
+
+This module gives high-authority actions a deterministic pre-action contract:
+prove enough context was gathered, name the active capabilities, and produce a
+compact three-paragraph warrant before the action is allowed.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from dharma_swarm.models import GateDecision, _new_id, _utc_now
+
+
+MIN_EVIDENCE_FILES = 50
+REQUIRED_EVIDENCE_CATEGORIES = frozenset(
+    {"root", "code", "tests", "history", "tools"}
+)
+
+_TRIGGER_KEYWORDS = {
+    "autonomous": "autonomy",
+    "dispatch": "dispatch_authority",
+    "execute": "execution_authority",
+    "governance": "governance_impact",
+    "gate": "governance_impact",
+    "hook": "hook_or_tooling",
+    "main": "main_branch_or_release",
+    "merge": "main_branch_or_release",
+    "mcp": "external_tool_use",
+    "network": "external_tool_use",
+    "policy": "governance_impact",
+    "push": "main_branch_or_release",
+    "spawn": "cross_agent_authority",
+    "tool": "external_tool_use",
+    "worktree": "code_mutation",
+    "write": "code_mutation",
+}
+
+_METADATA_TRIGGERS = {
+    "is_significant_action": "significant_action",
+    "writes_code": "code_mutation",
+    "mutates_repo": "code_mutation",
+    "governance_impact": "governance_impact",
+    "external_tool_use": "external_tool_use",
+    "network_access": "external_tool_use",
+    "cross_agent_authority": "cross_agent_authority",
+    "dispatch_authority": "dispatch_authority",
+    "main_branch": "main_branch_or_release",
+    "operator_visible": "operator_visible",
+}
+
+
+class EvidenceItem(BaseModel):
+    """One file, tool, or memory surface inspected before action."""
+
+    path: str
+    category: str
+    theme: str = ""
+    why: str = ""
+
+
+class CapabilityInventory(BaseModel):
+    """Capabilities available to the acting agent at decision time."""
+
+    skills: list[str] = Field(default_factory=list)
+    mcp_tools: list[str] = Field(default_factory=list)
+    plugins: list[str] = Field(default_factory=list)
+    hooks: list[str] = Field(default_factory=list)
+
+    @property
+    def total_count(self) -> int:
+        return (
+            len(self.skills)
+            + len(self.mcp_tools)
+            + len(self.plugins)
+            + len(self.hooks)
+        )
+
+
+class ActionWarrantRequest(BaseModel):
+    """Input facts for evaluating whether an action may proceed."""
+
+    title: str
+    description: str = ""
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    evidence: list[EvidenceItem] = Field(default_factory=list)
+    capabilities: CapabilityInventory = Field(default_factory=CapabilityInventory)
+    zeitgeist_signal_ids: list[str] = Field(default_factory=list)
+    integrated_vision: str = ""
+    connection_map: str = ""
+    meaningful_action: str = ""
+
+
+class FourfoldActionWarrant(BaseModel):
+    """Gate result for a proposed high-authority action."""
+
+    warrant_id: str = Field(default_factory=_new_id)
+    title: str
+    required: bool
+    decision: GateDecision
+    trigger_reasons: list[str] = Field(default_factory=list)
+    blockers: list[str] = Field(default_factory=list)
+    evidence_count: int = 0
+    evidence_categories: list[str] = Field(default_factory=list)
+    capabilities: CapabilityInventory = Field(default_factory=CapabilityInventory)
+    zeitgeist_signal_ids: list[str] = Field(default_factory=list)
+    four_levels: dict[str, str] = Field(default_factory=dict)
+    integrated_vision: str = ""
+    connection_map: str = ""
+    meaningful_action: str = ""
+    created_at: datetime = Field(default_factory=_utc_now)
+
+    @property
+    def allowed(self) -> bool:
+        return self.decision is GateDecision.ALLOW
+
+
+def trigger_reasons_for_action(
+    title: str,
+    description: str = "",
+    metadata: dict[str, Any] | None = None,
+) -> list[str]:
+    """Return deterministic reasons that the action needs a warrant."""
+
+    reasons: set[str] = set()
+    meta = metadata or {}
+    for key, reason in _METADATA_TRIGGERS.items():
+        if bool(meta.get(key)):
+            reasons.add(reason)
+
+    autonomy = str(meta.get("autonomy_level") or "").strip().lower()
+    if autonomy in {"aggressive", "full", "self_authorized", "autonomous"}:
+        reasons.add("high_autonomy")
+
+    text = f"{title}\n{description}".lower()
+    for keyword, reason in _TRIGGER_KEYWORDS.items():
+        if keyword in text and not _keyword_negated(text, keyword):
+            reasons.add(reason)
+
+    return sorted(reasons)
+
+
+def requires_fourfold_warrant(
+    title: str,
+    description: str = "",
+    metadata: dict[str, Any] | None = None,
+) -> bool:
+    """Whether the action must pass the Fourfold Action Warrant gate."""
+
+    return bool(trigger_reasons_for_action(title, description, metadata))
+
+
+def build_fourfold_action_warrant(
+    request: ActionWarrantRequest,
+    *,
+    min_evidence_files: int = MIN_EVIDENCE_FILES,
+) -> FourfoldActionWarrant:
+    """Evaluate a request and return a hard allow/block/review decision."""
+
+    reasons = trigger_reasons_for_action(
+        request.title,
+        request.description,
+        request.metadata,
+    )
+    required = bool(reasons)
+    categories = sorted({item.category for item in request.evidence if item.category})
+    unique_paths = {str(Path(item.path)) for item in request.evidence if item.path}
+
+    blockers: list[str] = []
+    if required and len(unique_paths) < min_evidence_files:
+        blockers.append(
+            f"evidence_files<{min_evidence_files} ({len(unique_paths)})"
+        )
+    if required:
+        missing = sorted(REQUIRED_EVIDENCE_CATEGORIES - set(categories))
+        if missing:
+            blockers.append("missing_evidence_categories:" + ",".join(missing))
+    if required and request.capabilities.total_count == 0:
+        blockers.append("missing_capability_inventory")
+
+    narrative_missing = _missing_narrative_fields(request)
+    if required and narrative_missing:
+        blockers.append("missing_warrant_paragraphs:" + ",".join(narrative_missing))
+
+    decision = GateDecision.ALLOW
+    if blockers:
+        decision = GateDecision.BLOCK
+    elif required and not request.zeitgeist_signal_ids:
+        decision = GateDecision.REVIEW
+
+    return FourfoldActionWarrant(
+        title=request.title,
+        required=required,
+        decision=decision,
+        trigger_reasons=reasons,
+        blockers=blockers,
+        evidence_count=len(unique_paths),
+        evidence_categories=categories,
+        capabilities=request.capabilities,
+        zeitgeist_signal_ids=list(request.zeitgeist_signal_ids),
+        four_levels=_four_levels(request),
+        integrated_vision=request.integrated_vision.strip(),
+        connection_map=request.connection_map.strip(),
+        meaningful_action=request.meaningful_action.strip(),
+    )
+
+
+def _missing_narrative_fields(request: ActionWarrantRequest) -> list[str]:
+    fields = {
+        "integrated_vision": request.integrated_vision,
+        "connection_map": request.connection_map,
+        "meaningful_action": request.meaningful_action,
+    }
+    return [name for name, value in fields.items() if len(value.strip()) < 80]
+
+
+def _keyword_negated(text: str, keyword: str) -> bool:
+    plural = f"{keyword}s"
+    negations = (
+        f"no {keyword}",
+        f"no {plural}",
+        f"no external {keyword}",
+        f"no external {plural}",
+        f"not {keyword}",
+        f"not {plural}",
+        f"without {keyword}",
+        f"without {plural}",
+        f"does not {keyword}",
+        f"does not {plural}",
+        f"do not {keyword}",
+        f"do not {plural}",
+    )
+    return any(phrase in text for phrase in negations)
+
+
+def _four_levels(request: ActionWarrantRequest) -> dict[str, str]:
+    return {
+        "vision": request.integrated_vision.strip(),
+        "authority": "; ".join(trigger_reasons_for_action(
+            request.title,
+            request.description,
+            request.metadata,
+        )),
+        "relationship": request.connection_map.strip(),
+        "precision": request.meaningful_action.strip(),
+    }
+
+
+__all__ = [
+    "ActionWarrantRequest",
+    "CapabilityInventory",
+    "EvidenceItem",
+    "FourfoldActionWarrant",
+    "MIN_EVIDENCE_FILES",
+    "REQUIRED_EVIDENCE_CATEGORIES",
+    "build_fourfold_action_warrant",
+    "requires_fourfold_warrant",
+    "trigger_reasons_for_action",
+]

--- a/dharma_swarm/shakti_zeitgeist_executive.py
+++ b/dharma_swarm/shakti_zeitgeist_executive.py
@@ -1,0 +1,352 @@
+"""Read-only S4 executive consumer.
+
+Stage 2 keeps the executive intentionally narrow: it consumes persisted
+ZeitgeistScanner signals, ranks strategic pressure, and emits warrant-pressure
+artifacts. It does not dispatch work, rewrite campaign memory, or own action
+authority.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from dharma_swarm.fourfold_action_warrant import (
+    ActionWarrantRequest,
+    CapabilityInventory,
+    EvidenceItem,
+    FourfoldActionWarrant,
+    MIN_EVIDENCE_FILES,
+    build_fourfold_action_warrant,
+    trigger_reasons_for_action,
+)
+from dharma_swarm.models import _new_id, _utc_now
+from dharma_swarm.zeitgeist import ZeitgeistScanner, ZeitgeistSignal
+
+logger = logging.getLogger(__name__)
+
+DISPATCH_AUTHORITY = False
+
+DOMAINS: tuple[str, ...] = (
+    "internal_maintenance",
+    "reliability",
+    "research",
+    "artifact_publication",
+    "productization",
+    "ecosystem_scan",
+    "revenue_exploration",
+    "strategic_infrastructure",
+)
+
+_DOMAIN_KEYWORDS: dict[str, tuple[str, ...]] = {
+    "reliability": ("failure", "blocked", "gate", "semgrep", "test", "hook"),
+    "research": ("research", "paper", "interpretability", "agentic", "model"),
+    "artifact_publication": ("article", "publish", "brief", "report", "docs"),
+    "productization": ("dashboard", "api", "user", "operator", "product"),
+    "ecosystem_scan": ("zeitgeist", "external", "frontier", "release", "tool"),
+    "revenue_exploration": ("revenue", "market", "customer", "venture"),
+    "strategic_infrastructure": ("ontology", "mcp", "plugin", "memory", "schema"),
+}
+
+_WORLD_FACING = frozenset(
+    {
+        "research",
+        "artifact_publication",
+        "productization",
+        "ecosystem_scan",
+        "revenue_exploration",
+    }
+)
+
+
+class ExecutiveSignal(BaseModel):
+    signal_id: str = Field(default_factory=_new_id)
+    source: str
+    category: str
+    title: str
+    relevance: float = 0.0
+    urgency: float = 0.0
+    domain: str = "internal_maintenance"
+    keywords: list[str] = Field(default_factory=list)
+    raw_data: dict[str, Any] = Field(default_factory=dict)
+    timestamp: datetime = Field(default_factory=_utc_now)
+
+
+class ScoredOpportunity(BaseModel):
+    opportunity_id: str = Field(default_factory=_new_id)
+    title: str
+    domain: str
+    thesis: str = ""
+    final_score: float = 0.0
+    evidence_signals: list[str] = Field(default_factory=list)
+    why_now: str = ""
+    timestamp: datetime = Field(default_factory=_utc_now)
+
+
+class WarrantPressure(BaseModel):
+    required_for_next_action: bool = False
+    pressure_score: float = 0.0
+    trigger_reasons: list[str] = Field(default_factory=list)
+    min_evidence_files: int = MIN_EVIDENCE_FILES
+    suggested_evidence_categories: list[str] = Field(
+        default_factory=lambda: ["root", "code", "tests", "history", "tools"]
+    )
+    zeitgeist_signal_ids: list[str] = Field(default_factory=list)
+
+
+class ExecutiveCycleState(BaseModel):
+    cycle_id: str = Field(default_factory=_new_id)
+    timestamp: datetime = Field(default_factory=_utc_now)
+    signals_ingested: int = 0
+    signals_by_source: dict[str, int] = Field(default_factory=dict)
+    opportunities: list[ScoredOpportunity] = Field(default_factory=list)
+    warrant_pressure: WarrantPressure = Field(default_factory=WarrantPressure)
+    dispatch_authority: bool = DISPATCH_AUTHORITY
+    duration_ms: float = 0.0
+
+
+class ShaktiZeitgeistExecutive:
+    """Read-only strategic consumer of S4 zeitgeist signals."""
+
+    def __init__(self, state_dir: Path | None = None) -> None:
+        self._state_dir = state_dir or (Path.home() / ".dharma")
+        self._meta_dir = self._state_dir / "meta"
+        self._briefs_dir = self._meta_dir / "executive_briefs"
+        self._history_path = self._meta_dir / "shakti_zeitgeist_history.jsonl"
+
+    async def cycle(self) -> ExecutiveCycleState:
+        """Ingest S4 signals, rank pressure, and emit read-only artifacts."""
+
+        start = datetime.now().timestamp()
+        signals = self._ingest_zeitgeist()
+        opportunities = self._rank_opportunities(signals)
+        warrant_pressure = self._build_warrant_pressure(signals)
+        state = ExecutiveCycleState(
+            signals_ingested=len(signals),
+            signals_by_source=_count_by(signals, "source"),
+            opportunities=opportunities[:8],
+            warrant_pressure=warrant_pressure,
+            duration_ms=round((datetime.now().timestamp() - start) * 1000, 1),
+        )
+        self._emit_artifacts(state)
+        return state
+
+    def assess_action(
+        self,
+        *,
+        title: str,
+        description: str = "",
+        metadata: dict[str, Any] | None = None,
+        evidence: list[EvidenceItem] | None = None,
+        capabilities: CapabilityInventory | None = None,
+        integrated_vision: str = "",
+        connection_map: str = "",
+        meaningful_action: str = "",
+        min_evidence_files: int = MIN_EVIDENCE_FILES,
+    ) -> FourfoldActionWarrant:
+        """Evaluate a proposed action without executing or routing it."""
+
+        signal_ids = [sig.signal_id for sig in self._ingest_zeitgeist()[-20:]]
+        request = ActionWarrantRequest(
+            title=title,
+            description=description,
+            metadata=metadata or {},
+            evidence=evidence or [],
+            capabilities=capabilities or CapabilityInventory(),
+            zeitgeist_signal_ids=signal_ids,
+            integrated_vision=integrated_vision,
+            connection_map=connection_map,
+            meaningful_action=meaningful_action,
+        )
+        return build_fourfold_action_warrant(
+            request,
+            min_evidence_files=min_evidence_files,
+        )
+
+    def _ingest_zeitgeist(self) -> list[ExecutiveSignal]:
+        try:
+            raw = ZeitgeistScanner(state_dir=self._state_dir).load_history()
+        except Exception as exc:
+            logger.debug("executive zeitgeist ingest failed: %s", exc)
+            return []
+
+        out: list[ExecutiveSignal] = []
+        for sig in raw[-200:]:
+            out.append(_from_zeitgeist(sig))
+        return out
+
+    def _rank_opportunities(
+        self,
+        signals: list[ExecutiveSignal],
+    ) -> list[ScoredOpportunity]:
+        grouped: dict[str, list[ExecutiveSignal]] = {domain: [] for domain in DOMAINS}
+        for sig in signals:
+            domain = sig.domain if sig.domain in grouped else "internal_maintenance"
+            grouped[domain].append(sig)
+
+        opportunities: list[ScoredOpportunity] = []
+        for domain, domain_signals in grouped.items():
+            if not domain_signals:
+                continue
+            best = max(
+                domain_signals,
+                key=lambda sig: (sig.urgency, sig.relevance, sig.timestamp),
+            )
+            score = _domain_score(domain, domain_signals)
+            opportunities.append(
+                ScoredOpportunity(
+                    title=best.title,
+                    domain=domain,
+                    thesis=best.category,
+                    final_score=score,
+                    evidence_signals=[sig.signal_id for sig in domain_signals[:8]],
+                    why_now=f"{len(domain_signals)} S4 signals in {domain}",
+                )
+            )
+        opportunities.sort(key=lambda item: item.final_score, reverse=True)
+        return opportunities
+
+    def _build_warrant_pressure(
+        self,
+        signals: list[ExecutiveSignal],
+    ) -> WarrantPressure:
+        pressure_signals = [
+            sig for sig in signals
+            if sig.category == "threat" or sig.relevance >= 0.85 or sig.urgency >= 0.8
+        ]
+        pressure_score = min(
+            1.0,
+            sum(max(sig.relevance, sig.urgency) for sig in pressure_signals) / 5.0,
+        )
+        reasons = set()
+        if pressure_signals:
+            reasons.add("active_s4_pressure")
+        for sig in pressure_signals:
+            reasons.update(trigger_reasons_for_action(sig.title, " ".join(sig.keywords)))
+        return WarrantPressure(
+            required_for_next_action=pressure_score >= 0.35,
+            pressure_score=round(pressure_score, 3),
+            trigger_reasons=sorted(reasons),
+            zeitgeist_signal_ids=[sig.signal_id for sig in pressure_signals[:12]],
+        )
+
+    def _emit_artifacts(self, state: ExecutiveCycleState) -> None:
+        self._meta_dir.mkdir(parents=True, exist_ok=True)
+        self._briefs_dir.mkdir(parents=True, exist_ok=True)
+        _write_json(
+            self._meta_dir / "shakti_zeitgeist_state.json",
+            state.model_dump(mode="json"),
+        )
+        _write_json(
+            self._meta_dir / "s4_warrant_pressure.json",
+            state.warrant_pressure.model_dump(mode="json"),
+        )
+        (self._meta_dir / "s4_warrant_pressure.md").write_text(
+            _render_warrant_pressure(state),
+            encoding="utf-8",
+        )
+        brief_name = state.timestamp.strftime("%Y-%m-%dT%H%M%S") + ".md"
+        (self._briefs_dir / brief_name).write_text(_render_brief(state), encoding="utf-8")
+        with self._history_path.open("a", encoding="utf-8") as fh:
+            fh.write(state.model_dump_json() + "\n")
+
+
+def _from_zeitgeist(signal: ZeitgeistSignal) -> ExecutiveSignal:
+    domain = _classify_domain(
+        f"{signal.title}\n{signal.description}\n{' '.join(signal.keywords)}"
+    )
+    urgency = 1.0 if signal.category == "threat" else min(0.8, signal.relevance_score)
+    return ExecutiveSignal(
+        source="zeitgeist",
+        category=signal.category,
+        title=signal.title,
+        relevance=signal.relevance_score,
+        urgency=urgency,
+        domain=domain,
+        keywords=signal.keywords,
+        raw_data={"zeitgeist_id": signal.id},
+        timestamp=signal.timestamp,
+    )
+
+
+def _classify_domain(text: str) -> str:
+    lowered = text.lower()
+    scores = {
+        domain: sum(1 for keyword in keywords if keyword in lowered)
+        for domain, keywords in _DOMAIN_KEYWORDS.items()
+    }
+    best_domain, best_score = max(scores.items(), key=lambda item: item[1])
+    return best_domain if best_score > 0 else "internal_maintenance"
+
+
+def _domain_score(domain: str, signals: list[ExecutiveSignal]) -> float:
+    avg_relevance = sum(sig.relevance for sig in signals) / max(1, len(signals))
+    max_urgency = max((sig.urgency for sig in signals), default=0.0)
+    world_bonus = 0.15 if domain in _WORLD_FACING else 0.0
+    density_bonus = min(0.15, len(signals) * 0.03)
+    score = min(1.0, avg_relevance * 0.5 + max_urgency * 0.35 + world_bonus + density_bonus)
+    return round(score * 100, 1)
+
+
+def _count_by(items: list[ExecutiveSignal], attr: str) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for item in items:
+        key = str(getattr(item, attr, ""))
+        counts[key] = counts.get(key, 0) + 1
+    return counts
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _render_warrant_pressure(state: ExecutiveCycleState) -> str:
+    pressure = state.warrant_pressure
+    lines = [
+        "# S4 Warrant Pressure",
+        "",
+        f"- Required: {pressure.required_for_next_action}",
+        f"- Pressure: {pressure.pressure_score}",
+        f"- Minimum evidence files: {pressure.min_evidence_files}",
+    ]
+    if pressure.trigger_reasons:
+        lines.append("- Triggers: " + ", ".join(pressure.trigger_reasons))
+    if pressure.zeitgeist_signal_ids:
+        lines.append("- Signal IDs: " + ", ".join(pressure.zeitgeist_signal_ids))
+    return "\n".join(lines) + "\n"
+
+
+def _render_brief(state: ExecutiveCycleState) -> str:
+    lines = [
+        "# Shakti Zeitgeist Executive Brief",
+        "",
+        f"Cycle: {state.cycle_id}",
+        f"Signals ingested: {state.signals_ingested}",
+        f"Dispatch authority: {state.dispatch_authority}",
+        "",
+        "## Top Opportunities",
+    ]
+    if not state.opportunities:
+        lines.append("No opportunities detected.")
+    for opp in state.opportunities:
+        lines.append(f"- [{opp.domain}] {opp.title} ({opp.final_score})")
+    lines.extend(["", "## Warrant Pressure"])
+    lines.append(f"- Required: {state.warrant_pressure.required_for_next_action}")
+    lines.append(f"- Pressure: {state.warrant_pressure.pressure_score}")
+    return "\n".join(lines) + "\n"
+
+
+__all__ = [
+    "DISPATCH_AUTHORITY",
+    "DOMAINS",
+    "ExecutiveCycleState",
+    "ExecutiveSignal",
+    "ScoredOpportunity",
+    "ShaktiZeitgeistExecutive",
+    "WarrantPressure",
+]

--- a/dharma_swarm/shakti_zeitgeist_executive.py
+++ b/dharma_swarm/shakti_zeitgeist_executive.py
@@ -26,6 +26,7 @@ from dharma_swarm.fourfold_action_warrant import (
     trigger_reasons_for_action,
 )
 from dharma_swarm.models import _new_id, _utc_now
+from dharma_swarm.runtime_state import DEFAULT_RUNTIME_DB
 from dharma_swarm.zeitgeist import ZeitgeistScanner, ZeitgeistSignal
 
 logger = logging.getLogger(__name__)
@@ -114,7 +115,7 @@ class ShaktiZeitgeistExecutive:
     """Read-only strategic consumer of S4 zeitgeist signals."""
 
     def __init__(self, state_dir: Path | None = None) -> None:
-        self._state_dir = state_dir or (Path.home() / ".dharma")
+        self._state_dir = state_dir or DEFAULT_RUNTIME_DB.parent.parent
         self._meta_dir = self._state_dir / "meta"
         self._briefs_dir = self._meta_dir / "executive_briefs"
         self._history_path = self._meta_dir / "shakti_zeitgeist_history.jsonl"

--- a/dharma_swarm/shakti_zeitgeist_executive.py
+++ b/dharma_swarm/shakti_zeitgeist_executive.py
@@ -229,7 +229,7 @@ class ShaktiZeitgeistExecutive:
         for sig in pressure_signals:
             reasons.update(trigger_reasons_for_action(sig.title, " ".join(sig.keywords)))
         return WarrantPressure(
-            required_for_next_action=pressure_score >= 0.35,
+            required_for_next_action=bool(pressure_signals),
             pressure_score=round(pressure_score, 3),
             trigger_reasons=sorted(reasons),
             zeitgeist_signal_ids=[sig.signal_id for sig in pressure_signals[:12]],

--- a/tests/test_fourfold_action_warrant.py
+++ b/tests/test_fourfold_action_warrant.py
@@ -1,0 +1,108 @@
+"""Tests for the Fourfold Action Warrant gate."""
+
+from __future__ import annotations
+
+from dharma_swarm.fourfold_action_warrant import (
+    ActionWarrantRequest,
+    CapabilityInventory,
+    EvidenceItem,
+    build_fourfold_action_warrant,
+    requires_fourfold_warrant,
+    trigger_reasons_for_action,
+)
+from dharma_swarm.models import GateDecision
+
+
+def _evidence(count: int) -> list[EvidenceItem]:
+    categories = ["root", "code", "tests", "history", "tools"]
+    return [
+        EvidenceItem(
+            path=f"/repo/file_{i}.py",
+            category=categories[i % len(categories)],
+            theme="stage2",
+            why="read before action",
+        )
+        for i in range(count)
+    ]
+
+
+def _capabilities() -> CapabilityInventory:
+    return CapabilityInventory(
+        skills=["mcp-synergy", "gitnexus-exploring"],
+        mcp_tools=["filesystem.read_multiple_files", "github.fetch_pr"],
+        plugins=["GitHub"],
+        hooks=["pre-commit"],
+    )
+
+
+def test_trigger_reasons_for_governance_action() -> None:
+    reasons = trigger_reasons_for_action(
+        "Merge governance hook into main",
+        "This writes code and changes a policy gate.",
+        {"is_significant_action": True, "governance_impact": True},
+    )
+
+    assert "significant_action" in reasons
+    assert "governance_impact" in reasons
+    assert "main_branch_or_release" in reasons
+    assert requires_fourfold_warrant(
+        "Merge governance hook into main",
+        metadata={"governance_impact": True},
+    )
+
+
+def test_required_warrant_blocks_incomplete_manifest() -> None:
+    request = ActionWarrantRequest(
+        title="Enable autonomous dispatch from S4",
+        metadata={"dispatch_authority": True},
+        evidence=_evidence(2),
+        capabilities=_capabilities(),
+        integrated_vision="short",
+        connection_map="short",
+        meaningful_action="short",
+    )
+
+    warrant = build_fourfold_action_warrant(request, min_evidence_files=5)
+
+    assert warrant.required
+    assert warrant.decision is GateDecision.BLOCK
+    assert any(blocker.startswith("evidence_files<5") for blocker in warrant.blockers)
+    assert any(blocker.startswith("missing_warrant_paragraphs") for blocker in warrant.blockers)
+
+
+def test_complete_manifest_allows_high_authority_action() -> None:
+    paragraph = (
+        "The action is understood as a bounded S4 consumer change: it improves "
+        "strategic sensing without granting dispatch authority or changing the "
+        "operator's control path."
+    )
+    request = ActionWarrantRequest(
+        title="Wire read-only governance pressure into S4",
+        metadata={"governance_impact": True, "writes_code": True},
+        evidence=_evidence(5),
+        capabilities=_capabilities(),
+        zeitgeist_signal_ids=["sig-a"],
+        integrated_vision=paragraph,
+        connection_map=paragraph.replace("S4", "S3/S4"),
+        meaningful_action=paragraph.replace("strategic sensing", "test-covered artifacts"),
+    )
+
+    warrant = build_fourfold_action_warrant(request, min_evidence_files=5)
+
+    assert warrant.required
+    assert warrant.decision is GateDecision.ALLOW
+    assert warrant.allowed
+    assert warrant.evidence_count == 5
+    assert set(warrant.evidence_categories) == {"root", "code", "tests", "history", "tools"}
+
+
+def test_non_authority_action_does_not_require_warrant() -> None:
+    request = ActionWarrantRequest(
+        title="Read the operator note",
+        description="No code mutation, no dispatch, no external tools.",
+    )
+
+    warrant = build_fourfold_action_warrant(request)
+
+    assert not warrant.required
+    assert warrant.decision is GateDecision.ALLOW

--- a/tests/test_shakti_zeitgeist_executive.py
+++ b/tests/test_shakti_zeitgeist_executive.py
@@ -89,6 +89,29 @@ async def test_cycle_consumes_zeitgeist_and_emits_artifacts(tmp_path: Path) -> N
     assert not (meta / "active_campaigns.json").exists()
 
 
+@pytest.mark.asyncio
+async def test_single_threat_sets_warrant_pressure(tmp_path: Path) -> None:
+    state_dir = _state(tmp_path)
+    _write_zeitgeist(
+        state_dir,
+        [
+            {
+                "id": "zg-threat",
+                "category": "threat",
+                "title": "New governance bypass threat",
+                "relevance_score": 0.9,
+                "keywords": ["governance", "dispatch"],
+            }
+        ],
+    )
+
+    state = await ShaktiZeitgeistExecutive(state_dir=state_dir).cycle()
+
+    assert state.warrant_pressure.required_for_next_action
+    assert state.warrant_pressure.pressure_score > 0
+    assert "active_s4_pressure" in state.warrant_pressure.trigger_reasons
+
+
 def test_assess_action_uses_fourfold_gate_without_dispatch(tmp_path: Path) -> None:
     state_dir = _state(tmp_path)
     _write_zeitgeist(

--- a/tests/test_shakti_zeitgeist_executive.py
+++ b/tests/test_shakti_zeitgeist_executive.py
@@ -1,0 +1,149 @@
+"""Tests for the read-only ShaktiZeitgeistExecutive seam."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from dharma_swarm.fourfold_action_warrant import CapabilityInventory, EvidenceItem
+from dharma_swarm.models import GateDecision
+from dharma_swarm.shakti_zeitgeist_executive import (
+    DISPATCH_AUTHORITY,
+    ExecutiveCycleState,
+    ShaktiZeitgeistExecutive,
+)
+
+
+def _state(tmp_path: Path) -> Path:
+    state_dir = tmp_path / ".dharma"
+    (state_dir / "meta").mkdir(parents=True)
+    return state_dir
+
+
+def _write_zeitgeist(state_dir: Path, rows: list[dict[str, object]]) -> None:
+    path = state_dir / "meta" / "zeitgeist.jsonl"
+    with path.open("w", encoding="utf-8") as fh:
+        for row in rows:
+            payload = {
+                "id": row.get("id", "sig"),
+                "source": row.get("source", "local_scan"),
+                "category": row.get("category", "opportunity"),
+                "title": row.get("title", "Signal"),
+                "relevance_score": row.get("relevance_score", 0.5),
+                "keywords": row.get("keywords", []),
+                "description": row.get("description", ""),
+                "timestamp": row.get("timestamp", datetime.now(timezone.utc).isoformat()),
+            }
+            fh.write(json.dumps(payload) + "\n")
+
+
+def _evidence(count: int) -> list[EvidenceItem]:
+    categories = ["root", "code", "tests", "history", "tools"]
+    return [
+        EvidenceItem(path=f"/repo/evidence_{i}.md", category=categories[i % 5])
+        for i in range(count)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cycle_consumes_zeitgeist_and_emits_artifacts(tmp_path: Path) -> None:
+    state_dir = _state(tmp_path)
+    _write_zeitgeist(
+        state_dir,
+        [
+            {
+                "id": "zg-threat",
+                "category": "threat",
+                "title": "High gate block rate from S3",
+                "relevance_score": 0.9,
+                "keywords": ["gate", "witness"],
+            },
+            {
+                "id": "zg-tool",
+                "category": "tool_release",
+                "title": "Frontier agentic coding tool release",
+                "relevance_score": 0.8,
+                "keywords": ["tool", "agentic"],
+            },
+        ],
+    )
+
+    executive = ShaktiZeitgeistExecutive(state_dir=state_dir)
+    state = await executive.cycle()
+
+    assert isinstance(state, ExecutiveCycleState)
+    assert state.signals_ingested == 2
+    assert state.signals_by_source == {"zeitgeist": 2}
+    assert state.opportunities
+    assert state.warrant_pressure.required_for_next_action
+    assert state.dispatch_authority is False
+
+    meta = state_dir / "meta"
+    assert (meta / "shakti_zeitgeist_state.json").exists()
+    assert (meta / "s4_warrant_pressure.json").exists()
+    assert (meta / "s4_warrant_pressure.md").exists()
+    assert (meta / "executive_briefs").is_dir()
+    assert not (meta / "active_campaigns.json").exists()
+
+
+def test_assess_action_uses_fourfold_gate_without_dispatch(tmp_path: Path) -> None:
+    state_dir = _state(tmp_path)
+    _write_zeitgeist(
+        state_dir,
+        [
+            {
+                "id": "zg-threat",
+                "category": "threat",
+                "title": "Governance pressure in hooks",
+                "relevance_score": 0.95,
+                "keywords": ["governance", "hook"],
+            }
+        ],
+    )
+    paragraph = (
+        "This action is bounded to evidence production and read-only executive "
+        "pressure. It names the trigger, links the S4 signal to governance risk, "
+        "and leaves dispatch authority outside this seam."
+    )
+    executive = ShaktiZeitgeistExecutive(state_dir=state_dir)
+
+    warrant = executive.assess_action(
+        title="Wire governance pressure for operator review",
+        description="Writes code but does not dispatch.",
+        metadata={"writes_code": True, "governance_impact": True},
+        evidence=_evidence(5),
+        capabilities=CapabilityInventory(
+            skills=["mcp-synergy"],
+            mcp_tools=["filesystem.read_multiple_files"],
+            plugins=["GitHub"],
+            hooks=["pre-commit"],
+        ),
+        integrated_vision=paragraph,
+        connection_map=paragraph,
+        meaningful_action=paragraph,
+        min_evidence_files=5,
+    )
+
+    assert warrant.decision is GateDecision.ALLOW
+    assert warrant.zeitgeist_signal_ids
+    assert DISPATCH_AUTHORITY is False
+    assert not hasattr(executive, "dispatch")
+    assert not hasattr(executive, "route")
+    assert not hasattr(executive, "execute")
+
+
+def test_assess_action_blocks_without_evidence(tmp_path: Path) -> None:
+    executive = ShaktiZeitgeistExecutive(state_dir=_state(tmp_path))
+
+    warrant = executive.assess_action(
+        title="Enable autonomous dispatch",
+        metadata={"dispatch_authority": True},
+        min_evidence_files=3,
+    )
+
+    assert warrant.decision is GateDecision.BLOCK
+    assert "dispatch_authority" in warrant.trigger_reasons
+    assert any(blocker.startswith("evidence_files<3") for blocker in warrant.blockers)


### PR DESCRIPTION
## Summary

Adds Stage 2 as a bounded read-only S4 executive seam on top of the merged opt-in zeitgeist LLM intake.

New modules:

- `dharma_swarm/fourfold_action_warrant.py`
  - deterministic trigger predicate for high-authority actions
  - evidence manifest + capability inventory models
  - hard BLOCK/REVIEW/ALLOW evaluation
  - default hard evidence floor of 50 files for required warrants
- `dharma_swarm/shakti_zeitgeist_executive.py`
  - consumes persisted `ZeitgeistScanner` history
  - ranks S4 strategic pressure into opportunities
  - emits `shakti_zeitgeist_state.json`, `s4_warrant_pressure.json`, `s4_warrant_pressure.md`, and an executive brief
  - exposes `assess_action()` to produce a Fourfold Action Warrant

## Governance Boundary

This PR intentionally does **not** add dispatch authority.

- `DISPATCH_AUTHORITY = False`
- no `dispatch`, `route`, or `execute` methods
- no orchestrator queue mutation
- no dashboard/API changes
- no active campaign memory writes
- no LF5 wholesale import or `executive_substrates.py` dependency
- default state root derives from `runtime_state.DEFAULT_RUNTIME_DB`, avoiding direct new `~/.dharma` ownership

The executive is a governed consumer of S4 signals, not an action owner.

## Verification

```text
33 passed: tests/test_fourfold_action_warrant.py tests/test_shakti_zeitgeist_executive.py tests/test_zeitgeist.py
compileall passed for new modules/tests
git diff --check passed
pre-commit run --files new modules/tests passed
commit hooks passed
```

## Notes

Stage 1 sensing seam is already merged in PR #61 as squash commit `780603d`. This branch starts from that commit on `origin/main`.