### PR TITLE
feat(governance): enforce fourfold warrant opt-in gate

### DIFF
--- a/dharma_swarm/policy_compiler.py
+++ b/dharma_swarm/policy_compiler.py
@@ -12,10 +12,17 @@ v2: Three-tier evaluation replaces naive keyword matching:
 
 from __future__ import annotations
 
+import json
+import os
 from typing import Any, Literal, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 
+from dharma_swarm.fourfold_action_warrant import (
+    FourfoldActionWarrant,
+    trigger_reasons_for_action,
+)
+from dharma_swarm.models import GateDecision
 from dharma_swarm.models import _utc_now
 from dharma_swarm.structured_predicate import (
     CompoundPredicate,
@@ -44,6 +51,10 @@ _SEVERITY_TO_ENFORCEMENT: dict[str, EnforcementLevel] = {
 # database now"), so 0.7 is the correct block boundary for this embedding.
 _SIMILARITY_BLOCK_THRESHOLD = 0.7
 _SIMILARITY_WARN_THRESHOLD = 0.45
+FOURFOLD_ACTION_WARRANT_GATE_ENV = "DHARMA_FOURFOLD_ACTION_WARRANT_GATE"
+FOURFOLD_ACTION_WARRANT_METADATA_KEY = "fourfold_action_warrant"
+FOURFOLD_ACTION_WARRANT_LEGACY_METADATA_KEY = "fourfold_warrant"
+FOURFOLD_ACTION_WARRANT_RULE_SOURCE = "kernel:fourfold_action_warrant"
 
 
 class PolicyRule(BaseModel):
@@ -87,6 +98,8 @@ class Policy(BaseModel):
         action: str,
         context: str = "",
         action_metadata: dict[str, Any] | None = None,
+        *,
+        enforce_fourfold_warrant: bool | None = None,
     ) -> PolicyDecision:
         """Evaluate an action against all policy rules using three-tier matching.
 
@@ -112,11 +125,24 @@ class Policy(BaseModel):
             context: Optional free-text context for the action.
             action_metadata: Optional dict of structured metadata for Tier 1
                 evaluation (e.g. {"evaluator_count": 1, "action_type": "destructive"}).
+            enforce_fourfold_warrant: Optional explicit override for the
+                Fourfold Action Warrant runtime gate. If omitted, the
+                ``DHARMA_FOURFOLD_ACTION_WARRANT_GATE`` environment flag
+                controls enforcement.
 
         Returns:
             PolicyDecision with allowed flag, violated rules, warnings, and reason.
         """
         metadata = action_metadata or {}
+        warrant_decision = _check_fourfold_action_warrant_gate(
+            action,
+            context,
+            metadata,
+            enforce=enforce_fourfold_warrant,
+        )
+        if warrant_decision is not None:
+            return warrant_decision
+
         combined = (action + " " + context).lower()
         violated: list[PolicyRule] = []
         warned: list[PolicyRule] = []
@@ -289,3 +315,100 @@ def _extract_compound_predicate(obj: Any) -> CompoundPredicate | None:
         except Exception:
             return None
     return None
+
+
+def fourfold_action_warrant_gate_enabled() -> bool:
+    """Whether the opt-in Fourfold Action Warrant runtime gate is active."""
+
+    value = os.getenv(FOURFOLD_ACTION_WARRANT_GATE_ENV, "")
+    return value.strip().lower() in {"1", "true", "yes", "on", "enforce", "block"}
+
+
+def _check_fourfold_action_warrant_gate(
+    action: str,
+    context: str,
+    metadata: dict[str, Any],
+    *,
+    enforce: bool | None,
+) -> PolicyDecision | None:
+    if enforce is None:
+        enforce = fourfold_action_warrant_gate_enabled()
+    if not enforce:
+        return None
+
+    trigger_reasons = trigger_reasons_for_action(action, context, metadata)
+    if not trigger_reasons:
+        return None
+
+    warrant, load_error = _load_fourfold_action_warrant(metadata)
+    if warrant is None:
+        return _fourfold_action_warrant_block(
+            trigger_reasons,
+            load_error or "missing_fourfold_action_warrant",
+        )
+
+    if not warrant.required:
+        return _fourfold_action_warrant_block(
+            trigger_reasons,
+            "stale_or_irrelevant_fourfold_action_warrant",
+        )
+
+    missing_reasons = sorted(set(trigger_reasons) - set(warrant.trigger_reasons))
+    if missing_reasons:
+        return _fourfold_action_warrant_block(
+            trigger_reasons,
+            "warrant_missing_trigger_reasons:" + ",".join(missing_reasons),
+        )
+
+    if warrant.decision is GateDecision.ALLOW:
+        return None
+
+    reason = f"fourfold_action_warrant_{warrant.decision.value}"
+    if warrant.blockers:
+        reason += ": " + ",".join(warrant.blockers)
+    return _fourfold_action_warrant_block(trigger_reasons, reason)
+
+
+def _load_fourfold_action_warrant(
+    metadata: dict[str, Any],
+) -> tuple[FourfoldActionWarrant | None, str | None]:
+    for key in (
+        FOURFOLD_ACTION_WARRANT_METADATA_KEY,
+        FOURFOLD_ACTION_WARRANT_LEGACY_METADATA_KEY,
+    ):
+        if key not in metadata:
+            continue
+        raw = metadata[key]
+        if isinstance(raw, FourfoldActionWarrant):
+            return raw, None
+        if isinstance(raw, str):
+            try:
+                raw = json.loads(raw)
+            except json.JSONDecodeError:
+                return None, "invalid_fourfold_action_warrant_json"
+        try:
+            return FourfoldActionWarrant.model_validate(raw), None
+        except (TypeError, ValidationError, ValueError):
+            return None, "invalid_fourfold_action_warrant"
+    return None, "missing_fourfold_action_warrant"
+
+
+def _fourfold_action_warrant_block(
+    trigger_reasons: list[str],
+    detail: str,
+) -> PolicyDecision:
+    rule = PolicyRule(
+        source=FOURFOLD_ACTION_WARRANT_RULE_SOURCE,
+        rule_text="high-authority actions require an allowing Fourfold Action Warrant",
+        weight=1.0,
+        is_immutable=True,
+        enforcement_level="block",
+    )
+    return PolicyDecision(
+        allowed=False,
+        violated_rules=[rule],
+        reason=(
+            "fourfold action warrant gate: "
+            f"{detail}; triggers={','.join(trigger_reasons)}"
+        ),
+    )

--- a/tests/test_policy_compiler_fourfold_warrant.py
+++ b/tests/test_policy_compiler_fourfold_warrant.py
@@ -1,0 +1,151 @@
+"""PolicyCompiler integration for the Fourfold Action Warrant runtime gate."""
+
+from __future__ import annotations
+
+from dharma_swarm.fourfold_action_warrant import (
+    ActionWarrantRequest,
+    CapabilityInventory,
+    EvidenceItem,
+    build_fourfold_action_warrant,
+)
+from dharma_swarm.models import GateDecision
+from dharma_swarm.policy_compiler import (
+    FOURFOLD_ACTION_WARRANT_GATE_ENV,
+    FOURFOLD_ACTION_WARRANT_METADATA_KEY,
+    FOURFOLD_ACTION_WARRANT_RULE_SOURCE,
+    Policy,
+)
+
+
+def _evidence(count: int = 50) -> list[EvidenceItem]:
+    categories = ["root", "code", "tests", "history", "tools"]
+    return [
+        EvidenceItem(
+            path=f"/repo/context_{idx}.py",
+            category=categories[idx % len(categories)],
+            theme="policy compiler runtime gate",
+            why="prove the agent read enough surfaces before action",
+        )
+        for idx in range(count)
+    ]
+
+
+def _capabilities() -> CapabilityInventory:
+    return CapabilityInventory(
+        skills=["mcp-synergy", "gitnexus-exploring"],
+        mcp_tools=["contextplus.semantic_code_search", "github.pull_request"],
+        plugins=["GitHub"],
+        hooks=["pre-commit"],
+    )
+
+
+def _paragraph(subject: str) -> str:
+    return (
+        f"{subject} is bounded as a policy-compiler runtime change: it links "
+        "the action metadata contract to an explicit warrant without granting "
+        "autonomous dispatch or changing default behavior for ordinary actions."
+    )
+
+
+def _allowing_warrant() -> dict[str, object]:
+    request = ActionWarrantRequest(
+        title="Merge governance policy into main",
+        description="This changes a policy gate for significant repo actions.",
+        metadata={"is_significant_action": True, "governance_impact": True},
+        evidence=_evidence(),
+        capabilities=_capabilities(),
+        zeitgeist_signal_ids=["sig-policy-1"],
+        integrated_vision=_paragraph("Vision"),
+        connection_map=_paragraph("Connection"),
+        meaningful_action=_paragraph("Action"),
+    )
+    warrant = build_fourfold_action_warrant(request)
+    assert warrant.decision is GateDecision.ALLOW
+    return warrant.model_dump(mode="json")
+
+
+def test_fourfold_gate_disabled_by_default() -> None:
+    policy = Policy()
+
+    decision = policy.check_action(
+        "Merge governance policy into main",
+        action_metadata={"is_significant_action": True, "governance_impact": True},
+    )
+
+    assert decision.allowed is True
+    assert decision.violated_rules == []
+
+
+def test_fourfold_gate_blocks_missing_warrant_when_enabled() -> None:
+    policy = Policy()
+
+    decision = policy.check_action(
+        "Merge governance policy into main",
+        action_metadata={"is_significant_action": True, "governance_impact": True},
+        enforce_fourfold_warrant=True,
+    )
+
+    assert decision.allowed is False
+    assert decision.violated_rules[0].source == FOURFOLD_ACTION_WARRANT_RULE_SOURCE
+    assert "missing_fourfold_action_warrant" in decision.reason
+    assert "significant_action" in decision.reason
+
+
+def test_fourfold_gate_blocks_non_allowing_warrant() -> None:
+    policy = Policy()
+    request = ActionWarrantRequest(
+        title="Merge governance policy into main",
+        description="This changes a policy gate for significant repo actions.",
+        metadata={"is_significant_action": True, "governance_impact": True},
+        evidence=_evidence(2),
+        capabilities=_capabilities(),
+        integrated_vision="short",
+        connection_map="short",
+        meaningful_action="short",
+    )
+    blocked = build_fourfold_action_warrant(request)
+    assert blocked.decision is GateDecision.BLOCK
+
+    decision = policy.check_action(
+        "Merge governance policy into main",
+        action_metadata={
+            "is_significant_action": True,
+            "governance_impact": True,
+            FOURFOLD_ACTION_WARRANT_METADATA_KEY: blocked.model_dump(mode="json"),
+        },
+        enforce_fourfold_warrant=True,
+    )
+
+    assert decision.allowed is False
+    assert "fourfold_action_warrant_block" in decision.reason
+    assert "evidence_files<50" in decision.reason
+
+
+def test_fourfold_gate_allows_complete_warrant() -> None:
+    policy = Policy()
+
+    decision = policy.check_action(
+        "Merge governance policy into main",
+        action_metadata={
+            "is_significant_action": True,
+            "governance_impact": True,
+            FOURFOLD_ACTION_WARRANT_METADATA_KEY: _allowing_warrant(),
+        },
+        enforce_fourfold_warrant=True,
+    )
+
+    assert decision.allowed is True
+    assert decision.violated_rules == []
+
+
+def test_fourfold_gate_can_be_enabled_by_environment(monkeypatch) -> None:
+    policy = Policy()
+    monkeypatch.setenv(FOURFOLD_ACTION_WARRANT_GATE_ENV, "1")
+
+    decision = policy.check_action(
+        "Merge governance policy into main",
+        action_metadata={"is_significant_action": True},
+    )
+
+    assert decision.allowed is False
+    assert "fourfold action warrant gate" in decision.reason


### PR DESCRIPTION
## Summary
- Add an opt-in Fourfold Action Warrant enforcement path to `Policy.check_action`.
- Block high-authority actions when the gate is enabled and metadata has no allowing warrant.
- Cover default-off behavior, explicit enforcement, env enforcement, blocked warrants, and allowing warrants.

## Verification
- `/Users/dhyana/dharma_swarm/.venv/bin/python -m pytest -q tests/test_policy_compiler_fourfold_warrant.py tests/test_policy_compiler.py tests/test_policy_compiler_v2.py tests/test_fourfold_action_warrant.py`
- `/Users/dhyana/dharma_swarm/.venv/bin/python -m pytest -q tests/test_shakti_zeitgeist_executive.py tests/test_zeitgeist.py`
- `python3 -m compileall dharma_swarm/policy_compiler.py tests/test_policy_compiler_fourfold_warrant.py`
- `git diff --check`
- `pre-commit run --files dharma_swarm/policy_compiler.py tests/test_policy_compiler_fourfold_warrant.py`