### PR TITLE
[superseded] [codex] enforce staged fourfold shakti warrant

### DIFF
--- a/dharma_swarm/shakti_warrant.py
+++ b/dharma_swarm/shakti_warrant.py
@@ -1,0 +1,635 @@
+"""Fourfold Shakti warrant evaluation for significant actions.
+
+This module is deliberately read-only. It turns the existing Shakti doctrine
+into a deterministic review artifact without creating another governance store.
+"""
+
+from __future__ import annotations
+
+import re
+from enum import Enum
+from typing import Any, Sequence
+
+from pydantic import BaseModel, Field
+
+from dharma_swarm.dharma_corpus import Claim
+from dharma_swarm.models import _new_id, _utc_now
+from dharma_swarm.semantic_governance import (
+    ActionEnvelope,
+    GovernanceVerdict,
+    SemanticGovernanceKernel,
+)
+from dharma_swarm.shakti import ShaktiEnergy
+
+
+class WarrantVerdict(str, Enum):
+    """Read-only action warrant verdict."""
+
+    ALLOW = "allow"
+    WARN = "warn"
+    HOLD = "hold"
+    BLOCK = "block"
+
+
+class ShaktiDimensionScore(BaseModel):
+    """Score for one Shakti question."""
+
+    energy: ShaktiEnergy
+    question: str
+    score: float
+    passed: bool
+    matched_terms: list[str] = Field(default_factory=list)
+    rationale: str = ""
+
+
+class WarrantEvidence(BaseModel):
+    """Evidence grounding a warrant in something outside intent text."""
+
+    source: str
+    kind: str
+    summary: str
+    paths: list[str] = Field(default_factory=list)
+    confidence: float = 1.0
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class FourfoldActionWarrantRequest(BaseModel):
+    """Input used to evaluate a proposed significant action."""
+
+    action_id: str = Field(default_factory=_new_id)
+    actor_id: str = "unknown"
+    actor_type: str = "agent"
+    runtime_type: str = "local"
+    action_type: str = "proposed_action"
+    intent: str
+    content: str = ""
+    target_paths: list[str] = Field(default_factory=list)
+    requested_tools: list[str] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    evidence: list[WarrantEvidence] = Field(default_factory=list)
+    provenance: list[str] = Field(default_factory=list)
+
+
+class FourfoldActionWarrant(BaseModel):
+    """Computed Shakti warrant for an action."""
+
+    warrant_id: str = Field(default_factory=_new_id)
+    action_id: str
+    actor_id: str
+    action_type: str
+    target_paths: list[str]
+    verdict: WarrantVerdict
+    score: float
+    pass_count: int
+    required_pass_count: int = 2
+    dimensions: list[ShaktiDimensionScore]
+    semantic_verdict: GovernanceVerdict | None = None
+    evidence: list[WarrantEvidence] = Field(default_factory=list)
+    ontology_refs: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+    rationale: str
+    provenance: list[str] = Field(default_factory=list)
+    created_at: str = Field(default_factory=lambda: _utc_now().isoformat())
+
+
+_QUESTIONS: dict[ShaktiEnergy, str] = {
+    ShaktiEnergy.MAHESHWARI: "Does this serve the larger pattern, telos, and emergence?",
+    ShaktiEnergy.MAHAKALI: "Is this the right moment and force level?",
+    ShaktiEnergy.MAHALAKSHMI: "Does this create harmony rather than noise?",
+    ShaktiEnergy.MAHASARASWATI: "Is every detail precise, evidenced, and verified?",
+}
+
+_KEYWORDS: dict[ShaktiEnergy, frozenset[str]] = {
+    ShaktiEnergy.MAHESHWARI: frozenset(
+        {
+            "architecture",
+            "canonical",
+            "doctrine",
+            "emergence",
+            "governance",
+            "jagat",
+            "kalyan",
+            "larger",
+            "manifest",
+            "mission",
+            "pattern",
+            "purpose",
+            "semantic",
+            "system",
+            "telos",
+            "vision",
+            "warrant",
+        }
+    ),
+    ShaktiEnergy.MAHAKALI: frozenset(
+        {
+            "block",
+            "crash",
+            "decisive",
+            "enforce",
+            "execute",
+            "fail",
+            "fix",
+            "force",
+            "guard",
+            "hold",
+            "restore",
+            "urgent",
+            "unblock",
+        }
+    ),
+    ShaktiEnergy.MAHALAKSHMI: frozenset(
+        {
+            "align",
+            "bridge",
+            "cohere",
+            "coherence",
+            "consolidate",
+            "harmonize",
+            "integrate",
+            "reduce",
+            "reuse",
+            "single",
+            "source",
+            "truth",
+            "unify",
+        }
+    ),
+    ShaktiEnergy.MAHASARASWATI: frozenset(
+        {
+            "deterministic",
+            "evidence",
+            "exact",
+            "idempotent",
+            "line",
+            "path",
+            "pre-commit",
+            "pytest",
+            "reference",
+            "test",
+            "typed",
+            "verify",
+        }
+    ),
+}
+
+_BLOCK_PATTERNS = (
+    re.compile(r"\brm\s+-rf\b", re.IGNORECASE),
+    re.compile(r"\bdelete\s+(production|prod)\b", re.IGNORECASE),
+    re.compile(r"\bdrop\s+database\b", re.IGNORECASE),
+    re.compile(r"\bforce\s+push\b", re.IGNORECASE),
+)
+
+_HOT_PATHS = frozenset(
+    {
+        ".pre-commit-config.yaml",
+        "api/main.py",
+        "api/routers/chat.py",
+        "api/ws.py",
+        "dharma_swarm/agent_runner.py",
+        "dharma_swarm/dgc_cli.py",
+        "dharma_swarm/orchestrator.py",
+        "dharma_swarm/runtime_state.py",
+        "dharma_swarm/swarm.py",
+        "dharma_swarm/telic_seam.py",
+    }
+)
+
+_SOURCE_EXTENSIONS = (".py", ".ts", ".tsx", ".js", ".jsx", ".rs", ".sh")
+_DOC_EXTENSIONS = (".md", ".rst", ".txt")
+_CONFIG_EXTENSIONS = (".yaml", ".yml", ".toml", ".json")
+
+
+def _normalize_path(path: str) -> str:
+    normalized = path.strip().replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized
+
+
+def _tokenize(text: str) -> set[str]:
+    return set(re.findall(r"[a-zA-Z0-9_.-]+", text.lower()))
+
+
+def _request_text(request: FourfoldActionWarrantRequest) -> str:
+    pieces = [
+        request.intent,
+        request.content,
+        " ".join(request.target_paths),
+        " ".join(request.requested_tools),
+    ]
+    for key, value in sorted(request.metadata.items()):
+        if isinstance(value, (str, int, float, bool)):
+            pieces.append(f"{key}:{value}")
+    for evidence in request.evidence:
+        pieces.append(evidence.summary)
+        pieces.append(" ".join(evidence.paths))
+    return " ".join(piece for piece in pieces if piece).strip()
+
+
+def _all_paths(request: FourfoldActionWarrantRequest) -> list[str]:
+    paths = list(request.target_paths)
+    for evidence in request.evidence:
+        paths.extend(evidence.paths)
+    return sorted(set(path for path in (_normalize_path(path) for path in paths) if path))
+
+
+def _has_diff_evidence(request: FourfoldActionWarrantRequest) -> bool:
+    return bool(
+        request.metadata.get("diff_bound") is True
+        or any(e.kind == "git_diff" for e in request.evidence)
+    )
+
+
+def _path_stats(paths: Sequence[str]) -> dict[str, int]:
+    source = 0
+    tests = 0
+    docs = 0
+    config = 0
+    governance = 0
+    hot = 0
+    for path in paths:
+        normalized = _normalize_path(path)
+        lower = normalized.lower()
+        if normalized in _HOT_PATHS:
+            hot += 1
+        if lower.startswith("tests/") or "/test_" in lower or lower.endswith("_test.py"):
+            tests += 1
+        if lower.startswith("docs/") or lower.endswith(_DOC_EXTENSIONS):
+            docs += 1
+        if lower.endswith(_CONFIG_EXTENSIONS):
+            config += 1
+        if lower.startswith("scripts/governance/") or lower.startswith("docs/governance/"):
+            governance += 1
+        if lower.endswith(_SOURCE_EXTENSIONS):
+            source += 1
+    return {
+        "changed_files": len(set(paths)),
+        "source_files": source,
+        "test_files": tests,
+        "doc_files": docs,
+        "config_files": config,
+        "governance_files": governance,
+        "hot_paths": hot,
+    }
+
+
+def _boosts_for_energy(
+    energy: ShaktiEnergy,
+    request: FourfoldActionWarrantRequest,
+) -> tuple[float, list[str]]:
+    boosts: list[str] = []
+    score = 0.0
+    metadata = request.metadata
+    target_paths = _all_paths(request)
+
+    if energy == ShaktiEnergy.MAHESHWARI:
+        if metadata.get("telos_aligned") is True:
+            score += 0.20
+            boosts.append("metadata:telos_aligned")
+        if any(path.endswith((".md", ".yaml", ".yml")) for path in target_paths):
+            score += 0.08
+            boosts.append("meta_or_manifest_path")
+        if _path_stats(_all_paths(request))["governance_files"]:
+            score += 0.10
+            boosts.append("governance_paths")
+
+    if energy == ShaktiEnergy.MAHAKALI:
+        if metadata.get("urgent") is True or metadata.get("fixes_blocker") is True:
+            score += 0.18
+            boosts.append("metadata:urgent_or_blocker")
+        if request.requested_tools and not _unauthorized_tools(request):
+            if _allowed_tool_names(metadata):
+                score += 0.12
+                boosts.append("authorized_tools")
+            else:
+                score += 0.02
+                boosts.append("requested_tools_unverified")
+        if metadata.get("impact_checked") is True:
+            score += 0.12
+            boosts.append("metadata:impact_checked")
+
+    if energy == ShaktiEnergy.MAHALAKSHMI:
+        if metadata.get("no_new_substrate") is True:
+            score += 0.20
+            boosts.append("metadata:no_new_substrate")
+        if metadata.get("reduces_fragmentation") is True:
+            score += 0.15
+            boosts.append("metadata:reduces_fragmentation")
+        stats = _path_stats(_all_paths(request))
+        if _has_diff_evidence(request) and 0 < stats["changed_files"] <= 8:
+            score += 0.08
+            boosts.append("bounded_diff")
+        if stats["governance_files"] and stats["doc_files"]:
+            score += 0.05
+            boosts.append("governance_doc_pair")
+
+    if energy == ShaktiEnergy.MAHASARASWATI:
+        if metadata.get("tests_planned") is True or metadata.get("tests_passed") is True:
+            score += 0.20
+            boosts.append("metadata:tests")
+        if target_paths:
+            score += 0.10
+            boosts.append("target_paths")
+        if any(item.startswith("test") or "pytest" in item for item in request.requested_tools):
+            score += 0.10
+            boosts.append("test_tool")
+        stats = _path_stats(_all_paths(request))
+        if _has_diff_evidence(request):
+            score += 0.15
+            boosts.append("git_diff_evidence")
+        if stats["test_files"]:
+            score += 0.10
+            boosts.append("test_paths")
+
+    return score, boosts
+
+
+def _score_dimension(
+    energy: ShaktiEnergy,
+    request: FourfoldActionWarrantRequest,
+    *,
+    pass_threshold: float,
+) -> ShaktiDimensionScore:
+    text = _request_text(request)
+    tokens = _tokenize(text)
+    keywords = _KEYWORDS[energy]
+    matched = sorted(token for token in tokens if token in keywords)
+    keyword_score = min(len(matched) / 4.0, 0.70)
+    boost, boosts = _boosts_for_energy(energy, request)
+    score = min(keyword_score + boost, 1.0)
+    passed = score >= pass_threshold
+    rationale_parts = []
+    if matched:
+        rationale_parts.append("matched " + ", ".join(matched[:6]))
+    if boosts:
+        rationale_parts.append("boosted by " + ", ".join(boosts))
+    if not rationale_parts:
+        rationale_parts.append("no strong evidence for this Shakti question")
+    return ShaktiDimensionScore(
+        energy=energy,
+        question=_QUESTIONS[energy],
+        score=round(score, 3),
+        passed=passed,
+        matched_terms=matched + boosts,
+        rationale="; ".join(rationale_parts),
+    )
+
+
+def _explicit_block_reasons(request: FourfoldActionWarrantRequest) -> list[str]:
+    reasons: list[str] = []
+    text = _request_text(request)
+    if request.metadata.get("destructive_without_consent") is True:
+        reasons.append("destructive action without consent")
+    if request.metadata.get("oversight_active") is False:
+        reasons.append("human oversight channel inactive")
+    for pattern in _BLOCK_PATTERNS:
+        if pattern.search(text):
+            reasons.append(f"matched unsafe pattern: {pattern.pattern}")
+    unauthorized = _unauthorized_tools(request)
+    if unauthorized and request.metadata.get("enforce_tool_allowlist") is True:
+        reasons.append("unauthorized requested tools: " + ", ".join(unauthorized))
+    hot_paths = _hot_paths(request)
+    if (
+        hot_paths
+        and request.metadata.get("enforce_hotpath_ack") is True
+        and request.metadata.get("impact_checked") is not True
+    ):
+        reasons.append("hot-path changes lack impact_checked: " + ", ".join(hot_paths))
+    return reasons
+
+
+def _tool_name(tool: str) -> str:
+    token = tool.strip().split(maxsplit=1)[0] if tool.strip() else ""
+    return token.rsplit("/", 1)[-1].lower()
+
+
+def _allowed_tool_names(metadata: dict[str, Any]) -> set[str]:
+    raw = metadata.get("allowed_tools", metadata.get("tool_allowlist"))
+    if raw is None:
+        return set()
+    if isinstance(raw, str):
+        pieces = [piece.strip() for piece in raw.split(",")]
+    elif isinstance(raw, (list, tuple, set)):
+        pieces = [str(piece).strip() for piece in raw]
+    else:
+        pieces = [str(raw).strip()]
+    return {_tool_name(piece) for piece in pieces if piece}
+
+
+def _unauthorized_tools(request: FourfoldActionWarrantRequest) -> list[str]:
+    allowed = _allowed_tool_names(request.metadata)
+    if not allowed:
+        return []
+    unauthorized = []
+    for tool in request.requested_tools:
+        name = _tool_name(tool)
+        if name and name not in allowed:
+            unauthorized.append(name)
+    return sorted(set(unauthorized))
+
+
+def _hot_paths(request: FourfoldActionWarrantRequest) -> list[str]:
+    return sorted(path for path in _all_paths(request) if path in _HOT_PATHS)
+
+
+def _evidence_warnings(request: FourfoldActionWarrantRequest) -> list[str]:
+    warnings: list[str] = []
+    paths = _all_paths(request)
+    stats = _path_stats(paths)
+    hot_paths = _hot_paths(request)
+
+    if request.metadata.get("requires_diff_evidence") is True and not _has_diff_evidence(request):
+        warnings.append("warrant requires git diff evidence but none was provided")
+    if _has_diff_evidence(request) and not paths:
+        warnings.append("diff-bound warrant did not provide changed paths")
+    if stats["source_files"] and not stats["test_files"] and not (
+        request.metadata.get("tests_planned") is True
+        or request.metadata.get("tests_passed") is True
+    ):
+        warnings.append("source changes lack test paths or test metadata")
+    if (
+        stats["doc_files"]
+        and not stats["source_files"]
+        and request.metadata.get("fixes_blocker") is True
+    ):
+        warnings.append(
+            "doc-only diff claims fixes_blocker; verify there is an executable fix elsewhere"
+        )
+    if hot_paths and request.metadata.get("impact_checked") is not True:
+        warnings.append("hot-path changes lack impact_checked: " + ", ".join(hot_paths))
+    if stats["changed_files"] > 12 and request.metadata.get("large_diff_ack") is not True:
+        warnings.append(f"large diff touches {stats['changed_files']} files without large_diff_ack")
+    return warnings
+
+
+def _extract_ontology_refs(request: FourfoldActionWarrantRequest) -> list[str]:
+    refs: set[str] = set()
+    for item in [*request.provenance, *_all_paths(request), request.content, request.intent]:
+        for ref in re.findall(r"ontology://[^\s,)]+", item):
+            refs.add(ref.rstrip(".,"))
+    return sorted(refs)
+
+
+def _semantic_verdict_for(
+    request: FourfoldActionWarrantRequest,
+    claims: Sequence[Claim],
+    kernel: SemanticGovernanceKernel,
+) -> GovernanceVerdict:
+    action = ActionEnvelope(
+        action_id=request.action_id,
+        actor_id=request.actor_id,
+        actor_type=request.actor_type,
+        runtime_type=request.runtime_type,
+        action_type=request.action_type,
+        content=" ".join(part for part in [request.intent, request.content] if part),
+        metadata=request.metadata,
+        requested_tools=request.requested_tools,
+        provenance=request.provenance,
+    )
+    return kernel.evaluate_action(action, claims)
+
+
+def evaluate_fourfold_warrant(
+    request: FourfoldActionWarrantRequest,
+    *,
+    claims: Sequence[Claim] | None = None,
+    kernel: SemanticGovernanceKernel | None = None,
+    pass_threshold: float = 0.35,
+    required_pass_count: int = 2,
+) -> FourfoldActionWarrant:
+    """Evaluate a proposed action against the four Shakti questions."""
+    dimensions = [
+        _score_dimension(energy, request, pass_threshold=pass_threshold)
+        for energy in (
+            ShaktiEnergy.MAHESHWARI,
+            ShaktiEnergy.MAHAKALI,
+            ShaktiEnergy.MAHALAKSHMI,
+            ShaktiEnergy.MAHASARASWATI,
+        )
+    ]
+    pass_count = sum(1 for item in dimensions if item.passed)
+    score = round(sum(item.score for item in dimensions) / len(dimensions), 3)
+    warnings: list[str] = []
+    block_reasons = _explicit_block_reasons(request)
+    semantic_verdict = None
+    unauthorized = _unauthorized_tools(request)
+    warnings.extend(_evidence_warnings(request))
+
+    if request.requested_tools and not _allowed_tool_names(request.metadata):
+        warnings.append("requested tools were not checked against an allowlist")
+    if unauthorized:
+        warnings.append("unauthorized requested tools: " + ", ".join(unauthorized))
+
+    if claims:
+        semantic_verdict = _semantic_verdict_for(
+            request,
+            claims,
+            kernel or SemanticGovernanceKernel(),
+        )
+        if semantic_verdict.enforcement_level == "block":
+            block_reasons.append(f"semantic governance blocked: {semantic_verdict.rationale}")
+        elif semantic_verdict.enforcement_level == "gate_human":
+            warnings.append(
+                f"semantic governance requires human gate: {semantic_verdict.rationale}"
+            )
+        elif semantic_verdict.enforcement_level == "warn":
+            warnings.extend(semantic_verdict.warnings or [semantic_verdict.rationale])
+
+    if block_reasons:
+        verdict = WarrantVerdict.BLOCK
+        rationale = "blocked: " + "; ".join(block_reasons)
+    elif semantic_verdict is not None and semantic_verdict.enforcement_level == "gate_human":
+        verdict = WarrantVerdict.HOLD
+        rationale = "hold: semantic governance requires review"
+    elif pass_count < required_pass_count:
+        verdict = WarrantVerdict.HOLD
+        rationale = (
+            f"hold: only {pass_count}/{len(dimensions)} Shakti questions passed; "
+            f"requires at least {required_pass_count}"
+        )
+    elif pass_count == required_pass_count or any(item.score < 0.20 for item in dimensions):
+        verdict = WarrantVerdict.WARN
+        rationale = "warn: minimum warrant satisfied, but one or more dimensions are thin"
+    else:
+        verdict = WarrantVerdict.ALLOW
+        rationale = "allow: sufficient fourfold warrant evidence"
+
+    provenance = sorted(
+        set(
+            [
+                *request.provenance,
+                f"action:{request.action_id}",
+                "kernel:shakti_questions",
+                "module:dharma_swarm.shakti_warrant",
+            ]
+        )
+    )
+
+    return FourfoldActionWarrant(
+        action_id=request.action_id,
+        actor_id=request.actor_id,
+        action_type=request.action_type,
+        target_paths=_all_paths(request),
+        verdict=verdict,
+        score=score,
+        pass_count=pass_count,
+        required_pass_count=required_pass_count,
+        dimensions=dimensions,
+        semantic_verdict=semantic_verdict,
+        evidence=request.evidence,
+        ontology_refs=_extract_ontology_refs(request),
+        warnings=warnings,
+        rationale=rationale,
+        provenance=provenance,
+    )
+
+
+def warrant_request_from_mapping(payload: dict[str, Any]) -> FourfoldActionWarrantRequest:
+    """Build a request from loosely structured CLI or API data."""
+    return FourfoldActionWarrantRequest.model_validate(payload)
+
+
+def render_warrant_report(warrant: FourfoldActionWarrant) -> str:
+    """Render a compact human-readable warrant report."""
+    lines = [
+        f"Fourfold Shakti Warrant: {warrant.verdict.value.upper()}",
+        f"Score: {warrant.score:.3f} | Passes: {warrant.pass_count}/4",
+        f"Action: {warrant.action_type} by {warrant.actor_id}",
+        f"Rationale: {warrant.rationale}",
+        "",
+        "Dimensions:",
+    ]
+    for dimension in warrant.dimensions:
+        status = "PASS" if dimension.passed else "MISS"
+        lines.append(
+            f"- {dimension.energy.value}: {status} {dimension.score:.3f} - {dimension.rationale}"
+        )
+    if warrant.warnings:
+        lines.append("")
+        lines.append("Warnings:")
+        lines.extend(f"- {warning}" for warning in warrant.warnings)
+    if warrant.evidence:
+        lines.append("")
+        lines.append("Evidence:")
+        for evidence in warrant.evidence:
+            lines.append(f"- {evidence.source}:{evidence.kind} - {evidence.summary}")
+            if evidence.paths:
+                lines.append("  paths: " + ", ".join(evidence.paths[:8]))
+    if warrant.ontology_refs:
+        lines.append("")
+        lines.append("Ontology refs:")
+        lines.extend(f"- {ref}" for ref in warrant.ontology_refs)
+    return "\n".join(lines)
+
+
+__all__ = [
+    "FourfoldActionWarrant",
+    "FourfoldActionWarrantRequest",
+    "ShaktiDimensionScore",
+    "WarrantEvidence",
+    "WarrantVerdict",
+    "evaluate_fourfold_warrant",
+    "render_warrant_report",
+    "warrant_request_from_mapping",
+]

--- a/dharma_swarm/shakti_warrant.py
+++ b/dharma_swarm/shakti_warrant.py
@@ -235,7 +235,7 @@ def _all_paths(request: FourfoldActionWarrantRequest) -> list[str]:
 
 
 def _has_diff_evidence(request: FourfoldActionWarrantRequest) -> bool:
-    return bool(
+    return (
         request.metadata.get("diff_bound") is True
         or any(e.kind == "git_diff" for e in request.evidence)
     )

--- a/docs/governance/FOURFOLD_ACTION_WARRANT.md
+++ b/docs/governance/FOURFOLD_ACTION_WARRANT.md
@@ -1,0 +1,95 @@
+# Fourfold Action Warrant
+
+Status: read-only governance artifact.
+
+The Fourfold Action Warrant turns the Shakti questions into an executable review
+artifact for significant actions. It does not replace telos gates, pre-commit
+guards, or ontology records. It provides a deterministic "should this action
+proceed?" packet that can be attached to reviews, PRs, and operator decisions.
+
+## Four Questions
+
+| Shakti | Question | Engineering Check |
+| --- | --- | --- |
+| Maheshwari | Does this serve the larger pattern, telos, and emergence? | Names the system-level purpose and avoids local-only optimization. |
+| Mahakali | Is this the right moment and force level? | Acts decisively on real blockers without unnecessary blast radius. |
+| Mahalakshmi | Does this create harmony rather than noise? | Reuses existing seams and reduces fragmentation. |
+| Mahasaraswati | Is every detail precise, evidenced, and verified? | Includes exact paths, deterministic checks, and tests. |
+
+The default warrant requires at least two of four dimensions to pass. Explicitly
+destructive actions without consent block regardless of score. Semantic
+governance block claims also override the fourfold score.
+
+## CLI
+
+```bash
+python3 scripts/governance/check_shakti_warrant.py \
+  --intent "restore canonical governance architecture" \
+  --content "fix blocker, reduce fragmentation, add deterministic pytest evidence" \
+  --target scripts/governance/check_shakti_warrant.py \
+  --target tests/test_shakti_warrant.py \
+  --tool pytest \
+  --metadata allowed_tools=pytest \
+  --metadata telos_aligned=true \
+  --metadata fixes_blocker=true \
+  --metadata no_new_substrate=true \
+  --metadata tests_planned=true
+```
+
+The command exits zero by default because the warrant is currently advisory.
+Use `--fail-on block --fail-on hold` when a caller wants to make the report a
+gate.
+
+Tool authorization is advisory unless `--metadata enforce_tool_allowlist=true`
+is supplied. With enforcement enabled, every `--tool` command must match a tool
+name in `--metadata allowed_tools=tool1,tool2`; unauthorized tools block the
+warrant.
+
+## Diff-Bound Warrants
+
+The warrant becomes much stronger when it is bound to actual git evidence:
+
+```bash
+python3 scripts/governance/check_shakti_warrant.py \
+  --intent "stabilize the governance warrant seam" \
+  --diff-scope unstaged \
+  --tool "pytest -q tests/test_shakti_warrant.py" \
+  --metadata allowed_tools=pytest \
+  --metadata tests_planned=true \
+  --metadata requires_diff_evidence=true
+```
+
+Supported scopes are `unstaged`, `staged`, `head`, and `base`. The `base` scope
+diffs `origin/main...HEAD` unless `--base-ref` is supplied. Untracked files are
+included by default; use `--no-include-untracked` when reviewing only tracked
+changes.
+
+Diff evidence is rendered in the report and copied into the JSON payload. It
+also changes scoring: bounded diffs improve Mahalakshmi, git evidence and test
+paths improve Mahasaraswati, and hot paths can be forced to block unless
+`--metadata impact_checked=true` accompanies `--metadata enforce_hotpath_ack=true`.
+The CLI also treats `DHARMA_UPLIFT_ACK=impact-checked` as `impact_checked=true`
+so it composes with the existing hot-path acknowledgement guard.
+
+The pre-commit uplift guard runs the staged warrant as part of
+`scripts/uplift_guards/run_pre_commit.py`:
+
+```bash
+python3 scripts/governance/check_shakti_warrant.py \
+  --intent "pre-commit staged diff fourfold governance warrant" \
+  --diff-scope staged \
+  --no-include-untracked \
+  --pass-on-empty-diff \
+  --metadata requires_diff_evidence=true \
+  --metadata enforce_hotpath_ack=true \
+  --fail-on block \
+  --fail-on hold
+```
+
+## Scope Boundary
+
+This is intentionally not another state system. The warrant is computed from an
+action request and optional semantic claims, then rendered. Future integrations
+may attach the warrant to `ActionProposal` or `GateDecisionRecord`, but the
+current implementation remains read-only so it can review Devin/Codex/human
+changes without mutating runtime state.

--- a/scripts/governance/check_shakti_warrant.py
+++ b/scripts/governance/check_shakti_warrant.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Render a read-only Fourfold Shakti warrant for a proposed action."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from dharma_swarm.shakti_warrant import (
+    FourfoldActionWarrantRequest,
+    WarrantEvidence,
+    WarrantVerdict,
+    evaluate_fourfold_warrant,
+    render_warrant_report,
+)
+
+
+def _parse_metadata(items: list[str]) -> dict[str, Any]:
+    metadata: dict[str, Any] = {}
+    for item in items:
+        if "=" not in item:
+            raise SystemExit(f"metadata must be key=value, got {item!r}")
+        key, raw_value = item.split("=", 1)
+        lowered = raw_value.lower()
+        if lowered == "true":
+            value: Any = True
+        elif lowered == "false":
+            value = False
+        else:
+            try:
+                value = int(raw_value)
+            except ValueError:
+                try:
+                    value = float(raw_value)
+                except ValueError:
+                    value = raw_value
+        metadata[key] = value
+    return metadata
+
+
+def _env_impact_checked() -> bool:
+    return os.environ.get("DHARMA_UPLIFT_ACK", "").strip().lower() == "impact-checked"
+
+
+def _run_git(repo_root: Path, args: list[str]) -> str:
+    proc = subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        detail = proc.stderr.strip() or proc.stdout.strip() or "git command failed"
+        raise SystemExit(f"git {' '.join(args)} failed: {detail}")
+    return proc.stdout
+
+
+def _parse_name_status(output: str) -> list[str]:
+    paths: list[str] = []
+    for line in output.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("\t")
+        if len(parts) < 2:
+            continue
+        paths.append(parts[-1])
+    return sorted(set(paths))
+
+
+def _parse_path_lines(output: str) -> list[str]:
+    return sorted(set(line.strip() for line in output.splitlines() if line.strip()))
+
+
+def _git_diff_args(scope: str, base_ref: str) -> list[str]:
+    if scope == "staged":
+        return ["diff", "--cached"]
+    if scope == "unstaged":
+        return ["diff"]
+    if scope == "head":
+        return ["diff", "HEAD"]
+    if scope == "base":
+        return ["diff", f"{base_ref}...HEAD"]
+    raise SystemExit(f"unknown diff scope: {scope}")
+
+
+def _path_counts(paths: list[str]) -> dict[str, int]:
+    return {
+        "source": sum(
+            path.endswith((".py", ".ts", ".tsx", ".js", ".jsx", ".rs", ".sh"))
+            for path in paths
+        ),
+        "tests": sum(
+            path.startswith("tests/") or "/test_" in path or path.endswith("_test.py")
+            for path in paths
+        ),
+        "docs": sum(
+            path.startswith("docs/") or path.endswith((".md", ".rst", ".txt"))
+            for path in paths
+        ),
+    }
+
+
+def _git_evidence(
+    *,
+    repo_root: Path,
+    scope: str,
+    base_ref: str,
+    include_untracked: bool,
+    max_diff_chars: int,
+) -> tuple[WarrantEvidence | None, dict[str, Any], list[str], str]:
+    if scope == "none":
+        return None, {}, [], ""
+
+    diff_args = _git_diff_args(scope, base_ref)
+    name_status = _run_git(repo_root, [*diff_args, "--name-status"])
+    stat = _run_git(repo_root, [*diff_args, "--stat"])
+    diff_text = _run_git(repo_root, [*diff_args, "--", "."])
+    paths = _parse_name_status(name_status)
+    untracked: list[str] = []
+    if include_untracked:
+        untracked = _parse_path_lines(
+            _run_git(repo_root, ["ls-files", "--others", "--exclude-standard"])
+        )
+        paths = sorted(set([*paths, *untracked]))
+
+    counts = _path_counts(paths)
+    metadata = {
+        "diff_bound": True,
+        "diff_scope": scope,
+        "changed_files_count": len(paths),
+        "source_files_count": counts["source"],
+        "test_files_count": counts["tests"],
+        "doc_files_count": counts["docs"],
+        "untracked_files_count": len(untracked),
+    }
+    summary = (
+        f"git diff scope={scope}: {len(paths)} changed path(s), "
+        f"source={counts['source']}, tests={counts['tests']}, docs={counts['docs']}, "
+        f"untracked={len(untracked)}"
+    )
+    if stat.strip():
+        summary += "; " + " ".join(stat.strip().splitlines()[:3])
+    if len(diff_text) > max_diff_chars:
+        diff_text = diff_text[:max_diff_chars] + "\n[diff truncated]"
+
+    evidence = WarrantEvidence(
+        source="git",
+        kind="git_diff",
+        summary=summary,
+        paths=paths,
+        confidence=1.0,
+        metadata=metadata,
+    )
+    return evidence, metadata, paths, diff_text
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Evaluate a proposed action against the four Shakti questions.",
+    )
+    parser.add_argument("--intent", required=True, help="Short statement of intended action.")
+    parser.add_argument(
+        "--content",
+        default="",
+        help="Additional action detail. Reads stdin if omitted and stdin is piped.",
+    )
+    parser.add_argument("--actor-id", default="operator", help="Actor requesting the action.")
+    parser.add_argument("--actor-type", default="agent", help="Actor type.")
+    parser.add_argument("--runtime-type", default="local", help="Runtime type.")
+    parser.add_argument("--action-type", default="proposed_action", help="Action type label.")
+    parser.add_argument(
+        "--target",
+        action="append",
+        default=[],
+        help="Target file/path. Repeatable.",
+    )
+    parser.add_argument(
+        "--tool",
+        action="append",
+        default=[],
+        help="Requested tool/command. Repeatable.",
+    )
+    parser.add_argument(
+        "--metadata",
+        action="append",
+        default=[],
+        help="Metadata key=value. Repeatable.",
+    )
+    parser.add_argument(
+        "--provenance",
+        action="append",
+        default=[],
+        help="Provenance reference. Repeatable.",
+    )
+    parser.add_argument("--repo-root", default=".", help="Repository root for git diff binding.")
+    parser.add_argument(
+        "--diff-scope",
+        choices=["none", "unstaged", "staged", "head", "base"],
+        default="none",
+        help="Bind the warrant to git changes.",
+    )
+    parser.add_argument("--base-ref", default="origin/main", help="Base ref for --diff-scope base.")
+    parser.add_argument(
+        "--include-untracked",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Include untracked files in git evidence.",
+    )
+    parser.add_argument(
+        "--max-diff-chars",
+        type=int,
+        default=8000,
+        help="Maximum diff text chars to include in warrant content.",
+    )
+    parser.add_argument(
+        "--pass-on-empty-diff",
+        action="store_true",
+        help="Exit 0 without a warrant when the selected diff scope has no changed paths.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON instead of text report.")
+    parser.add_argument(
+        "--fail-on",
+        choices=[item.value for item in WarrantVerdict],
+        action="append",
+        default=[],
+        help="Exit non-zero when verdict matches. Repeatable.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    content = args.content
+    if not content and not sys.stdin.isatty():
+        content = sys.stdin.read()
+    metadata = _parse_metadata(args.metadata)
+    if _env_impact_checked():
+        metadata.setdefault("impact_checked", True)
+    evidence_items = []
+    target_paths = list(args.target)
+    if args.diff_scope != "none":
+        evidence, diff_metadata, diff_paths, diff_text = _git_evidence(
+            repo_root=Path(args.repo_root),
+            scope=args.diff_scope,
+            base_ref=args.base_ref,
+            include_untracked=args.include_untracked,
+            max_diff_chars=args.max_diff_chars,
+        )
+        metadata = {**diff_metadata, **metadata}
+        if evidence is not None:
+            evidence_items.append(evidence)
+        target_paths = sorted(set([*target_paths, *diff_paths]))
+        if args.pass_on_empty_diff and not target_paths:
+            print(f"No changed paths for diff scope {args.diff_scope}; warrant not required.")
+            return 0
+        content = "\n\n".join(part for part in [content, diff_text] if part)
+
+    request = FourfoldActionWarrantRequest(
+        actor_id=args.actor_id,
+        actor_type=args.actor_type,
+        runtime_type=args.runtime_type,
+        action_type=args.action_type,
+        intent=args.intent,
+        content=content,
+        target_paths=target_paths,
+        requested_tools=args.tool,
+        metadata=metadata,
+        evidence=evidence_items,
+        provenance=args.provenance,
+    )
+    warrant = evaluate_fourfold_warrant(request)
+    if args.json:
+        print(json.dumps(warrant.model_dump(mode="json"), indent=2, sort_keys=True))
+    else:
+        print(render_warrant_report(warrant))
+
+    return 1 if warrant.verdict.value in set(args.fail_on) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/uplift_guards/__init__.py
+++ b/scripts/uplift_guards/__init__.py
@@ -8,6 +8,7 @@ autonomous-build damage post-mortem (commit d7af817).
 from __future__ import annotations
 
 from .autonomous_guard import check_autonomous_destruction
+from .shakti_warrant_guard import check_fourfold_shakti_warrant
 from .kernel_guard import check_kernel_integrity
 from .secrets_guard import check_no_secrets
 from .hotpath_guard import check_hotpath_acknowledged
@@ -18,6 +19,7 @@ from .mismatch_registry import (
 
 __all__ = [
     "check_autonomous_destruction",
+    "check_fourfold_shakti_warrant",
     "check_kernel_integrity",
     "check_no_secrets",
     "check_hotpath_acknowledged",

--- a/scripts/uplift_guards/run_pre_commit.py
+++ b/scripts/uplift_guards/run_pre_commit.py
@@ -15,6 +15,7 @@ sys.path.insert(0, str(REPO_ROOT))
 
 from scripts.uplift_guards import (
     check_autonomous_destruction,
+    check_fourfold_shakti_warrant,
     check_hotpath_acknowledged,
     check_kernel_integrity,
     check_mismatch_adjacency,
@@ -71,6 +72,7 @@ GUARDS = [
     ("secrets-scan", check_no_secrets),
     ("autonomous-destruction", check_autonomous_destruction),
     ("hotpath-ack", check_hotpath_acknowledged),
+    ("fourfold-shakti-warrant", check_fourfold_shakti_warrant),
     ("mismatch-adjacency", check_mismatch_adjacency),
     ("assurance-diff", check_assurance_diff),
 ]

--- a/scripts/uplift_guards/shakti_warrant_guard.py
+++ b/scripts/uplift_guards/shakti_warrant_guard.py
@@ -1,0 +1,96 @@
+"""Fourfold Shakti Warrant guard for staged pre-commit diffs."""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+CHECK_SCRIPT = Path(__file__).resolve().parents[1] / "governance/check_shakti_warrant.py"
+ACK_TAG = "[impact-checked]"
+ACK_ENV = "DHARMA_UPLIFT_ACK"
+ACK_ENV_VALUE = "impact-checked"
+
+
+def _read_commit_message(repo_root: Path, msg_file: str | None) -> str:
+    if msg_file:
+        return Path(msg_file).read_text(errors="replace")
+    candidate = repo_root / ".git" / "COMMIT_EDITMSG"
+    if candidate.exists():
+        return candidate.read_text(errors="replace")
+    return ""
+
+
+def _impact_acknowledged(repo_root: Path, msg_file: str | None = None) -> bool:
+    if ACK_TAG in _read_commit_message(repo_root, msg_file):
+        return True
+    return os.environ.get(ACK_ENV, "").strip().lower() == ACK_ENV_VALUE.lower()
+
+
+def _summarize_warrant_output(output: str) -> str:
+    lines = output.splitlines()
+    first_line = lines[0] if lines else "no warrant output"
+    for index, line in enumerate(lines):
+        if line.strip() == "Warnings:" and index + 1 < len(lines):
+            return f"{first_line} | warning: {lines[index + 1].removeprefix('- ').strip()}"
+    return first_line
+
+
+def _command(repo_root: Path, *, impact_checked: bool) -> list[str]:
+    cmd = [
+        sys.executable,
+        str(CHECK_SCRIPT),
+        "--intent",
+        (
+            "pre-commit staged diff fourfold governance warrant for system telos, "
+            "semantic architecture, bounded change, deterministic evidence, "
+            "exact paths, and verification"
+        ),
+        "--diff-scope",
+        "staged",
+        "--no-include-untracked",
+        "--pass-on-empty-diff",
+        "--max-diff-chars",
+        "12000",
+        "--tool",
+        "pytest",
+        "--metadata",
+        "allowed_tools=pytest",
+        "--metadata",
+        "requires_diff_evidence=true",
+        "--metadata",
+        "enforce_hotpath_ack=true",
+        "--fail-on",
+        "block",
+        "--fail-on",
+        "hold",
+    ]
+    if impact_checked:
+        cmd.extend(["--metadata", "impact_checked=true"])
+    return cmd
+
+
+def check_fourfold_shakti_warrant(
+    repo_root: Path | None = None,
+    *,
+    commit_msg_file: str | None = None,
+) -> tuple[bool, str]:
+    """Run an evidence-bound Fourfold Shakti Warrant against staged changes."""
+    repo_root = repo_root or Path.cwd()
+    if os.environ.get("DHARMA_SKIP_SHAKTI_WARRANT_GUARD", "").strip() == "1":
+        return True, "shakti warrant guard skipped by DHARMA_SKIP_SHAKTI_WARRANT_GUARD=1"
+
+    proc = subprocess.run(
+        _command(
+            repo_root,
+            impact_checked=_impact_acknowledged(repo_root, commit_msg_file),
+        ),
+        cwd=str(repo_root),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    output = "\n".join(part.strip() for part in [proc.stdout, proc.stderr] if part.strip())
+    if proc.returncode == 0:
+        return True, _summarize_warrant_output(output)
+    return False, output or f"shakti warrant exited {proc.returncode}"

--- a/tests/test_shakti_warrant.py
+++ b/tests/test_shakti_warrant.py
@@ -1,0 +1,489 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from dharma_swarm.dharma_corpus import Claim, ClaimCategory, ClaimStatus
+from dharma_swarm.shakti_warrant import (
+    FourfoldActionWarrantRequest,
+    WarrantEvidence,
+    WarrantVerdict,
+    evaluate_fourfold_warrant,
+    render_warrant_report,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _claim(claim_id: str, statement: str, *, enforcement: str = "warn") -> Claim:
+    return Claim(
+        id=claim_id,
+        statement=statement,
+        category=ClaimCategory.ARCHITECTURAL,
+        confidence=1.0,
+        enforcement=enforcement,
+        status=ClaimStatus.ACCEPTED,
+    )
+
+
+def test_fourfold_warrant_allows_well_evidenced_governance_action():
+    request = FourfoldActionWarrantRequest(
+        actor_id="codex",
+        action_type="governance_patch",
+        intent=(
+            "restore canonical governance warrant architecture and integrate a single "
+            "source of truth for the larger telos pattern"
+        ),
+        content=(
+            "fix blocker guard, reduce fragmentation, reuse existing semantic governance, "
+            "add deterministic pytest verification and exact path evidence"
+        ),
+        target_paths=[
+            "dharma_swarm/shakti_warrant.py",
+            "scripts/governance/check_shakti_warrant.py",
+            "tests/test_shakti_warrant.py",
+        ],
+        requested_tools=["pytest"],
+        metadata={
+            "telos_aligned": True,
+            "fixes_blocker": True,
+            "no_new_substrate": True,
+            "reduces_fragmentation": True,
+            "tests_planned": True,
+            "allowed_tools": ["pytest"],
+        },
+    )
+
+    warrant = evaluate_fourfold_warrant(request)
+
+    assert warrant.verdict == WarrantVerdict.ALLOW
+    assert warrant.pass_count == 4
+    assert {dimension.energy.value for dimension in warrant.dimensions if dimension.passed} == {
+        "maheshwari",
+        "mahakali",
+        "mahalakshmi",
+        "mahasaraswati",
+    }
+
+
+def test_fourfold_warrant_holds_when_only_force_is_clear():
+    request = FourfoldActionWarrantRequest(
+        actor_id="worker",
+        action_type="rapid_patch",
+        intent="execute urgent action now",
+        content="move quickly and deploy immediately",
+        metadata={"urgent": True},
+    )
+
+    warrant = evaluate_fourfold_warrant(request)
+
+    assert warrant.verdict == WarrantVerdict.HOLD
+    assert warrant.pass_count < warrant.required_pass_count
+    assert "only" in warrant.rationale
+
+
+def test_fourfold_warrant_blocks_explicit_destructive_action():
+    request = FourfoldActionWarrantRequest(
+        actor_id="worker",
+        action_type="shell_command",
+        intent="clean state",
+        content="rm -rf ~/.dharma",
+        metadata={"destructive_without_consent": True},
+    )
+
+    warrant = evaluate_fourfold_warrant(request)
+
+    assert warrant.verdict == WarrantVerdict.BLOCK
+    assert "destructive action without consent" in warrant.rationale
+
+
+def test_semantic_claim_block_overrides_fourfold_score():
+    request = FourfoldActionWarrantRequest(
+        actor_id="codex",
+        action_type="governance_patch",
+        intent="restore architecture and add deterministic tests",
+        content="delete production database after tests",
+        target_paths=["scripts/governance/check_shakti_warrant.py"],
+        requested_tools=["pytest"],
+        metadata={
+            "telos_aligned": True,
+            "fixes_blocker": True,
+            "no_new_substrate": True,
+            "tests_planned": True,
+        },
+    )
+
+    warrant = evaluate_fourfold_warrant(
+        request,
+        claims=[_claim("DC-TEST-1", "delete production database", enforcement="block")],
+    )
+
+    assert warrant.verdict == WarrantVerdict.BLOCK
+    assert warrant.semantic_verdict is not None
+    assert warrant.semantic_verdict.enforcement_level == "block"
+
+
+def test_render_warrant_report_includes_dimension_status():
+    request = FourfoldActionWarrantRequest(
+        actor_id="codex",
+        action_type="review",
+        intent="verify exact tests for semantic governance",
+        content="pytest evidence",
+        target_paths=["tests/test_shakti_warrant.py"],
+        metadata={"tests_planned": True},
+    )
+
+    report = render_warrant_report(evaluate_fourfold_warrant(request))
+
+    assert "Fourfold Shakti Warrant" in report
+    assert "mahasaraswati" in report
+    assert "Score:" in report
+
+
+def test_check_shakti_warrant_cli_json_output():
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "scripts/governance/check_shakti_warrant.py",
+            "--intent",
+            "restore canonical governance architecture",
+            "--content",
+            "fix blocker reduce fragmentation deterministic pytest evidence",
+            "--target",
+            "tests/test_shakti_warrant.py",
+            "--tool",
+            "pytest",
+            "--metadata",
+            "telos_aligned=true",
+            "--metadata",
+            "fixes_blocker=true",
+            "--metadata",
+            "no_new_substrate=true",
+            "--metadata",
+            "tests_planned=true",
+            "--metadata",
+            "allowed_tools=pytest",
+            "--json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(proc.stdout)
+    assert payload["verdict"] in {"allow", "warn"}
+    assert payload["pass_count"] >= 2
+
+
+def test_requested_tool_without_allowlist_warns():
+    request = FourfoldActionWarrantRequest(
+        actor_id="codex",
+        action_type="governance_patch",
+        intent="restore architecture and add deterministic tests",
+        content="fix blocker reduce fragmentation pytest evidence",
+        target_paths=["tests/test_shakti_warrant.py"],
+        requested_tools=["pytest -q tests/test_shakti_warrant.py"],
+        metadata={
+            "telos_aligned": True,
+            "fixes_blocker": True,
+            "no_new_substrate": True,
+            "tests_planned": True,
+        },
+    )
+
+    warrant = evaluate_fourfold_warrant(request)
+
+    assert warrant.verdict in {WarrantVerdict.ALLOW, WarrantVerdict.WARN}
+    assert "requested tools were not checked against an allowlist" in warrant.warnings
+
+
+def test_enforced_tool_allowlist_blocks_unauthorized_tool():
+    request = FourfoldActionWarrantRequest(
+        actor_id="codex",
+        action_type="governance_patch",
+        intent="restore architecture and add deterministic tests",
+        content="fix blocker reduce fragmentation pytest evidence",
+        target_paths=["tests/test_shakti_warrant.py"],
+        requested_tools=["pytest -q tests/test_shakti_warrant.py", "curl https://example.test"],
+        metadata={
+            "telos_aligned": True,
+            "fixes_blocker": True,
+            "no_new_substrate": True,
+            "tests_planned": True,
+            "allowed_tools": ["pytest"],
+            "enforce_tool_allowlist": True,
+        },
+    )
+
+    warrant = evaluate_fourfold_warrant(request)
+
+    assert warrant.verdict == WarrantVerdict.BLOCK
+    assert "unauthorized requested tools: curl" in warrant.rationale
+
+
+def test_diff_evidence_records_paths_and_boosts_precision():
+    evidence = WarrantEvidence(
+        source="git",
+        kind="git_diff",
+        summary="git diff scope=staged: 2 changed path(s)",
+        paths=["./dharma_swarm/shakti_warrant.py", "tests/test_shakti_warrant.py"],
+    )
+    request = FourfoldActionWarrantRequest(
+        actor_id="codex",
+        action_type="governance_patch",
+        intent="restore canonical governance architecture with deterministic evidence",
+        content="reduce fragmentation and verify exact pytest path evidence",
+        requested_tools=["pytest -q tests/test_shakti_warrant.py"],
+        metadata={
+            "diff_bound": True,
+            "no_new_substrate": True,
+            "tests_planned": True,
+            "allowed_tools": ["pytest"],
+        },
+        evidence=[evidence],
+    )
+
+    warrant = evaluate_fourfold_warrant(request)
+    mahasaraswati = next(
+        dimension
+        for dimension in warrant.dimensions
+        if dimension.energy.value == "mahasaraswati"
+    )
+    report = render_warrant_report(warrant)
+
+    assert "dharma_swarm/shakti_warrant.py" in warrant.target_paths
+    assert "git_diff_evidence" in mahasaraswati.matched_terms
+    assert "test_paths" in mahasaraswati.matched_terms
+    assert warrant.evidence[0].kind == "git_diff"
+    assert "Evidence:" in report
+
+
+def test_enforced_hot_path_ack_blocks_without_impact_check():
+    request = FourfoldActionWarrantRequest(
+        actor_id="codex",
+        action_type="runtime_patch",
+        intent="fix urgent orchestration guard with deterministic evidence",
+        content="restore system architecture and run pytest verification",
+        target_paths=["./dharma_swarm/orchestrator.py"],
+        metadata={
+            "diff_bound": True,
+            "fixes_blocker": True,
+            "tests_planned": True,
+            "enforce_hotpath_ack": True,
+        },
+    )
+
+    warrant = evaluate_fourfold_warrant(request)
+
+    assert warrant.verdict == WarrantVerdict.BLOCK
+    assert "hot-path changes lack impact_checked" in warrant.rationale
+    assert any("hot-path changes lack impact_checked" in warning for warning in warrant.warnings)
+
+
+def test_source_diff_without_tests_warns():
+    request = FourfoldActionWarrantRequest(
+        actor_id="codex",
+        action_type="source_patch",
+        intent="implement deterministic source change",
+        target_paths=["dharma_swarm/new_feature.py"],
+        metadata={"diff_bound": True},
+    )
+
+    warrant = evaluate_fourfold_warrant(request)
+
+    assert "source changes lack test paths or test metadata" in warrant.warnings
+
+
+def test_doc_only_blocker_claim_warns():
+    request = FourfoldActionWarrantRequest(
+        actor_id="codex",
+        action_type="governance_doc_patch",
+        intent="document blocker fix for governance",
+        target_paths=["docs/governance/fourfold.md"],
+        metadata={"diff_bound": True, "fixes_blocker": True},
+    )
+
+    warrant = evaluate_fourfold_warrant(request)
+
+    assert (
+        "doc-only diff claims fixes_blocker; verify there is an executable fix elsewhere"
+        in warrant.warnings
+    )
+
+
+def test_check_shakti_warrant_cli_binds_to_git_diff_and_untracked_files(tmp_path):
+    def git(*args: str) -> None:
+        subprocess.run(
+            ["git", "-C", str(tmp_path), *args],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    git("init")
+    git("config", "user.email", "test@example.invalid")
+    git("config", "user.name", "Test User")
+    (tmp_path / "app.py").write_text("VALUE = 1\n", encoding="utf-8")
+    git("add", "app.py")
+    git("commit", "-m", "init")
+    (tmp_path / "app.py").write_text("VALUE = 2\n", encoding="utf-8")
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "test_app.py").write_text(
+        "def test_value():\n    assert True\n",
+        encoding="utf-8",
+    )
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(REPO_ROOT) + os.pathsep + env.get("PYTHONPATH", "")
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "scripts/governance/check_shakti_warrant.py"),
+            "--repo-root",
+            str(tmp_path),
+            "--diff-scope",
+            "unstaged",
+            "--intent",
+            "restore architecture with deterministic pytest evidence",
+            "--tool",
+            "pytest -q",
+            "--metadata",
+            "allowed_tools=pytest",
+            "--metadata",
+            "tests_planned=true",
+            "--json",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(proc.stdout)
+    evidence = payload["evidence"][0]
+
+    assert evidence["kind"] == "git_diff"
+    assert evidence["metadata"]["diff_bound"] is True
+    assert evidence["metadata"]["untracked_files_count"] == 1
+    assert "app.py" in payload["target_paths"]
+    assert "tests/test_app.py" in payload["target_paths"]
+
+
+def test_check_shakti_warrant_cli_passes_empty_staged_diff(tmp_path):
+    def git(*args: str) -> None:
+        subprocess.run(
+            ["git", "-C", str(tmp_path), *args],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    git("init")
+    git("config", "user.email", "test@example.invalid")
+    git("config", "user.name", "Test User")
+    (tmp_path / "README.md").write_text("# test\n", encoding="utf-8")
+    git("add", "README.md")
+    git("commit", "-m", "init")
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(REPO_ROOT) + os.pathsep + env.get("PYTHONPATH", "")
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "scripts/governance/check_shakti_warrant.py"),
+            "--repo-root",
+            str(tmp_path),
+            "--diff-scope",
+            "staged",
+            "--pass-on-empty-diff",
+            "--intent",
+            "pre-commit staged diff fourfold governance warrant",
+            "--metadata",
+            "requires_diff_evidence=true",
+            "--fail-on",
+            "hold",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "No changed paths for diff scope staged" in proc.stdout
+
+
+def test_check_shakti_warrant_cli_honors_env_impact_ack_for_hot_paths(tmp_path):
+    def git(*args: str) -> None:
+        subprocess.run(
+            ["git", "-C", str(tmp_path), *args],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    git("init")
+    git("config", "user.email", "test@example.invalid")
+    git("config", "user.name", "Test User")
+    hot_path = tmp_path / "dharma_swarm" / "orchestrator.py"
+    hot_path.parent.mkdir()
+    hot_path.write_text("VALUE = 1\n", encoding="utf-8")
+    git("add", "dharma_swarm/orchestrator.py")
+    git("commit", "-m", "init")
+    hot_path.write_text("VALUE = 2\n", encoding="utf-8")
+    git("add", "dharma_swarm/orchestrator.py")
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(REPO_ROOT) + os.pathsep + env.get("PYTHONPATH", "")
+    base_cmd = [
+        sys.executable,
+        str(REPO_ROOT / "scripts/governance/check_shakti_warrant.py"),
+        "--repo-root",
+        str(tmp_path),
+        "--diff-scope",
+        "staged",
+        "--no-include-untracked",
+        "--intent",
+        (
+            "pre-commit staged diff fourfold governance warrant for system telos "
+            "semantic architecture deterministic evidence exact paths verification"
+        ),
+        "--tool",
+        "pytest",
+        "--metadata",
+        "allowed_tools=pytest",
+        "--metadata",
+        "enforce_hotpath_ack=true",
+        "--fail-on",
+        "block",
+        "--fail-on",
+        "hold",
+        "--json",
+    ]
+    blocked = subprocess.run(
+        base_cmd,
+        cwd=REPO_ROOT,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert blocked.returncode == 1
+    assert "hot-path changes lack impact_checked" in blocked.stdout
+
+    env["DHARMA_UPLIFT_ACK"] = "impact-checked"
+    allowed = subprocess.run(
+        base_cmd,
+        cwd=REPO_ROOT,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    payload = json.loads(allowed.stdout)
+
+    assert payload["verdict"] in {"allow", "warn"}
+    assert not any("hot-path changes lack impact_checked" in item for item in payload["warnings"])


### PR DESCRIPTION
Superseded by a ready-for-review replacement PR because the GitHub connector draft-to-ready mutation is currently failing response normalization, while GitHub still blocks merging draft PRs.

Branch head retained: `4c8b368fe666d273dd0ac3e679d9a3647b17e760`.

The replacement keeps the same code scope and includes the follow-up Semgrep fix for the stale `nan-injection` bot finding.