### PR TITLE
fix(governance): remove command and eval semgrep sinks

### DIFF
--- a/dharma_swarm/build_engine.py
+++ b/dharma_swarm/build_engine.py
@@ -202,7 +202,12 @@ def _git_diff_files(project_path: str) -> list[str]:
             capture_output=True, text=True, cwd=project_path, timeout=30,
         )
         staged = result2.stdout.strip().splitlines() if result2.stdout.strip() else []
-        return list(set(unstaged + staged))
+        result3 = subprocess.run(
+            ["git", "ls-files", "--others", "--exclude-standard"],
+            capture_output=True, text=True, cwd=project_path, timeout=30,
+        )
+        untracked = result3.stdout.strip().splitlines() if result3.stdout.strip() else []
+        return sorted(set(unstaged + staged + untracked))
     except (subprocess.TimeoutExpired, OSError):
         return []
 
@@ -223,10 +228,13 @@ def _git_reset_hard(project_path: str) -> None:
 
 
 def _git_commit(project_path: str, message: str) -> bool:
-    """Stage all changes and commit. Returns True on success."""
+    """Stage explicit changed paths and commit. Returns True on success."""
     try:
+        changed_paths = _git_diff_files(project_path)
+        if not changed_paths:
+            return False
         subprocess.run(
-            ["git", "add", "-A"],
+            ["git", "add", "--", *changed_paths],
             capture_output=True, text=True, cwd=project_path, timeout=30,
         )
         result = subprocess.run(

--- a/dharma_swarm/citation_index.py
+++ b/dharma_swarm/citation_index.py
@@ -13,15 +13,50 @@ and ``stigmergy.py``.  All I/O is async via aiofiles.
 from __future__ import annotations
 
 import asyncio
+import ast
+import operator
 import json
 from datetime import datetime
 from pathlib import Path
-from typing import Literal, Optional
+from typing import Any, Literal, Optional
 
 import aiofiles
 from pydantic import BaseModel, Field
 
 from dharma_swarm.models import _new_id, _utc_now
+
+_SAFE_VERIFICATION_NAMES = {
+    "True": True,
+    "False": False,
+    "None": None,
+    "int": int,
+    "float": float,
+    "str": str,
+    "bool": bool,
+    "len": len,
+    "abs": abs,
+    "Path": Path,
+    "min": min,
+    "max": max,
+}
+
+_SAFE_BIN_OPS = {
+    ast.Add: operator.add,
+    ast.Sub: operator.sub,
+    ast.Mult: operator.mul,
+    ast.Div: operator.truediv,
+    ast.FloorDiv: operator.floordiv,
+    ast.Mod: operator.mod,
+}
+
+_SAFE_CMP_OPS = {
+    ast.Eq: operator.eq,
+    ast.NotEq: operator.ne,
+    ast.Lt: operator.lt,
+    ast.LtE: operator.le,
+    ast.Gt: operator.gt,
+    ast.GtE: operator.ge,
+}
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -59,6 +94,58 @@ class Citation(BaseModel):
     access_count: int = 0
     last_accessed: Optional[datetime] = None
     last_verified: Optional[datetime] = None
+
+
+def _eval_verification_expr(expr: str) -> Any:
+    """Evaluate the small expression subset allowed for citation checks."""
+
+    tree = ast.parse(expr, mode="eval")
+    return _eval_verification_node(tree.body)
+
+
+def _eval_verification_node(node: ast.AST) -> Any:
+    if isinstance(node, ast.Constant):
+        return node.value
+    if isinstance(node, ast.Name):
+        if node.id not in _SAFE_VERIFICATION_NAMES:
+            raise ValueError(f"name not allowed: {node.id}")
+        return _SAFE_VERIFICATION_NAMES[node.id]
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+        return -_eval_verification_node(node.operand)
+    if isinstance(node, ast.BinOp):
+        op = _SAFE_BIN_OPS.get(type(node.op))
+        if op is None:
+            raise ValueError(f"operator not allowed: {type(node.op).__name__}")
+        return op(_eval_verification_node(node.left), _eval_verification_node(node.right))
+    if isinstance(node, ast.BoolOp):
+        values = [_eval_verification_node(value) for value in node.values]
+        if isinstance(node.op, ast.And):
+            return all(values)
+        if isinstance(node.op, ast.Or):
+            return any(values)
+        raise ValueError(f"boolean operator not allowed: {type(node.op).__name__}")
+    if isinstance(node, ast.Compare):
+        left = _eval_verification_node(node.left)
+        for op_node, comparator in zip(node.ops, node.comparators):
+            op = _SAFE_CMP_OPS.get(type(op_node))
+            if op is None:
+                raise ValueError(f"comparison not allowed: {type(op_node).__name__}")
+            right = _eval_verification_node(comparator)
+            if not op(left, right):
+                return False
+            left = right
+        return True
+    if isinstance(node, ast.Call):
+        func = _eval_verification_node(node.func)
+        args = [_eval_verification_node(arg) for arg in node.args]
+        kwargs = {kw.arg: _eval_verification_node(kw.value) for kw in node.keywords if kw.arg}
+        return func(*args, **kwargs)
+    if isinstance(node, ast.Attribute):
+        value = _eval_verification_node(node.value)
+        if isinstance(value, Path) and node.attr == "exists":
+            return value.exists
+        raise ValueError(f"attribute not allowed: {node.attr}")
+    raise ValueError(f"expression not allowed: {type(node).__name__}")
 
 
 # ---------------------------------------------------------------------------
@@ -165,29 +252,18 @@ class CitationIndex:
     async def verify_all(self) -> dict[str, bool]:
         """Run verification tests for all citations that have them.
 
-        Each ``verification_test`` is a Python expression evaluated in
-        a namespace containing ``Path`` and ``os``.  Returns a mapping
-        of citation id to pass/fail.
+        Each ``verification_test`` is a small Python expression subset
+        evaluated without ``eval``.  Returns a mapping of citation id to
+        pass/fail.
         """
-        import os
-
         results: dict[str, bool] = {}
         for cid, citation in self._citations.items():
             if not citation.verification_test:
                 continue
             try:
-                # Safety: use compile+eval with restricted builtins instead of open eval
-                # Allows simple expressions (1+1==2, Path(...).exists()) but blocks
-                # os.system, __import__, exec, open, etc.
                 test_expr = citation.verification_test.strip()
-                _safe_builtins = {"True": True, "False": False, "None": None,
-                                  "int": int, "float": float, "str": str,
-                                  "bool": bool, "len": len, "abs": abs,
-                                  "Path": Path, "min": min, "max": max}
                 try:
-                    code = compile(test_expr, "<verification>", "eval")
-                    # Block any name not in safe_builtins
-                    passed = bool(eval(code, {"__builtins__": {}}, _safe_builtins))  # noqa: S307
+                    passed = bool(_eval_verification_expr(test_expr))
                 except Exception:
                     passed = False
             except Exception:

--- a/dharma_swarm/world_actions.py
+++ b/dharma_swarm/world_actions.py
@@ -64,6 +64,20 @@ def _run(cmd: list[str], cwd: Path | None = None, timeout: int = 60) -> tuple[in
     return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
 
 
+def _git_changed_paths(repo: Path) -> list[str]:
+    """Return explicit paths that need staging in a git repository."""
+    paths: set[str] = set()
+    for cmd in (
+        ["git", "diff", "--name-only"],
+        ["git", "diff", "--cached", "--name-only"],
+        ["git", "ls-files", "--others", "--exclude-standard"],
+    ):
+        code, out, _ = _run(cmd, cwd=repo, timeout=30)
+        if code == 0 and out:
+            paths.update(line for line in out.splitlines() if line)
+    return sorted(paths)
+
+
 def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
@@ -136,9 +150,11 @@ def github_commit_push(repo_dir: str, commit_message: str, branch: str | None = 
     if branch:
         _run(["git", "checkout", "-B", branch], cwd=repo, timeout=30)
 
-    code, out, err = _run(["git", "add", "-A"], cwd=repo, timeout=60)
-    if code != 0:
-        return WorldActionResult(False, "github_commit_push", err or out, path=str(repo))
+    changed_paths = _git_changed_paths(repo)
+    if changed_paths:
+        code, out, err = _run(["git", "add", "--", *changed_paths], cwd=repo, timeout=60)
+        if code != 0:
+            return WorldActionResult(False, "github_commit_push", err or out, path=str(repo))
 
     code, out, err = _run(["git", "commit", "-m", commit_message], cwd=repo, timeout=60)
     if code != 0 and "nothing to commit" not in (out + err).lower():

--- a/scripts/mimo_explorer.py
+++ b/scripts/mimo_explorer.py
@@ -21,6 +21,7 @@ if _root not in sys.path:
 import argparse
 import asyncio
 import os
+import shlex
 import subprocess
 import textwrap
 import time
@@ -100,9 +101,9 @@ PHASES: list[dict] = [
         ),
         "files": [],
         "run_commands": [
-            ("pytest smoke test", "python3 -m pytest tests/ -q --tb=line -x --timeout=10 2>&1 | tail -30"),
-            ("dgc status", "dgc status 2>&1 | head -60"),
-            ("dgc health", "dgc health 2>&1 | head -60"),
+            ("pytest smoke test", "python3 -m pytest tests/ -q --tb=line -x --timeout=10"),
+            ("dgc status", "dgc status"),
+            ("dgc health", "dgc health"),
         ],
     },
     {
@@ -141,9 +142,9 @@ PHASES: list[dict] = [
             "dharma_swarm/agent_registry.py",
         ],
         "run_commands": [
-            ("module count", "find dharma_swarm/dharma_swarm -name '*.py' | wc -l"),
-            ("test count", "find tests -name '*.py' | wc -l"),
-            ("LOC", "wc -l dharma_swarm/dharma_swarm/*.py 2>/dev/null | tail -1"),
+            ("module count", "repo-module-count"),
+            ("test count", "repo-test-count"),
+            ("LOC", "repo-module-loc"),
         ],
     },
 ]
@@ -168,14 +169,50 @@ def _read_file_excerpt(path: Path, max_chars: int = 8000) -> str:
         return f"[ERROR reading {path}: {e}]"
 
 
+def _trim_lines(text: str, *, first: int | None = None, last: int | None = None) -> str:
+    lines = text.splitlines()
+    if first is not None:
+        lines = lines[:first]
+    if last is not None:
+        lines = lines[-last:]
+    return "\n".join(lines)
+
+
+def _repo_metric(label: str, root: Path) -> str | None:
+    if label == "module count":
+        count = sum(1 for _ in (root / "dharma_swarm").rglob("*.py"))
+        return str(count)
+    if label == "test count":
+        count = sum(1 for _ in (root / "tests").rglob("*.py"))
+        return str(count)
+    if label == "LOC":
+        total = 0
+        for path in (root / "dharma_swarm").rglob("*.py"):
+            total += len(path.read_text(encoding="utf-8", errors="ignore").splitlines())
+        return str(total)
+    return None
+
+
 def _run_command(label: str, cmd: str) -> str:
-    """Run a shell command and return output."""
+    """Run a command without a shell and return output."""
+    root = Path.home() / "dharma_swarm"
+    metric = _repo_metric(label, root)
+    if metric is not None:
+        return f"$ {label}\n{metric}"
+
     try:
+        args = shlex.split(cmd)
+        if not args:
+            return f"$ {label}\n[ERROR: empty command]"
         result = subprocess.run(
-            cmd, shell=True, capture_output=True, text=True, timeout=60,
-            cwd=str(Path.home() / "dharma_swarm"),
+            args, capture_output=True, text=True, timeout=60,
+            cwd=str(root),
         )
         output = result.stdout + result.stderr
+        if label == "pytest smoke test":
+            output = _trim_lines(output, last=30)
+        elif label in {"dgc status", "dgc health"}:
+            output = _trim_lines(output, first=60)
         return f"$ {label}\n{output.strip()}"
     except Exception as e:
         return f"$ {label}\n[ERROR: {e}]"

--- a/scripts/validate_conscious_control_plane_spec.py
+++ b/scripts/validate_conscious_control_plane_spec.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import shlex
 import subprocess
 import sys
 from pathlib import Path
@@ -107,24 +108,41 @@ def _run_command_checks(data: dict) -> tuple[list[dict], bool]:
     all_ok = True
 
     for check in data["command_checks"]:
-        proc = subprocess.run(
-            check["command"],
-            cwd=REPO_ROOT,
-            shell=True,
-            capture_output=True,
-            text=True,
-        )
-        ok = proc.returncode == 0
+        command = str(check["command"])
+        try:
+            args = shlex.split(command)
+        except ValueError as exc:
+            args = []
+            parse_error = str(exc)
+        else:
+            parse_error = ""
+
+        if not args:
+            ok = False
+            returncode = 127
+            stdout = ""
+            stderr = parse_error or "empty command"
+        else:
+            proc = subprocess.run(
+                args,
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+            )
+            ok = proc.returncode == 0
+            returncode = proc.returncode
+            stdout = proc.stdout
+            stderr = proc.stderr
         results.append(
             {
                 "id": check["id"],
                 "type": "command",
-                "command": check["command"],
+                "command": command,
                 "ok": ok,
                 "description": check["description"],
-                "returncode": proc.returncode,
-                "stdout_tail": proc.stdout[-400:],
-                "stderr_tail": proc.stderr[-400:],
+                "returncode": returncode,
+                "stdout_tail": stdout[-400:],
+                "stderr_tail": stderr[-400:],
             }
         )
         all_ok &= ok

--- a/tests/test_citation_index.py
+++ b/tests/test_citation_index.py
@@ -208,6 +208,12 @@ class TestVerification:
         results = await index.verify_all()
         assert results[c.id] is False
 
+    async def test_verify_blocks_import_calls(self, index: CitationIndex) -> None:
+        c = _make_citation(verification_test="__import__('os').system('true') == 0")
+        await index.add(c)
+        results = await index.verify_all()
+        assert results[c.id] is False
+
     async def test_verify_skips_citations_without_test(self, index: CitationIndex) -> None:
         c = _make_citation(verification_test=None)
         await index.add(c)


### PR DESCRIPTION
## Summary
- Replace citation verification `eval` with a restricted AST evaluator and add a regression test for blocked import calls.
- Replace `git add -A` usage in autonomous commit helpers with explicit changed-path staging.
- Remove `shell=True` from MiMo/control-plane command runners while preserving output trimming in Python.

## Verification
- `python3 -m py_compile dharma_swarm/citation_index.py dharma_swarm/build_engine.py dharma_swarm/world_actions.py scripts/mimo_explorer.py scripts/validate_conscious_control_plane_spec.py tests/test_citation_index.py`
- `/Users/dhyana/dharma_swarm/.venv/bin/python -m pytest -q tests/test_citation_index.py tests/test_build_engine.py::TestGitSafety::test_diff_files_clean tests/test_build_engine.py::TestGitSafety::test_diff_files_dirty tests/test_build_engine.py::TestGitSafety::test_reset_hard` -> 35 passed
- `DHARMA_PYTHON=/Users/dhyana/dharma_swarm/.venv/bin/python pre-commit run --files ...` -> passed
- `scripts/governance/run_semgrep_with_ca.sh --config .semgrep --json --metrics=off --output /tmp/dharma_semgrep_sinks.json` -> 116 findings remain: 112 state ownership, 4 provider canonical
- `/Users/dhyana/dharma_swarm/.venv/bin/python -m pytest tests/ --collect-only -q` -> 9059 collected
- `/Users/dhyana/dharma_swarm/.venv/bin/python scripts/governance/check_module_budget.py --base-ref origin/main --head-ref HEAD` -> OK

## Scope
No dashboard/API/Interop, memory, ontology, provider routing, `dharma_kernel.py`, or `telos_gates.py` changes.