### PR TITLE
test(governance): align quiet hours contract

### DIFF
--- a/tests/test_daemon_config.py
+++ b/tests/test_daemon_config.py
@@ -59,7 +59,7 @@ def test_daemon_config_defaults():
     assert cfg.crown_jewel_threshold == 0.85
     assert len(cfg.threads) == 5
     assert cfg.rotation_mode == "sequential"
-    assert 2 in cfg.quiet_hours
+    assert cfg.quiet_hours == []
 
 
 def test_thread_prompts_complete():

--- a/tests/test_pulse_adaptive.py
+++ b/tests/test_pulse_adaptive.py
@@ -28,6 +28,15 @@ def test_adaptive_quiet_hours_returns_static_floor_when_no_activity(
     assert quiet == [2, 3, 4, 5]
 
 
+def test_adaptive_quiet_hours_defaults_to_no_static_floor(
+    tmp_path: Path,
+) -> None:
+    """By default the swarm runs 24/7 with no quiet-hour floor."""
+    state_dir = tmp_path / ".dharma"
+    aqh = AdaptiveQuietHours(state_dir=state_dir)
+    assert aqh.compute_quiet_hours() == []
+
+
 def test_adaptive_quiet_hours_includes_active_work_hours(
     tmp_path: Path,
 ) -> None:
@@ -99,5 +108,4 @@ def test_adaptive_quiet_hours_update_config_mutates_in_place(
     # config.quiet_hours is now adaptive — includes both static floor and hour 9
     assert 9 in config.quiet_hours
     assert all(h in config.quiet_hours for h in [2, 3, 4, 5])
-    # It changed from the original (which only had [2,3,4,5] without hour 9)
-    assert config.quiet_hours != original_quiet or 9 in original_quiet
+    assert config.quiet_hours != original_quiet


### PR DESCRIPTION
## Summary
- reclassifies the stale DaemonConfig quiet-hours test to match the intentional 24/7 runtime contract from `f8b073c`
- adds an explicit AdaptiveQuietHours regression test showing the default has no static quiet-hour floor
- leaves runtime behavior unchanged

## Verification
- `/Users/dhyana/dharma_swarm/.venv/bin/python -m pytest -q tests/test_daemon_config.py tests/test_pulse_adaptive.py` => 21 passed
- `DHARMA_PYTHON=/Users/dhyana/dharma_swarm/.venv/bin/python pre-commit run --files tests/test_daemon_config.py tests/test_pulse_adaptive.py` => passed
- `/Users/dhyana/dharma_swarm/.venv/bin/python -m pytest tests/ --collect-only -q` => 9065 tests collected
- `scripts/governance/run_semgrep_with_ca.sh --config .semgrep --json --metrics=off` => 0 findings
- `git diff --check` => passed
- module budget => OK, no target Python files changed