### PR TITLE
[codex] run fourfold warrant on PR diffs

### DIFF
--- a/.github/workflows/fourfold-warrant.yml
+++ b/.github/workflows/fourfold-warrant.yml
@@ -1,0 +1,83 @@
+name: fourfold-warrant
+
+on:
+  pull_request:
+    branches: [main, "promote/**", "governance/**", "codex/**"]
+
+concurrency:
+  group: fourfold-warrant-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  fourfold-warrant:
+    name: Fourfold Shakti Warrant
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    steps:
+      - name: Checkout full history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install package
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run Fourfold Shakti Warrant on PR diff
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          WARRANT_INTENT: >-
+            CI PR diff fourfold governance warrant for system telos, semantic
+            architecture, bounded change, deterministic evidence, exact paths,
+            and verification
+        run: |
+          mkdir -p reports/governance
+          impact_checked=false
+          if [[ "$PR_TITLE" == *"[impact-checked]"* || "$PR_BODY" == *"[impact-checked]"* ]]; then
+            impact_checked=true
+          fi
+          set +e
+          python3 scripts/governance/check_shakti_warrant.py \
+            --intent "$WARRANT_INTENT" \
+            --diff-scope base \
+            --base-ref "${{ github.event.pull_request.base.sha }}" \
+            --no-include-untracked \
+            --pass-on-empty-diff \
+            --max-diff-chars 20000 \
+            --tool "pytest" \
+            --metadata allowed_tools=pytest \
+            --metadata requires_diff_evidence=true \
+            --metadata enforce_hotpath_ack=true \
+            --metadata impact_checked="${impact_checked}" \
+            --fail-on block \
+            --fail-on hold \
+            --report-output reports/governance/fourfold-warrant.txt \
+            --json-output reports/governance/fourfold-warrant.json
+          status=$?
+          {
+            echo "## Fourfold Shakti Warrant"
+            echo
+            echo '```text'
+            cat reports/governance/fourfold-warrant.txt 2>/dev/null || true
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit "$status"
+
+      - name: Upload warrant artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fourfold-warrant
+          path: reports/governance/fourfold-warrant.*
+          if-no-files-found: ignore

--- a/docs/governance/CI_GATES.md
+++ b/docs/governance/CI_GATES.md
@@ -4,6 +4,7 @@ Phase 2 of the governance install adds three GitHub Actions workflows:
 
 | Workflow | File | Triggers | Hard-fail? |
 |---|---|---|---|
+| Fourfold Shakti Warrant | `.github/workflows/fourfold-warrant.yml` | PRs to main/promote/governance/codex | Yes on BLOCK/HOLD; WARN is surfaced but non-blocking |
 | CodeQL | `.github/workflows/codeql.yml` | PRs to main/promote/governance, weekly schedule | No (observe-only first 2 weeks) |
 | Semgrep | `.github/workflows/semgrep.yml` | PRs, push to main, weekly schedule | Yes on local `.semgrep/` ERRORs; advisory on registry packs |
 | Gitleaks | `.github/workflows/gitleaks.yml` | Push and PR | Yes on any finding |
@@ -18,6 +19,18 @@ Python. Findings go to the **Security** tab (Code scanning alerts).
 We do **not** fail the build on findings during the first observation
 window; ratchet to fail-on-high in a follow-up PR after triaging the
 baseline.
+
+### Fourfold Shakti Warrant
+Runs `scripts/governance/check_shakti_warrant.py` against the PR diff using
+`--diff-scope base` and the pull request base SHA. The check hard-fails on
+BLOCK or HOLD verdicts and allows WARN so teams can see weak evidence without
+turning every thin dimension into a merge blocker.
+
+The workflow writes both text and JSON warrant artifacts under
+`reports/governance/fourfold-warrant.*` and appends the text report to the
+GitHub Step Summary. Hot-path diffs require explicit impact acknowledgement:
+include `[impact-checked]` in the PR title or body when the blast radius has
+actually been reviewed.
 
 ### Semgrep
 Two modes:
@@ -47,6 +60,7 @@ add status badges to `README.md`:
 [![codeql](https://github.com/AmitabhainArunachala/dharma_swarm/actions/workflows/codeql.yml/badge.svg)](https://github.com/AmitabhainArunachala/dharma_swarm/actions/workflows/codeql.yml)
 [![semgrep](https://github.com/AmitabhainArunachala/dharma_swarm/actions/workflows/semgrep.yml/badge.svg)](https://github.com/AmitabhainArunachala/dharma_swarm/actions/workflows/semgrep.yml)
 [![gitleaks](https://github.com/AmitabhainArunachala/dharma_swarm/actions/workflows/gitleaks.yml/badge.svg)](https://github.com/AmitabhainArunachala/dharma_swarm/actions/workflows/gitleaks.yml)
+[![fourfold-warrant](https://github.com/AmitabhainArunachala/dharma_swarm/actions/workflows/fourfold-warrant.yml/badge.svg)](https://github.com/AmitabhainArunachala/dharma_swarm/actions/workflows/fourfold-warrant.yml)
 ```
 
 Defer badge additions until the workflows have run cleanly on `main`.

--- a/scripts/governance/check_shakti_warrant.py
+++ b/scripts/governance/check_shakti_warrant.py
@@ -224,6 +224,14 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--json", action="store_true", help="Emit JSON instead of text report.")
     parser.add_argument(
+        "--json-output",
+        help="Write JSON warrant payload to this path in addition to stdout output.",
+    )
+    parser.add_argument(
+        "--report-output",
+        help="Write text warrant report to this path in addition to stdout output.",
+    )
+    parser.add_argument(
         "--fail-on",
         choices=[item.value for item in WarrantVerdict],
         action="append",
@@ -275,10 +283,22 @@ def main(argv: list[str] | None = None) -> int:
         provenance=args.provenance,
     )
     warrant = evaluate_fourfold_warrant(request)
+    json_output = json.dumps(warrant.model_dump(mode="json"), indent=2, sort_keys=True)
+    report_output = render_warrant_report(warrant)
+
+    if args.json_output:
+        json_path = Path(args.json_output)
+        json_path.parent.mkdir(parents=True, exist_ok=True)
+        json_path.write_text(json_output + "\n", encoding="utf-8")
+    if args.report_output:
+        report_path = Path(args.report_output)
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(report_output + "\n", encoding="utf-8")
+
     if args.json:
-        print(json.dumps(warrant.model_dump(mode="json"), indent=2, sort_keys=True))
+        print(json_output)
     else:
-        print(render_warrant_report(warrant))
+        print(report_output)
 
     return 1 if warrant.verdict.value in set(args.fail_on) else 0
 

--- a/tests/test_shakti_warrant.py
+++ b/tests/test_shakti_warrant.py
@@ -487,3 +487,45 @@ def test_check_shakti_warrant_cli_honors_env_impact_ack_for_hot_paths(tmp_path):
 
     assert payload["verdict"] in {"allow", "warn"}
     assert not any("hot-path changes lack impact_checked" in item for item in payload["warnings"])
+
+
+def test_check_shakti_warrant_cli_writes_report_and_json_outputs(tmp_path):
+    report_path = tmp_path / "warrant.txt"
+    json_path = tmp_path / "warrant.json"
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(REPO_ROOT) + os.pathsep + env.get("PYTHONPATH", "")
+
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "scripts/governance/check_shakti_warrant.py"),
+            "--intent",
+            "restore canonical governance architecture",
+            "--content",
+            "fix blocker reduce fragmentation deterministic pytest evidence",
+            "--target",
+            "tests/test_shakti_warrant.py",
+            "--tool",
+            "pytest",
+            "--metadata",
+            "allowed_tools=pytest",
+            "--metadata",
+            "tests_planned=true",
+            "--report-output",
+            str(report_path),
+            "--json-output",
+            str(json_path),
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(json_path.read_text(encoding="utf-8"))
+
+    assert "Fourfold Shakti Warrant" in proc.stdout
+    assert "Fourfold Shakti Warrant" in report_path.read_text(encoding="utf-8")
+    assert payload["action_type"] == "proposed_action"
+    assert payload["target_paths"] == ["tests/test_shakti_warrant.py"]


### PR DESCRIPTION
## What changed

This PR adds CI enforcement for the Fourfold Shakti Warrant now that #81 has landed the local staged-diff warrant gate.

- Adds `.github/workflows/fourfold-warrant.yml`.
- Runs `scripts/governance/check_shakti_warrant.py` on pull request diffs with `--diff-scope base` and the PR base SHA.
- Fails CI on BLOCK or HOLD verdicts; WARN remains visible but non-blocking.
- Writes both text and JSON warrant artifacts under `reports/governance/fourfold-warrant.*`.
- Appends the text warrant report to the GitHub Step Summary.
- Lets hot-path PRs satisfy impact acknowledgement by including `[impact-checked]` in the PR title or body.
- Adds CLI output-file options: `--report-output` and `--json-output`.
- Updates `docs/governance/CI_GATES.md`.

## Why

#81 catches local staged commits. This catches bypasses: GitHub web edits, commits made without local hooks, force-pushed branches, and human/agent workflows that skip pre-commit locally.

## Validation

- `python3 -m py_compile dharma_swarm/shakti_warrant.py scripts/governance/check_shakti_warrant.py scripts/uplift_guards/shakti_warrant_guard.py scripts/uplift_guards/run_pre_commit.py`
- Parsed all `.github/workflows/*.yml` with PyYAML.
- `pytest -q tests/test_shakti_warrant.py` -> 16 passed after rebase onto the Semgrep-fixed warrant branch.
- `pytest -q tests/test_shakti.py tests/test_semantic_governance.py tests/test_shakti_warrant.py tests/test_dharma_kernel.py` -> 45 passed before the rebase.
- `env DHARMA_UPLIFT_ACK=impact-checked pre-commit run dharma-uplift-guards --hook-stage pre-commit` -> passed before the rebase.
- Full commit hooks passed during the original CI-gate commit.

## Review focus

Please review whether the CI acknowledgement rule (`[impact-checked]` in title/body) is acceptable as an explicit review marker, or whether this should require a stronger signal such as a checked PR label, approval from CODEOWNER, or uploaded impact report.

Supersedes draft PR #79, which remains draft because the connector draft-to-ready mutation is currently failing.