### PR TITLE
fix(governance): harden mismatch and semgrep guard follow-ups

### DIFF
--- a/INTERFACE_MISMATCH_MAP.md
+++ b/INTERFACE_MISMATCH_MAP.md
@@ -1,7 +1,7 @@
 # Interface Mismatch Map — dharma_swarm
 
-**Last X-Ray:** 2026-04-08 (fresh audit against current HEAD `c73db94`+)
-**Previous version:** 2026-04-04 (55 module pairs, 13 mismatches, 9 prioritized)
+**Last X-Ray:** 2026-05-04 (Repo Reality Gauntlet audit against HEAD `3919207`)
+**Previous version:** 2026-04-08 (55 module pairs, 13 mismatches, 9 prioritized)
 **Maintainer:** Guardian Crew (`guardian_crew.py`) — auto-updates every 4 hours
 **How to read this:** Severity = BLOCKER (crashes at runtime), DEGRADED (silent failure / wrong behavior), WARNING (structural smell).
 
@@ -12,7 +12,7 @@
 | Mismatch | Old Status | New Status | Resolution |
 |----------|-----------|-----------|-----------|
 | MM-01: huggingface_hub ImportError | BLOCKER | ✅ RESOLVED | `try/except ImportError` added; heuristic fallback path confirmed |
-| MM-02/03: PersistentAgent enum coercion | BLOCKER | ⚠️ STILL LIVE | `orchestrate_live.py:1247` still passes bare strings — confirmed by x-ray |
+| MM-02/03: PersistentAgent enum coercion | BLOCKER | ✅ RESOLVED | `orchestrate_live.py:1363` now wraps in `AgentRole()` / `PT()` — verified 2026-05-04 |
 | MM-04: AgentPool None guard | DEGRADED | ✅ RESOLVED | `SubsystemNotReady` raised at line 870, `_agent_pool` guard present |
 | MM-06: Dual StigmergyStore | DEGRADED | ✅ RESOLVED | `run_living_layers_loop` now accepts `stigmergy_store` param; passes swarm's store |
 | MM-08: ECC_INSTINCT_SIGNAL constant | DEGRADED | ✅ RESOLVED | `SIGNAL_ECC_INSTINCT` defined in `signal_bus.py:40`, used in `instinct_bridge.py` |
@@ -21,35 +21,32 @@
 | MM-11: WitnessAuditor ModelRouter provider | DEGRADED | ✅ RESOLVED | `swarm.py:456-457` now uses `OpenRouterFreeProvider()` |
 | NEW-01: archaeology_ingestion palace.query | BLOCKER | ✅ FIXED THIS SESSION | Replaced with `palace.recall(PalaceQuery(...))` + correct `max_results=` |
 | NEW-02: dgm_loop _provider attr | DEGRADED | ✅ FIXED THIS SESSION | Removed nonexistent `hasattr(engine, '_provider')` check |
+| NEW-03: TelicSeam constructor kwarg | BLOCKER | ✅ FIXED THIS SESSION | `orchestrator.py:154` passed `registry_path=` but `TelicSeam.__init__` expects `path=` |
+| MM-13: message_bus.receive semantics | DEGRADED | ⚠️ OPEN | `orchestrate_live` → `message_bus.receive()` semantics unclear |
+| MM-17: gnani → TaskBoard.get_by_title | DEGRADED | ⚠️ OPEN | `gnani_lodestone.py:562` calls `get_by_title()` but method does not exist on `TaskBoard` |
+| MM-18: gnani → TelosGraph.get_by_name | DEGRADED | ⚠️ OPEN | `gnani_lodestone.py:518` calls `get_by_name()` but method does not exist on `TelosGraph` |
 
-**Net change:** 7 resolved, 2 new fixed, 1 still live BLOCKER, 4 structural degraded remain.
+**Net change:** 9 resolved (MM-02/03 confirmed fixed, NEW-03 TelicSeam constructor fixed 2026-05-04), 2 new fixed, 0 open BLOCKERs, 5 structural degraded remain.
 
 ---
 
 ## Current Live Mismatches
 
-### MM-02/03 — BLOCKER: PersistentAgent enum deserialization (still live)
+### MM-02/03 — ✅ RESOLVED: PersistentAgent enum deserialization
 
-**File:** `orchestrate_live.py:1247`
-**What's wrong:** `child_spec.get("role", "worker")` returns a bare string (`"conductor"`).
-`PersistentAgent.__init__` declares `role: AgentRole`. Pydantic v2 lax mode may coerce it — but this is brittle and will break on any invalid value.
+**File:** `orchestrate_live.py:1361-1366`
+**Status:** Fixed. Both call sites now wrap bare strings in `AgentRole()` / `PT()`.
+**Verified:** 2026-05-04 by grep + code inspection.
+**Pinning test:** `tests/test_mismatch_blockers.py::test_mm02_persistent_agent_enum`
 
 ```python
-# CURRENT (brittle):
-child = PersistentAgent(
-    role=outcome.child_spec.get("role", "worker"),           # str
-    provider_type=outcome.child_spec.get("default_provider", "openrouter_free"),  # str
-)
-
-# CORRECT:
+# CURRENT (correct):
 from dharma_swarm.models import AgentRole, ProviderType as PT
 child = PersistentAgent(
-    role=AgentRole(outcome.child_spec.get("role", "worker")),
+    role=AgentRole(outcome.child_spec.get("role", "general")),
     provider_type=PT(outcome.child_spec.get("default_provider", "openrouter_free")),
 )
 ```
-
-**Fix complexity:** 2 lines. High leverage — replication is a critical path.
 
 ---
 
@@ -71,10 +68,10 @@ child = PersistentAgent(
 
 ---
 
-### MM-12 — DEGRADED: Same as MM-02/03 (second call site)
+### MM-12 — ✅ RESOLVED: Second PersistentAgent call site
 
-**File:** `orchestrate_live.py:1354-1364` (conductor configs path)
-**Status:** This path uses already-constructed enum values (`role=cfg["role"]` where `cfg["role"]` is `AgentRole.CONDUCTOR`) — no mismatch here. **This is fine.** The problem is only in the replication monitor path at line 1247.
+**File:** `orchestrate_live.py:1471` (conductor configs path)
+**Status:** This path uses already-constructed enum values (`cfg["role"]` is `AgentRole.CONDUCTOR`). No mismatch. The replication path (MM-02/03) is also now fixed.
 
 ---
 
@@ -153,7 +150,7 @@ ROUTER_PROBE   — Reads circuit_breakers.json for open providers
 | 8 | `swarm` → `organism.OrganismRuntime.samvara` | ✅ |
 | 9 | `swarm` → `witness.WitnessAuditor` | ✅ |
 | 10 | `swarm` → `stigmergy.StigmergyStore` | ✅ |
-| 11 | `orchestrate_live` → `persistent_agent.PersistentAgent` (replication) | ⚠️ BLOCKER |
+| 11 | `orchestrate_live` → `persistent_agent.PersistentAgent` (replication) | ✅ (enum wrapping fixed) |
 | 12 | `orchestrate_live` → `message_bus.receive()` semantics | ⚠️ DEGRADED |
 | 13 | `orchestrate_live` → `meta_evolution.observe_cycle_result` cadence | ⚠️ DEGRADED |
 | 14 | `orchestrate_live` → `living_layers` (dual StigmergyStore) | ✅ |

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # DHARMA SWARM — Makefile
 # Run `make help` to see all targets.
 
-.PHONY: help boot stop logs health metrics test lint clean install docker-up docker-down gh-auth semgrep semgrep-strict gitleaks precommit-install precommit-run governance-baseline test-hygiene test-contracts uplift-guards module-budget governance-all
+.PHONY: help boot stop logs health metrics test lint clean install docker-up docker-down gh-auth semgrep semgrep-strict gitleaks precommit-install precommit-run governance-baseline test-hygiene test-contracts uplift-guards module-budget mismatch-check mismatch-tests governance-all
 
 PYTHON ?= python3
 SEMGREP ?= scripts/governance/run_semgrep_with_ca.sh
@@ -176,4 +176,24 @@ module-budget:
 	$(PYTHON) scripts/governance/check_module_budget.py \
 		--base-ref origin/main --head-ref HEAD
 
-governance-all: semgrep gitleaks test-hygiene test-contracts uplift-guards module-budget
+mismatch-check:
+	@echo "=== Mismatch Registry Check ==="
+	$(PYTHON) -c "\
+import yaml, sys; \
+p='docs/interface_mismatches.yaml'; \
+d=yaml.safe_load(open(p)); \
+entries=d.get('entries',[]); \
+ob=[e for e in entries if e['status']=='open' and e['severity']=='BLOCKER']; \
+od=[e for e in entries if e['status']=='open' and e['severity']=='DEGRADED']; \
+print(f'  Total entries: {len(entries)}'); \
+print(f'  Open BLOCKERs: {len(ob)}'); \
+print(f'  Open DEGRADED: {len(od)}'); \
+print(f'  Resolved: {len([e for e in entries if e[\"status\"]==\"resolved\"])}'); \
+[print(f'    {e[\"id\"]}: {e[\"summary\"]}') for e in ob]; \
+sys.exit(1) if ob else None; \
+print('  No open BLOCKERs — gate PASS')"
+
+mismatch-tests:
+	$(PYTHON) -m pytest tests/test_mismatch_blockers.py -v --tb=short
+
+governance-all: semgrep gitleaks test-hygiene test-contracts uplift-guards module-budget mismatch-check mismatch-tests

--- a/dharma_swarm/orchestrator.py
+++ b/dharma_swarm/orchestrator.py
@@ -151,7 +151,7 @@ class Orchestrator:
 
             ontology_db = self._runtime_root() / "ontology.db"
             registry = get_shared_registry(path=ontology_db)
-            return TelicSeam(registry=registry, registry_path=ontology_db)
+            return TelicSeam(registry=registry, path=ontology_db)
         except Exception:
             logger.debug("Failed to initialize local telic seam", exc_info=True)
             return None

--- a/docs/interface_mismatches.yaml
+++ b/docs/interface_mismatches.yaml
@@ -1,0 +1,174 @@
+# Interface Mismatch Registry — machine-readable source of truth.
+#
+# Normalized from INTERFACE_MISMATCH_MAP.md.
+# Both files MUST agree: if you add/resolve a mismatch, update both.
+#
+# Schema per entry:
+#   id:        unique identifier (MM-XX or NEW-XX)
+#   severity:  BLOCKER | DEGRADED | WARNING
+#   status:    open | resolved
+#   caller:    module:line or module path that makes the call
+#   callee:    module.Class.method that is called incorrectly
+#   summary:   one-line description
+#   fixed_in:  commit hash or PR (empty if open)
+#   test_path: path to test that pins the fix (empty if no test yet)
+#
+# Last synced: 2026-05-04 from INTERFACE_MISMATCH_MAP.md (HEAD 3919207)
+
+entries:
+  # ── Resolved ────────────────────────────────────────────────────
+
+  - id: MM-01
+    severity: BLOCKER
+    status: resolved
+    caller: dharma_swarm/orchestrator.py
+    callee: huggingface_hub
+    summary: "huggingface_hub ImportError crashes orchestrator startup"
+    fixed_in: "try/except ImportError added; heuristic fallback"
+    test_path: ""
+
+  - id: MM-04
+    severity: DEGRADED
+    status: resolved
+    caller: dharma_swarm/swarm.py:870
+    callee: dharma_swarm.agent_runner.AgentPool
+    summary: "AgentPool None guard missing — SubsystemNotReady now raised"
+    fixed_in: "SubsystemNotReady raised at line 870"
+    test_path: ""
+
+  - id: MM-06
+    severity: DEGRADED
+    status: resolved
+    caller: dharma_swarm/orchestrate_live.py
+    callee: dharma_swarm.living_map.run_living_layers_loop
+    summary: "Dual StigmergyStore — swarm and living_layers each created own store"
+    fixed_in: "run_living_layers_loop now accepts stigmergy_store param"
+    test_path: ""
+
+  - id: MM-08
+    severity: DEGRADED
+    status: resolved
+    caller: dharma_swarm/instinct_bridge.py
+    callee: dharma_swarm.signal_bus.SIGNAL_ECC_INSTINCT
+    summary: "ECC_INSTINCT_SIGNAL constant undefined in signal_bus"
+    fixed_in: "SIGNAL_ECC_INSTINCT defined in signal_bus.py:40"
+    test_path: ""
+
+  - id: MM-09
+    severity: DEGRADED
+    status: resolved
+    caller: dharma_swarm/swarm.py:2182
+    callee: dharma_swarm.organism.OrganismRuntime.samvara.current_power
+    summary: "samvara.current_power None chain — no guard"
+    fixed_in: "Double guard at swarm.py:2182-2184"
+    test_path: ""
+
+  - id: MM-10
+    severity: DEGRADED
+    status: resolved
+    caller: dharma_swarm/auto_proposer.py:297
+    callee: dharma_swarm.stigmergy.StigmergyStore
+    summary: "AutoProposer crashes on None stigmergy store"
+    fixed_in: "auto_proposer.py:297 has 'if self._stigmergy is None: return'"
+    test_path: ""
+
+  - id: MM-11
+    severity: DEGRADED
+    status: resolved
+    caller: dharma_swarm/swarm.py:456
+    callee: dharma_swarm.witness.WitnessAuditor
+    summary: "WitnessAuditor ModelRouter provider mismatch"
+    fixed_in: "swarm.py:456-457 now uses OpenRouterFreeProvider()"
+    test_path: ""
+
+  - id: NEW-01
+    severity: BLOCKER
+    status: resolved
+    caller: dharma_swarm/archaeology_ingestion.py
+    callee: dharma_swarm.memory_palace.MemoryPalace.recall
+    summary: "palace.query() called but method is palace.recall(PalaceQuery(...))"
+    fixed_in: "Replaced with palace.recall(PalaceQuery(...)) + max_results="
+    test_path: ""
+
+  - id: NEW-02
+    severity: DEGRADED
+    status: resolved
+    caller: dharma_swarm/dgm_loop.py
+    callee: dharma_swarm.evolution.DarwinEngine
+    summary: "hasattr(engine, '_provider') checks nonexistent attribute"
+    fixed_in: "Removed nonexistent hasattr check"
+    test_path: ""
+
+  - id: NEW-03
+    severity: BLOCKER
+    status: resolved
+    caller: dharma_swarm/orchestrator.py:154
+    callee: dharma_swarm.telic_seam.TelicSeam.__init__
+    summary: "TelicSeam() called with registry_path= but __init__ expects path="
+    fixed_in: "Changed registry_path=ontology_db to path=ontology_db (this PR)"
+    test_path: tests/test_mismatch_blockers.py::test_new03_telic_seam_constructor
+
+  # ── Open ────────────────────────────────────────────────────────
+
+  - id: MM-02
+    severity: BLOCKER
+    status: resolved
+    caller: dharma_swarm/orchestrate_live.py:1361
+    callee: dharma_swarm.persistent_agent.PersistentAgent.__init__
+    summary: "PersistentAgent role/provider_type passed as bare strings, not AgentRole/ProviderType enums"
+    fixed_in: "orchestrate_live.py:1363 now uses AgentRole(), :1364 uses PT()"
+    test_path: tests/test_mismatch_blockers.py::test_mm02_persistent_agent_enum
+
+  - id: MM-05
+    severity: DEGRADED
+    status: open
+    caller: dharma_swarm/swarm.py:1883
+    callee: dharma_swarm.orchestrator.Orchestrator._classify_failure
+    summary: "swarm.py calls private Orchestrator methods (_classify_failure, _resolve_retry_policy, _apply_failure_retry_defaults)"
+    fixed_in: ""
+    test_path: tests/test_mismatch_blockers.py::test_mm05_orchestrator_private_methods
+
+  - id: MM-07
+    severity: DEGRADED
+    status: open
+    caller: dharma_swarm/orchestrate_live.py:399
+    callee: dharma_swarm.meta_evolution.MetaEvolutionEngine.observe_cycle_result
+    summary: "observe_cycle_result called twice per cycle — meta-adaptation fires within single cycle"
+    fixed_in: ""
+    test_path: tests/test_mismatch_blockers.py::test_mm07_meta_evolution_cadence
+
+  - id: MM-12
+    severity: WARNING
+    status: resolved
+    caller: dharma_swarm/orchestrate_live.py:1354
+    callee: dharma_swarm.persistent_agent.PersistentAgent.__init__
+    summary: "Second PersistentAgent call site — uses constructed enum values, no mismatch"
+    fixed_in: "Verified correct: cfg['role'] is already AgentRole.CONDUCTOR"
+    test_path: ""
+
+  - id: MM-13
+    severity: DEGRADED
+    status: open
+    caller: dharma_swarm/orchestrate_live.py
+    callee: dharma_swarm.message_bus.receive
+    summary: "message_bus.receive() semantics unclear across orchestrator boundary"
+    fixed_in: ""
+    test_path: ""
+
+  - id: MM-17
+    severity: DEGRADED
+    status: open
+    caller: dharma_swarm/gnani_lodestone.py
+    callee: dharma_swarm.task_board.TaskBoard.get_by_title
+    summary: "get_by_title() method may not exist on TaskBoard"
+    fixed_in: ""
+    test_path: tests/test_mismatch_blockers.py::test_mm17_gnani_task_board
+
+  - id: MM-18
+    severity: DEGRADED
+    status: open
+    caller: dharma_swarm/gnani_lodestone.py
+    callee: dharma_swarm.telos_graph.TelosGraph.get_by_name
+    summary: "get_by_name() method may not exist on TelosGraph"
+    fixed_in: ""
+    test_path: tests/test_mismatch_blockers.py::test_mm18_gnani_telos_graph

--- a/docs/interface_mismatches.yaml
+++ b/docs/interface_mismatches.yaml
@@ -108,7 +108,7 @@ entries:
     fixed_in: "Changed registry_path=ontology_db to path=ontology_db (this PR)"
     test_path: tests/test_mismatch_blockers.py::test_new03_telic_seam_constructor
 
-  # ── Open ────────────────────────────────────────────────────────
+  # ── Replication mismatch + open degraded follow-ups ─────────────
 
   - id: MM-02
     severity: BLOCKER

--- a/scripts/governance/run_semgrep_with_ca.sh
+++ b/scripts/governance/run_semgrep_with_ca.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if [[ "${DHARMA_SKIP_SEMGREP:-}" == "1" ]]; then
+  echo "SEMGREP SKIPPED — DHARMA_SKIP_SEMGREP=1 (operator-acknowledged)" >&2
+  exit 0
+fi
+
 ca_bundle=""
 
 if [[ -n "${SSL_CERT_FILE:-}" && -s "${SSL_CERT_FILE}" ]]; then
@@ -82,10 +87,6 @@ if ! command -v semgrep &>/dev/null; then
   echo "SEMGREP NOT INSTALLED — gate status: NOT RUN" >&2
   echo "  Install: pip install semgrep  (or brew install semgrep)" >&2
   echo "  To skip explicitly: DHARMA_SKIP_SEMGREP=1 git commit ..." >&2
-  if [[ "${DHARMA_SKIP_SEMGREP:-}" == "1" ]]; then
-    echo "  DHARMA_SKIP_SEMGREP=1 — skipping (operator-acknowledged)" >&2
-    exit 0
-  fi
   exit 1
 fi
 

--- a/scripts/governance/run_semgrep_with_ca.sh
+++ b/scripts/governance/run_semgrep_with_ca.sh
@@ -78,4 +78,15 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+if ! command -v semgrep &>/dev/null; then
+  echo "SEMGREP NOT INSTALLED — gate status: NOT RUN" >&2
+  echo "  Install: pip install semgrep  (or brew install semgrep)" >&2
+  echo "  To skip explicitly: DHARMA_SKIP_SEMGREP=1 git commit ..." >&2
+  if [[ "${DHARMA_SKIP_SEMGREP:-}" == "1" ]]; then
+    echo "  DHARMA_SKIP_SEMGREP=1 — skipping (operator-acknowledged)" >&2
+    exit 0
+  fi
+  exit 1
+fi
+
 exec semgrep "${args[@]}"

--- a/scripts/uplift_guards/mismatch_registry.py
+++ b/scripts/uplift_guards/mismatch_registry.py
@@ -2,11 +2,11 @@
 
 Reads docs/interface_mismatches.yaml — the machine-readable form of
 INTERFACE_MISMATCH_MAP.md — and exposes a check that fails the commit
-when a staged change touches a caller/callee pair flagged BLOCKER or
-DEGRADED with status=open.
+when a staged change touches a caller/callee pair flagged BLOCKER with
+status=open.
 
 This is the doc→code coupling: an entry can move from `open` to
-`resolved` only when its xfail test in tests/mismatches/ flips to pass.
+`resolved` only when its pinned regression test passes.
 """
 from __future__ import annotations
 
@@ -21,6 +21,17 @@ except ImportError:  # pragma: no cover - PyYAML is a project dep already
     yaml = None  # type: ignore
 
 REGISTRY_REL_PATH = "docs/interface_mismatches.yaml"
+
+
+def _local_path_candidates(ref: str) -> set[str]:
+    """Return repo path candidates for a mismatch caller/callee reference."""
+    base = ref.split(":", 1)[0] if ":" in ref else ref
+    candidates = {base}
+    if "/" not in base and base.startswith("dharma_swarm."):
+        parts = base.split(".")
+        for end in range(len(parts), 1, -1):
+            candidates.add("/".join(parts[:end]) + ".py")
+    return candidates
 
 
 @dataclass(frozen=True)
@@ -46,6 +57,10 @@ class Mismatch:
     def callee_path(self) -> str:
         return self.callee.split(":", 1)[0] if ":" in self.callee else self.callee
 
+    @property
+    def path_candidates(self) -> set[str]:
+        return _local_path_candidates(self.caller) | _local_path_candidates(self.callee)
+
 
 @dataclass
 class MismatchRegistry:
@@ -61,7 +76,7 @@ class MismatchRegistry:
         path_set = set(paths)
         hits: list[Mismatch] = []
         for m in self.entries:
-            if m.caller_path in path_set or m.callee_path in path_set:
+            if m.path_candidates & path_set:
                 hits.append(m)
         return hits
 
@@ -119,8 +134,8 @@ def check_mismatch_adjacency(
         return (
             False,
             f"MISMATCH REGISTRY MISSING: {REGISTRY_REL_PATH} does not exist.\n"
-            "  Create it from INTERFACE_MISMATCH_MAP.md or run:\n"
-            "    make mismatch-sync\n"
+            "  Restore it from git, or recreate it from INTERFACE_MISMATCH_MAP.md, then run:\n"
+            "    make mismatch-check\n"
             "  To skip: DHARMA_SKIP_MISMATCH_GUARD=1",
         )
     if yaml is None:
@@ -134,8 +149,8 @@ def check_mismatch_adjacency(
         return (
             False,
             f"MISMATCH REGISTRY EMPTY: {REGISTRY_REL_PATH} has no entries.\n"
-            "  Populate from INTERFACE_MISMATCH_MAP.md or run:\n"
-            "    make mismatch-sync",
+            "  Populate it from INTERFACE_MISMATCH_MAP.md, then run:\n"
+            "    make mismatch-check",
         )
 
     staged = _staged_files(repo_root)

--- a/scripts/uplift_guards/mismatch_registry.py
+++ b/scripts/uplift_guards/mismatch_registry.py
@@ -110,10 +110,33 @@ def check_mismatch_adjacency(
     repo_root: Path | None = None,
 ) -> tuple[bool, str]:
     """Refuse commits that touch a caller/callee in an open BLOCKER mismatch."""
+    import os
     repo_root = repo_root or Path.cwd()
+    if os.environ.get("DHARMA_SKIP_MISMATCH_GUARD", "").strip() == "1":
+        return True, "mismatch adjacency skipped by DHARMA_SKIP_MISMATCH_GUARD=1"
+    registry_path = repo_root / REGISTRY_REL_PATH
+    if not registry_path.exists():
+        return (
+            False,
+            f"MISMATCH REGISTRY MISSING: {REGISTRY_REL_PATH} does not exist.\n"
+            "  Create it from INTERFACE_MISMATCH_MAP.md or run:\n"
+            "    make mismatch-sync\n"
+            "  To skip: DHARMA_SKIP_MISMATCH_GUARD=1",
+        )
+    if yaml is None:
+        return (
+            False,
+            "MISMATCH REGISTRY UNREADABLE: PyYAML not installed.\n"
+            "  Install: pip install pyyaml",
+        )
     registry = load_mismatch_registry(repo_root)
     if not registry.entries:
-        return True, "mismatch registry empty or unreadable — skipping"
+        return (
+            False,
+            f"MISMATCH REGISTRY EMPTY: {REGISTRY_REL_PATH} has no entries.\n"
+            "  Populate from INTERFACE_MISMATCH_MAP.md or run:\n"
+            "    make mismatch-sync",
+        )
 
     staged = _staged_files(repo_root)
     if not staged:

--- a/scripts/uplift_guards/run_pre_commit.py
+++ b/scripts/uplift_guards/run_pre_commit.py
@@ -26,8 +26,16 @@ def check_assurance_diff(repo_root: Path) -> tuple[bool, str]:
     if os.environ.get("DHARMA_SKIP_ASSURANCE_GUARD", "").strip() == "1":
         return True, "assurance diff guard skipped by DHARMA_SKIP_ASSURANCE_GUARD=1"
 
-    from dharma_swarm.assurance.runner import run_assurance
-    from dharma_swarm.assurance.scanner_test_gaps import _git_changed_files
+    try:
+        from dharma_swarm.assurance.runner import run_assurance
+        from dharma_swarm.assurance.scanner_test_gaps import _git_changed_files
+    except ImportError as exc:
+        return (
+            False,
+            f"ASSURANCE DIFF GUARD: dependency not available: {exc}\n"
+            "  Install: pip install -e '.[dev]'\n"
+            "  To skip: DHARMA_SKIP_ASSURANCE_GUARD=1",
+        )
 
     changed_files = _git_changed_files(repo_root)
     if not changed_files:

--- a/tests/test_mismatch_blockers.py
+++ b/tests/test_mismatch_blockers.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import ast
 import inspect
-import textwrap
 from pathlib import Path
 
 import yaml
@@ -33,7 +32,7 @@ def test_registry_loads_and_is_nonempty() -> None:
 
 
 def test_registry_yaml_markdown_count_agree() -> None:
-    """Number of entries in YAML must match the summary table in markdown."""
+    """Entry IDs in YAML must match the summary table and sections in markdown."""
     registry_path = REPO_ROOT / "docs" / "interface_mismatches.yaml"
     data = yaml.safe_load(registry_path.read_text())
     yaml_ids = {e["id"] for e in data["entries"]}
@@ -82,6 +81,14 @@ def test_resolved_entries_have_fixed_in() -> None:
 # ── MM-02: PersistentAgent enum wrapping (RESOLVED) ──────────────
 
 
+def _call_name(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return ""
+
+
 def test_mm02_persistent_agent_enum() -> None:
     """Replication-path PersistentAgent() must wrap role in AgentRole().
 
@@ -96,6 +103,7 @@ def test_mm02_persistent_agent_enum() -> None:
     tree = ast.parse(src)
 
     # Find PersistentAgent(...) calls that use outcome.child_spec (replication path)
+    replication_calls: list[ast.Call] = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
             continue
@@ -107,12 +115,30 @@ def test_mm02_persistent_agent_enum() -> None:
             )
             if not uses_child_spec:
                 continue  # conductor-configs path — already enum
-            for kw in node.keywords:
-                if kw.arg == "role":
-                    assert isinstance(kw.value, ast.Call), (
-                        f"PersistentAgent(role=...) at line {node.lineno}: "
-                        "role must be wrapped in AgentRole(), not a bare value"
-                    )
+            replication_calls.append(node)
+
+    assert replication_calls, "No PersistentAgent child_spec replication call found"
+    for node in replication_calls:
+        keywords = {kw.arg: kw.value for kw in node.keywords}
+        role = keywords.get("role")
+        assert isinstance(role, ast.Call), (
+            f"PersistentAgent(role=...) at line {node.lineno}: "
+            "role must be wrapped in AgentRole(), not a bare value"
+        )
+        assert _call_name(role.func) == "AgentRole", (
+            f"PersistentAgent(role=...) at line {node.lineno}: "
+            "role must specifically use AgentRole(...)"
+        )
+
+        provider_type = keywords.get("provider_type")
+        assert isinstance(provider_type, ast.Call), (
+            f"PersistentAgent(provider_type=...) at line {node.lineno}: "
+            "provider_type must be wrapped in ProviderType/PT(), not a bare value"
+        )
+        assert _call_name(provider_type.func) in {"PT", "ProviderType"}, (
+            f"PersistentAgent(provider_type=...) at line {node.lineno}: "
+            "provider_type must specifically use ProviderType/PT(...)"
+        )
 
 
 # ── NEW-03: TelicSeam constructor kwarg (RESOLVED) ───────────────
@@ -192,6 +218,15 @@ def test_mm07_meta_evolution_cadence() -> None:
 # ── MM-17: gnani_lodestone → TaskBoard.get_by_title (OPEN/DEGRADED) ──
 
 
+def _registry_entry(entry_id: str) -> dict:
+    registry_path = REPO_ROOT / "docs" / "interface_mismatches.yaml"
+    data = yaml.safe_load(registry_path.read_text())
+    for entry in data["entries"]:
+        if entry["id"] == entry_id:
+            return entry
+    raise AssertionError(f"{entry_id} missing from interface mismatch registry")
+
+
 def test_mm17_gnani_task_board() -> None:
     """TaskBoard has no get_by_title method — gnani_lodestone.py will crash.
 
@@ -200,14 +235,19 @@ def test_mm17_gnani_task_board() -> None:
     """
     from dharma_swarm.task_board import TaskBoard
 
+    entry = _registry_entry("MM-17")
     has_method = hasattr(TaskBoard, "get_by_title")
-    if not has_method:
-        # Expected: method missing. Document the mismatch.
-        src = (REPO_ROOT / "dharma_swarm" / "gnani_lodestone.py").read_text()
-        assert "get_by_title" in src, (
-            "gnani_lodestone.py no longer calls get_by_title — remove MM-17"
+    src = (REPO_ROOT / "dharma_swarm" / "gnani_lodestone.py").read_text()
+    still_calls_missing_method = "get_by_title" in src
+    if entry["status"] == "open":
+        assert not has_method, "TaskBoard.get_by_title exists — mark MM-17 resolved"
+        assert still_calls_missing_method, (
+            "gnani_lodestone.py no longer calls get_by_title — mark MM-17 resolved"
         )
-    # If method exists, the mismatch is resolved — test passes either way
+    else:
+        assert has_method or not still_calls_missing_method, (
+            "MM-17 is resolved, but gnani_lodestone.py still calls missing get_by_title"
+        )
 
 
 # ── MM-18: gnani_lodestone → TelosGraph.get_by_name (OPEN/DEGRADED) ──
@@ -221,14 +261,19 @@ def test_mm18_gnani_telos_graph() -> None:
     """
     from dharma_swarm.telos_graph import TelosGraph
 
+    entry = _registry_entry("MM-18")
     has_method = hasattr(TelosGraph, "get_by_name")
-    if not has_method:
-        # Expected: method missing. Document the mismatch.
-        src = (REPO_ROOT / "dharma_swarm" / "gnani_lodestone.py").read_text()
-        assert "get_by_name" in src, (
-            "gnani_lodestone.py no longer calls get_by_name — remove MM-18"
+    src = (REPO_ROOT / "dharma_swarm" / "gnani_lodestone.py").read_text()
+    still_calls_missing_method = "get_by_name" in src
+    if entry["status"] == "open":
+        assert not has_method, "TelosGraph.get_by_name exists — mark MM-18 resolved"
+        assert still_calls_missing_method, (
+            "gnani_lodestone.py no longer calls get_by_name — mark MM-18 resolved"
         )
-    # If method exists, the mismatch is resolved — test passes either way
+    else:
+        assert has_method or not still_calls_missing_method, (
+            "MM-18 is resolved, but gnani_lodestone.py still calls missing get_by_name"
+        )
 
 
 # ── Mismatch Registry Guard ──────────────────────────────────────
@@ -247,3 +292,24 @@ def test_mismatch_registry_guard_loads() -> None:
         f"Expected 0 open BLOCKERs, found {len(open_blockers)}: "
         f"{[m.id for m in open_blockers]}"
     )
+
+
+def test_mismatch_registry_matches_dotted_callee_paths() -> None:
+    """Dotted callee refs should match concrete repo file paths."""
+    from scripts.uplift_guards.mismatch_registry import Mismatch, MismatchRegistry
+
+    registry = MismatchRegistry(
+        entries=[
+            Mismatch(
+                id="NEW-03",
+                severity="BLOCKER",
+                status="resolved",
+                caller="dharma_swarm/orchestrator.py:154",
+                callee="dharma_swarm.telic_seam.TelicSeam.__init__",
+                summary="constructor kwarg mismatch",
+            )
+        ]
+    )
+
+    matches = registry.matching_paths(["dharma_swarm/telic_seam.py"])
+    assert [m.id for m in matches] == ["NEW-03"]

--- a/tests/test_mismatch_blockers.py
+++ b/tests/test_mismatch_blockers.py
@@ -1,0 +1,249 @@
+"""Pinning tests for interface mismatches documented in docs/interface_mismatches.yaml.
+
+Each test corresponds to a YAML entry. A resolved mismatch has a test that
+would fail if the fix were reverted. An open mismatch has a test that
+documents the current (broken) state.
+
+Run:
+    python -m pytest tests/test_mismatch_blockers.py -v
+"""
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+# ── Registry integrity ────────────────────────────────────────────
+
+
+def test_registry_loads_and_is_nonempty() -> None:
+    """docs/interface_mismatches.yaml must exist and parse with entries."""
+    registry_path = REPO_ROOT / "docs" / "interface_mismatches.yaml"
+    assert registry_path.exists(), f"{registry_path} does not exist"
+    data = yaml.safe_load(registry_path.read_text())
+    assert isinstance(data, dict), "YAML root must be a mapping"
+    entries = data.get("entries", [])
+    assert len(entries) > 0, "Registry has no entries"
+
+
+def test_registry_yaml_markdown_count_agree() -> None:
+    """Number of entries in YAML must match the summary table in markdown."""
+    registry_path = REPO_ROOT / "docs" / "interface_mismatches.yaml"
+    data = yaml.safe_load(registry_path.read_text())
+    yaml_ids = {e["id"] for e in data["entries"]}
+
+    md_path = REPO_ROOT / "INTERFACE_MISMATCH_MAP.md"
+    md_text = md_path.read_text()
+    import re
+    md_ids: set[str] = set()
+    for line in md_text.splitlines():
+        # Match summary table rows "| MM-01: ..." or "| NEW-01: ..."
+        m = re.match(r"\|\s*((?:MM-\d+(?:/\d+)?)|(?:NEW-\d+)):", line)
+        if m:
+            raw = m.group(1)
+            if "/" in raw:
+                raw = raw.split("/")[0]
+            md_ids.add(raw)
+        # Match detailed section headers "### MM-XX"
+        m2 = re.match(r"###\s+(MM-\d+(?:/\d+)?|NEW-\d+)\s", line)
+        if m2:
+            raw = m2.group(1)
+            if "/" in raw:
+                raw = raw.split("/")[0]
+            md_ids.add(raw)
+
+    missing_in_yaml = md_ids - yaml_ids
+    missing_in_md = yaml_ids - md_ids
+    assert not missing_in_yaml, (
+        f"IDs in markdown but not YAML: {missing_in_yaml}"
+    )
+    assert not missing_in_md, (
+        f"IDs in YAML but not markdown: {missing_in_md}"
+    )
+
+
+def test_resolved_entries_have_fixed_in() -> None:
+    """Every resolved entry must have a non-empty fixed_in field."""
+    registry_path = REPO_ROOT / "docs" / "interface_mismatches.yaml"
+    data = yaml.safe_load(registry_path.read_text())
+    for entry in data["entries"]:
+        if entry["status"] == "resolved":
+            assert entry.get("fixed_in", "").strip(), (
+                f"{entry['id']} is resolved but has no fixed_in"
+            )
+
+
+# ── MM-02: PersistentAgent enum wrapping (RESOLVED) ──────────────
+
+
+def test_mm02_persistent_agent_enum() -> None:
+    """Replication-path PersistentAgent() must wrap role in AgentRole().
+
+    Regression test: without AgentRole() wrapping, PersistentAgent would
+    receive a bare string and crash on enum validation.
+
+    The conductor-configs path (line ~1471) uses pre-constructed enum
+    values from CONDUCTOR_CONFIGS (cfg["role"] is already AgentRole.CONDUCTOR),
+    so that call site is exempt.
+    """
+    src = (REPO_ROOT / "dharma_swarm" / "orchestrate_live.py").read_text()
+    tree = ast.parse(src)
+
+    # Find PersistentAgent(...) calls that use outcome.child_spec (replication path)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Name) and func.id == "PersistentAgent":
+            # Check if this call uses child_spec (replication path)
+            uses_child_spec = any(
+                "child_spec" in ast.dump(kw.value) for kw in node.keywords
+            )
+            if not uses_child_spec:
+                continue  # conductor-configs path — already enum
+            for kw in node.keywords:
+                if kw.arg == "role":
+                    assert isinstance(kw.value, ast.Call), (
+                        f"PersistentAgent(role=...) at line {node.lineno}: "
+                        "role must be wrapped in AgentRole(), not a bare value"
+                    )
+
+
+# ── NEW-03: TelicSeam constructor kwarg (RESOLVED) ───────────────
+
+
+def test_new03_telic_seam_constructor() -> None:
+    """orchestrator.py must call TelicSeam(path=...), not TelicSeam(registry_path=...).
+
+    Regression test: TelicSeam.__init__ accepts `path=`, not `registry_path=`.
+    """
+    from dharma_swarm.telic_seam import TelicSeam
+
+    sig = inspect.signature(TelicSeam.__init__)
+    params = list(sig.parameters.keys())
+    assert "path" in params, "TelicSeam.__init__ must accept 'path' parameter"
+    assert "registry_path" not in params, (
+        "TelicSeam.__init__ must NOT accept 'registry_path'"
+    )
+
+    # Verify orchestrator.py uses the correct kwarg
+    src = (REPO_ROOT / "dharma_swarm" / "orchestrator.py").read_text()
+    assert "registry_path=" not in src, (
+        "orchestrator.py still uses registry_path= (should be path=)"
+    )
+    assert "TelicSeam(registry=registry, path=" in src, (
+        "orchestrator.py must call TelicSeam(registry=..., path=...)"
+    )
+
+
+# ── MM-05: Private Orchestrator method coupling (OPEN/DEGRADED) ──
+
+
+def test_mm05_orchestrator_private_methods() -> None:
+    """Document that swarm.py couples to private Orchestrator methods.
+
+    This test PASSES to document the current (broken) state — the private
+    methods exist on Orchestrator, so the code doesn't crash. But the
+    coupling is fragile. When Orchestrator exposes a public retry API,
+    update this test.
+    """
+    from dharma_swarm.orchestrator import Orchestrator
+
+    # These private methods exist — the coupling works at runtime
+    assert hasattr(Orchestrator, "_classify_failure"), (
+        "Orchestrator._classify_failure removed — swarm.py:1978 will crash"
+    )
+    assert hasattr(Orchestrator, "_resolve_retry_policy"), (
+        "Orchestrator._resolve_retry_policy removed — swarm.py:1986 will crash"
+    )
+    assert hasattr(Orchestrator, "_apply_failure_retry_defaults"), (
+        "Orchestrator._apply_failure_retry_defaults removed — swarm.py:1987 will crash"
+    )
+
+    # Verify swarm.py still references them
+    src = (REPO_ROOT / "dharma_swarm" / "swarm.py").read_text()
+    assert "_classify_failure" in src, "swarm.py no longer references _classify_failure"
+    assert "_resolve_retry_policy" in src, "swarm.py no longer references _resolve_retry_policy"
+
+
+# ── MM-07: MetaEvolutionEngine cadence (OPEN/DEGRADED) ───────────
+
+
+def test_mm07_meta_evolution_cadence() -> None:
+    """Document that observe_cycle_result is called multiple times per cycle.
+
+    This test counts call sites in orchestrate_live.py. When the cadence
+    fix lands (single call per cycle), update the expected count.
+    """
+    src = (REPO_ROOT / "dharma_swarm" / "orchestrate_live.py").read_text()
+    count = src.count("observe_cycle_result(")
+    assert count >= 2, (
+        f"Expected >=2 observe_cycle_result calls, found {count}. "
+        "If this is 1, the cadence fix may have landed — update MM-07 status."
+    )
+
+
+# ── MM-17: gnani_lodestone → TaskBoard.get_by_title (OPEN/DEGRADED) ──
+
+
+def test_mm17_gnani_task_board() -> None:
+    """TaskBoard has no get_by_title method — gnani_lodestone.py will crash.
+
+    When a get_by_title (or equivalent) is added, update this test and
+    mark MM-17 as resolved.
+    """
+    from dharma_swarm.task_board import TaskBoard
+
+    has_method = hasattr(TaskBoard, "get_by_title")
+    if not has_method:
+        # Expected: method missing. Document the mismatch.
+        src = (REPO_ROOT / "dharma_swarm" / "gnani_lodestone.py").read_text()
+        assert "get_by_title" in src, (
+            "gnani_lodestone.py no longer calls get_by_title — remove MM-17"
+        )
+    # If method exists, the mismatch is resolved — test passes either way
+
+
+# ── MM-18: gnani_lodestone → TelosGraph.get_by_name (OPEN/DEGRADED) ──
+
+
+def test_mm18_gnani_telos_graph() -> None:
+    """TelosGraph has no get_by_name method — gnani_lodestone.py will crash.
+
+    When a get_by_name (or equivalent) is added, update this test and
+    mark MM-18 as resolved.
+    """
+    from dharma_swarm.telos_graph import TelosGraph
+
+    has_method = hasattr(TelosGraph, "get_by_name")
+    if not has_method:
+        # Expected: method missing. Document the mismatch.
+        src = (REPO_ROOT / "dharma_swarm" / "gnani_lodestone.py").read_text()
+        assert "get_by_name" in src, (
+            "gnani_lodestone.py no longer calls get_by_name — remove MM-18"
+        )
+    # If method exists, the mismatch is resolved — test passes either way
+
+
+# ── Mismatch Registry Guard ──────────────────────────────────────
+
+
+def test_mismatch_registry_guard_loads() -> None:
+    """scripts/uplift_guards/mismatch_registry.py loads YAML correctly."""
+    from scripts.uplift_guards.mismatch_registry import load_mismatch_registry
+
+    registry = load_mismatch_registry(REPO_ROOT)
+    assert len(registry.entries) > 0, "Registry loaded 0 entries from YAML"
+    # Verify open blockers
+    open_blockers = registry.open_blockers()
+    # MM-02 is now resolved — no open blockers expected
+    assert len(open_blockers) == 0, (
+        f"Expected 0 open BLOCKERs, found {len(open_blockers)}: "
+        f"{[m.id for m in open_blockers]}"
+    )

--- a/tests/test_mismatch_blockers.py
+++ b/tests/test_mismatch_blockers.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 
 import ast
 import inspect
+import os
+import subprocess
 from pathlib import Path
 
 import yaml
@@ -294,6 +296,38 @@ def test_mismatch_registry_guard_loads() -> None:
     )
 
 
+def test_mismatch_registry_missing_is_fail_closed_with_valid_remediation(
+    tmp_path: Path,
+) -> None:
+    """Missing registry diagnostics must not point at nonexistent Make targets."""
+    from scripts.uplift_guards.mismatch_registry import check_mismatch_adjacency
+
+    ok, message = check_mismatch_adjacency(tmp_path)
+
+    assert not ok
+    assert "MISMATCH REGISTRY MISSING" in message
+    assert "make mismatch-check" in message
+    assert "mismatch-sync" not in message
+
+
+def test_mismatch_registry_empty_is_fail_closed_with_valid_remediation(
+    tmp_path: Path,
+) -> None:
+    """Empty registry diagnostics must not point at nonexistent Make targets."""
+    from scripts.uplift_guards.mismatch_registry import check_mismatch_adjacency
+
+    registry_path = tmp_path / "docs" / "interface_mismatches.yaml"
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text("entries: []\n")
+
+    ok, message = check_mismatch_adjacency(tmp_path)
+
+    assert not ok
+    assert "MISMATCH REGISTRY EMPTY" in message
+    assert "make mismatch-check" in message
+    assert "mismatch-sync" not in message
+
+
 def test_mismatch_registry_matches_dotted_callee_paths() -> None:
     """Dotted callee refs should match concrete repo file paths."""
     from scripts.uplift_guards.mismatch_registry import Mismatch, MismatchRegistry
@@ -313,3 +347,24 @@ def test_mismatch_registry_matches_dotted_callee_paths() -> None:
 
     matches = registry.matching_paths(["dharma_swarm/telic_seam.py"])
     assert [m.id for m in matches] == ["NEW-03"]
+
+
+def test_semgrep_skip_env_exits_before_invoking_semgrep() -> None:
+    """DHARMA_SKIP_SEMGREP=1 must skip even when semgrep is installed."""
+    env = {**os.environ, "DHARMA_SKIP_SEMGREP": "1"}
+    result = subprocess.run(
+        [
+            "bash",
+            "scripts/governance/run_semgrep_with_ca.sh",
+            "--version",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "SEMGREP SKIPPED" in result.stderr
+    assert result.stdout == ""


### PR DESCRIPTION
Follow-up to #69.

Hardens the governance fixes by:
- making `DHARMA_SKIP_SEMGREP=1` skip before invoking semgrep
- removing nonexistent `make mismatch-sync` remediation
- matching dotted mismatch callees to concrete repo paths
- tightening MM-02 regression coverage for `AgentRole(...)` and `PT(...)`
- pinning missing/empty registry remediation behavior in tests

Depends on #69 / includes #69 head as parent.

Local validation:
- `pytest -q tests/test_mismatch_blockers.py` -> 14 passed
- `make mismatch-check PYTHON=/Users/dhyana/dharma_swarm/.venv/bin/python` -> pass
- `make mismatch-tests PYTHON=/Users/dhyana/dharma_swarm/.venv/bin/python` -> pass
- `pre-commit run semgrep-local --all-files` -> pass
- `pre-commit run --all-files` -> pass
- `make governance-all PYTHON=/Users/dhyana/dharma_swarm/.venv/bin/python` -> pass
- `git diff --check` -> pass

Notes:
- `make governance-all` still prints existing Semgrep exclude-pattern warnings and timeout warnings on large files, but exits green with 0 findings.
- `python -m ruff` was not run because ruff is not installed in the shared repo venv.