### PR TITLE
test: add coverage for 7 critical substrates

### DIFF
--- a/tests/test_algedonic_activation.py
+++ b/tests/test_algedonic_activation.py
@@ -1,0 +1,292 @@
+"""Tests for dharma_swarm.algedonic_activation — pain/pleasure bypass signals.
+
+Validates:
+- AlgedonicAction model construction
+- All five pain signal checkers with threshold boundaries
+- evaluate() aggregation of multiple signals
+- apply() logging and organism memory recording
+- recent_activations property
+- Non-fatal error handling in checkers
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from dharma_swarm.algedonic_activation import (
+    AlgedonicAction,
+    AlgedonicActivation,
+)
+
+
+def _make_pulse(**kwargs) -> SimpleNamespace:
+    """Build a pulse-like object with configurable attributes."""
+    defaults = {
+        "audit_failure_rate": 0.0,
+        "fleet_health": 1.0,
+        "identity_coherence": 1.0,
+        "anomalous_gate_patterns": 0,
+    }
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# AlgedonicAction model
+# ---------------------------------------------------------------------------
+
+
+class TestAlgedonicAction:
+    def test_construction(self):
+        action = AlgedonicAction(
+            signal_type="failure_rate",
+            severity="high",
+            description="Rate at 60%",
+            action="recalibrate_routing",
+        )
+        assert action.signal_type == "failure_rate"
+        assert action.severity == "high"
+        assert action.metadata == {}
+
+    def test_metadata_default_factory(self):
+        a1 = AlgedonicAction(signal_type="x", severity="low", description="d", action="a")
+        a2 = AlgedonicAction(signal_type="y", severity="low", description="d", action="a")
+        a1.metadata["key"] = "value"
+        assert "key" not in a2.metadata
+
+
+# ---------------------------------------------------------------------------
+# Individual pain signal checkers
+# ---------------------------------------------------------------------------
+
+
+class TestFailureRateChecker:
+    def test_below_threshold_no_action(self):
+        activation = AlgedonicActivation(organism=None)
+        pulse = _make_pulse(audit_failure_rate=0.3)
+        assert activation._check_failure_rate(pulse) is None
+
+    def test_at_threshold_no_action(self):
+        activation = AlgedonicActivation(organism=None)
+        pulse = _make_pulse(audit_failure_rate=0.5)
+        assert activation._check_failure_rate(pulse) is None
+
+    def test_above_threshold_triggers(self):
+        activation = AlgedonicActivation(organism=None)
+        pulse = _make_pulse(audit_failure_rate=0.7)
+        action = activation._check_failure_rate(pulse)
+        assert action is not None
+        assert action.signal_type == "failure_rate"
+        assert action.severity == "high"
+        assert action.action == "recalibrate_routing"
+
+    def test_missing_attribute_safe(self):
+        activation = AlgedonicActivation(organism=None)
+        pulse = SimpleNamespace()
+        assert activation._check_failure_rate(pulse) is None
+
+
+class TestOmegaDivergenceChecker:
+    def test_small_divergence_no_action(self):
+        activation = AlgedonicActivation(organism=None)
+        pulse = _make_pulse(fleet_health=0.8, identity_coherence=0.7)
+        assert activation._check_omega_divergence(pulse) is None
+
+    def test_at_threshold_no_action(self):
+        activation = AlgedonicActivation(organism=None)
+        pulse = _make_pulse(fleet_health=0.8, identity_coherence=0.4)
+        assert activation._check_omega_divergence(pulse) is None
+
+    def test_above_threshold_triggers(self):
+        activation = AlgedonicActivation(organism=None)
+        pulse = _make_pulse(fleet_health=0.9, identity_coherence=0.3)
+        action = activation._check_omega_divergence(pulse)
+        assert action is not None
+        assert action.signal_type == "omega_divergence"
+        assert action.action == "rebalance_priorities"
+        assert "lagging" in action.metadata
+
+    def test_identifies_lagging_subscore(self):
+        activation = AlgedonicActivation(organism=None)
+        pulse = _make_pulse(fleet_health=0.3, identity_coherence=0.9)
+        action = activation._check_omega_divergence(pulse)
+        assert action is not None
+        assert action.metadata["lagging"] == "fleet_health"
+
+
+class TestOntologicalDriftChecker:
+    def test_few_patterns_no_action(self):
+        activation = AlgedonicActivation(organism=None)
+        pulse = _make_pulse(anomalous_gate_patterns=3)
+        assert activation._check_ontological_drift(pulse) is None
+
+    def test_at_threshold_no_action(self):
+        activation = AlgedonicActivation(organism=None)
+        pulse = _make_pulse(anomalous_gate_patterns=5)
+        assert activation._check_ontological_drift(pulse) is None
+
+    def test_above_threshold_triggers(self):
+        activation = AlgedonicActivation(organism=None)
+        pulse = _make_pulse(anomalous_gate_patterns=10)
+        action = activation._check_ontological_drift(pulse)
+        assert action is not None
+        assert action.signal_type == "ontological_drift"
+        assert action.action == "enforce_glossary"
+
+
+class TestSelfModelGapChecker:
+    def test_no_organism_no_action(self):
+        activation = AlgedonicActivation(organism=None)
+        pulse = _make_pulse()
+        assert activation._check_self_model_gap(pulse) is None
+
+    def test_organism_without_memory_no_action(self):
+        organism = SimpleNamespace(memory=None)
+        activation = AlgedonicActivation(organism=organism)
+        pulse = _make_pulse()
+        assert activation._check_self_model_gap(pulse) is None
+
+    def test_high_accuracy_no_action(self):
+        memory = MagicMock()
+        memory.self_model_accuracy.return_value = 0.8
+        organism = SimpleNamespace(memory=memory)
+        activation = AlgedonicActivation(organism=organism)
+        pulse = _make_pulse()
+        assert activation._check_self_model_gap(pulse) is None
+
+    def test_low_accuracy_triggers(self):
+        memory = MagicMock()
+        memory.self_model_accuracy.return_value = 0.3
+        organism = SimpleNamespace(memory=memory)
+        activation = AlgedonicActivation(organism=organism)
+        pulse = _make_pulse()
+        action = activation._check_self_model_gap(pulse)
+        assert action is not None
+        assert action.signal_type == "self_model_gap"
+        assert action.action == "recalibrate_from_metrics"
+
+    def test_memory_exception_non_fatal(self):
+        memory = MagicMock()
+        memory.self_model_accuracy.side_effect = RuntimeError("boom")
+        organism = SimpleNamespace(memory=memory)
+        activation = AlgedonicActivation(organism=organism)
+        pulse = _make_pulse()
+        assert activation._check_self_model_gap(pulse) is None
+
+
+class TestTelosDriftChecker:
+    def test_healthy_coherence_no_action(self):
+        activation = AlgedonicActivation(organism=None)
+        pulse = _make_pulse(identity_coherence=0.8, fleet_health=0.9)
+        assert activation._check_telos_drift(pulse) is None
+
+    def test_low_coherence_low_fleet_no_action(self):
+        activation = AlgedonicActivation(organism=None)
+        pulse = _make_pulse(identity_coherence=0.3, fleet_health=0.3)
+        assert activation._check_telos_drift(pulse) is None
+
+    def test_low_coherence_healthy_fleet_triggers(self):
+        activation = AlgedonicActivation(organism=None)
+        pulse = _make_pulse(identity_coherence=0.2, fleet_health=0.8)
+        action = activation._check_telos_drift(pulse)
+        assert action is not None
+        assert action.signal_type == "telos_drift"
+        assert action.severity == "critical"
+        assert action.action == "gnani_checkpoint"
+
+
+# ---------------------------------------------------------------------------
+# evaluate() integration
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluate:
+    def test_healthy_pulse_no_actions(self):
+        activation = AlgedonicActivation(organism=None)
+        pulse = _make_pulse()
+        actions = activation.evaluate(pulse)
+        assert actions == []
+
+    def test_multiple_signals_aggregated(self):
+        activation = AlgedonicActivation(organism=None)
+        pulse = _make_pulse(
+            audit_failure_rate=0.8,
+            fleet_health=0.9,
+            identity_coherence=0.2,
+            anomalous_gate_patterns=10,
+        )
+        actions = activation.evaluate(pulse)
+        signal_types = {a.signal_type for a in actions}
+        assert "failure_rate" in signal_types
+        assert "ontological_drift" in signal_types
+
+    def test_checker_exception_non_fatal(self):
+        activation = AlgedonicActivation(organism=None)
+        pulse = "not a namespace"
+        actions = activation.evaluate(pulse)
+        assert isinstance(actions, list)
+
+
+# ---------------------------------------------------------------------------
+# apply() and logging
+# ---------------------------------------------------------------------------
+
+
+class TestApply:
+    def test_apply_logs_activation(self):
+        activation = AlgedonicActivation(organism=None)
+        action = AlgedonicAction(
+            signal_type="failure_rate",
+            severity="high",
+            description="Rate at 80%",
+            action="recalibrate_routing",
+        )
+        activation.apply(action)
+        assert len(activation.recent_activations) == 1
+        log = activation.recent_activations[0]
+        assert log["signal"] == "failure_rate"
+        assert log["severity"] == "high"
+        assert "timestamp" in log
+
+    def test_apply_records_to_organism_memory(self):
+        memory = MagicMock()
+        organism = SimpleNamespace(memory=memory)
+        activation = AlgedonicActivation(organism=organism)
+        action = AlgedonicAction(
+            signal_type="telos_drift",
+            severity="critical",
+            description="Drift detected",
+            action="gnani_checkpoint",
+        )
+        activation.apply(action)
+        memory.record_event.assert_called_once()
+        call_kwargs = memory.record_event.call_args
+        assert call_kwargs[1]["entity_type"] == "algedonic_event" or \
+               call_kwargs.kwargs.get("entity_type") == "algedonic_event"
+
+    def test_recent_activations_capped_at_20(self):
+        activation = AlgedonicActivation(organism=None)
+        for i in range(25):
+            action = AlgedonicAction(
+                signal_type="test",
+                severity="low",
+                description=f"Entry {i}",
+                action="noop",
+            )
+            activation.apply(action)
+        assert len(activation.recent_activations) == 20
+
+    def test_apply_with_no_memory_no_crash(self):
+        organism = SimpleNamespace(memory=None)
+        activation = AlgedonicActivation(organism=organism)
+        action = AlgedonicAction(
+            signal_type="test",
+            severity="low",
+            description="Test",
+            action="noop",
+        )
+        activation.apply(action)
+        assert len(activation.recent_activations) == 1

--- a/tests/test_certified_lanes.py
+++ b/tests/test_certified_lanes.py
@@ -1,0 +1,244 @@
+"""Tests for dharma_swarm.certified_lanes — certified operator lane registry.
+
+Validates:
+- CertifiedLane.matches_profile_id with exact and alias matching
+- CertifiedLane.matches_alias across all identity fields
+- CertifiedLane.matches_provider_model with default and alias models
+- get_certified_lane lookup by profile_id
+- match_certified_lane multi-strategy resolution
+- CERTIFIED_LANES tuple completeness
+- CERTIFIED_LANE_BY_PROFILE_ID dict correctness
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dharma_swarm.certified_lanes import (
+    CERTIFIED_LANE_BY_PROFILE_ID,
+    CERTIFIED_LANES,
+    CertifiedLane,
+    get_certified_lane,
+    match_certified_lane,
+)
+from dharma_swarm.models import ProviderType
+
+
+# ---------------------------------------------------------------------------
+# CERTIFIED_LANES data integrity
+# ---------------------------------------------------------------------------
+
+
+class TestCertifiedLanesData:
+    def test_lanes_not_empty(self):
+        assert len(CERTIFIED_LANES) > 0
+
+    def test_all_lanes_have_unique_profile_ids(self):
+        ids = [lane.profile_id for lane in CERTIFIED_LANES]
+        assert len(ids) == len(set(ids))
+
+    def test_all_lanes_have_unique_registration_ids(self):
+        ids = [lane.registration_id for lane in CERTIFIED_LANES]
+        assert len(ids) == len(set(ids))
+
+    def test_by_profile_id_dict_matches_tuple(self):
+        assert len(CERTIFIED_LANE_BY_PROFILE_ID) == len(CERTIFIED_LANES)
+        for lane in CERTIFIED_LANES:
+            assert CERTIFIED_LANE_BY_PROFILE_ID[lane.profile_id] is lane
+
+    def test_all_lanes_have_required_fields(self):
+        for lane in CERTIFIED_LANES:
+            assert lane.profile_id
+            assert lane.label
+            assert lane.summary
+            assert lane.registration_id
+            assert lane.codename
+            assert lane.display_name
+
+
+# ---------------------------------------------------------------------------
+# CertifiedLane.matches_profile_id
+# ---------------------------------------------------------------------------
+
+
+class TestMatchesProfileId:
+    def test_exact_match(self):
+        lane = CERTIFIED_LANES[0]
+        assert lane.matches_profile_id(lane.profile_id) is True
+
+    def test_case_insensitive(self):
+        lane = CERTIFIED_LANES[0]
+        assert lane.matches_profile_id(lane.profile_id.upper()) is True
+
+    def test_alias_match(self):
+        for lane in CERTIFIED_LANES:
+            if lane.aliases:
+                assert lane.matches_profile_id(lane.aliases[0]) is True
+
+    def test_none_returns_false(self):
+        lane = CERTIFIED_LANES[0]
+        assert lane.matches_profile_id(None) is False
+
+    def test_empty_string_returns_false(self):
+        lane = CERTIFIED_LANES[0]
+        assert lane.matches_profile_id("") is False
+
+    def test_no_match(self):
+        lane = CERTIFIED_LANES[0]
+        assert lane.matches_profile_id("nonexistent_profile") is False
+
+
+# ---------------------------------------------------------------------------
+# CertifiedLane.matches_alias
+# ---------------------------------------------------------------------------
+
+
+class TestMatchesAlias:
+    def test_matches_profile_id(self):
+        lane = CERTIFIED_LANES[0]
+        assert lane.matches_alias(lane.profile_id) is True
+
+    def test_matches_codename(self):
+        lane = CERTIFIED_LANES[0]
+        assert lane.matches_alias(lane.codename) is True
+
+    def test_matches_display_name(self):
+        lane = CERTIFIED_LANES[0]
+        assert lane.matches_alias(lane.display_name) is True
+
+    def test_matches_label(self):
+        lane = CERTIFIED_LANES[0]
+        assert lane.matches_alias(lane.label) is True
+
+    def test_matches_alias_entry(self):
+        for lane in CERTIFIED_LANES:
+            if lane.aliases:
+                assert lane.matches_alias(lane.aliases[0]) is True
+
+    def test_case_insensitive(self):
+        lane = CERTIFIED_LANES[0]
+        assert lane.matches_alias(lane.codename.upper()) is True
+
+    def test_none_returns_false(self):
+        assert CERTIFIED_LANES[0].matches_alias(None) is False
+
+    def test_empty_returns_false(self):
+        assert CERTIFIED_LANES[0].matches_alias("") is False
+
+    def test_no_match(self):
+        assert CERTIFIED_LANES[0].matches_alias("totally_unknown_alias") is False
+
+
+# ---------------------------------------------------------------------------
+# CertifiedLane.matches_provider_model
+# ---------------------------------------------------------------------------
+
+
+class TestMatchesProviderModel:
+    def test_default_model_match(self):
+        for lane in CERTIFIED_LANES:
+            for provider, model in lane.default_models.items():
+                assert lane.matches_provider_model(provider, model) is True
+
+    def test_model_alias_match(self):
+        for lane in CERTIFIED_LANES:
+            if lane.model_aliases:
+                for provider, aliases in lane.model_aliases.items():
+                    for alias in aliases:
+                        assert lane.matches_provider_model(provider, alias) is True
+
+    def test_wrong_model_no_match(self):
+        lane = CERTIFIED_LANES[0]
+        provider = list(lane.default_models.keys())[0]
+        assert lane.matches_provider_model(provider, "completely-wrong-model") is False
+
+    def test_wrong_provider_no_match(self):
+        lane = CERTIFIED_LANES[0]
+        model = list(lane.default_models.values())[0]
+        assert lane.matches_provider_model("nonexistent_provider", model) is False
+
+    def test_none_provider_returns_false(self):
+        lane = CERTIFIED_LANES[0]
+        assert lane.matches_provider_model(None, "some-model") is False
+
+    def test_none_model_returns_false(self):
+        lane = CERTIFIED_LANES[0]
+        provider = list(lane.default_models.keys())[0]
+        assert lane.matches_provider_model(provider, None) is False
+
+    def test_provider_as_string(self):
+        for lane in CERTIFIED_LANES:
+            for provider, model in lane.default_models.items():
+                assert lane.matches_provider_model(provider.value, model) is True
+
+
+# ---------------------------------------------------------------------------
+# get_certified_lane
+# ---------------------------------------------------------------------------
+
+
+class TestGetCertifiedLane:
+    def test_known_profile_id(self):
+        lane = CERTIFIED_LANES[0]
+        result = get_certified_lane(lane.profile_id)
+        assert result is lane
+
+    def test_alias_profile_id(self):
+        for lane in CERTIFIED_LANES:
+            if lane.aliases:
+                result = get_certified_lane(lane.aliases[0])
+                assert result is lane
+
+    def test_none_returns_none(self):
+        assert get_certified_lane(None) is None
+
+    def test_empty_returns_none(self):
+        assert get_certified_lane("") is None
+
+    def test_unknown_returns_none(self):
+        assert get_certified_lane("totally_unknown") is None
+
+
+# ---------------------------------------------------------------------------
+# match_certified_lane
+# ---------------------------------------------------------------------------
+
+
+class TestMatchCertifiedLane:
+    def test_by_profile_id(self):
+        lane = CERTIFIED_LANES[0]
+        result = match_certified_lane(profile_id=lane.profile_id)
+        assert result is lane
+
+    def test_by_alias(self):
+        lane = CERTIFIED_LANES[0]
+        result = match_certified_lane(alias=lane.codename)
+        assert result is lane
+
+    def test_by_provider_model(self):
+        lane = CERTIFIED_LANES[0]
+        provider = list(lane.default_models.keys())[0]
+        model = lane.default_models[provider]
+        result = match_certified_lane(provider=provider, model=model)
+        assert result is lane
+
+    def test_profile_id_takes_priority(self):
+        lane = CERTIFIED_LANES[0]
+        other = CERTIFIED_LANES[1] if len(CERTIFIED_LANES) > 1 else CERTIFIED_LANES[0]
+        result = match_certified_lane(
+            profile_id=lane.profile_id,
+            alias=other.codename,
+        )
+        assert result is lane
+
+    def test_no_match_returns_none(self):
+        result = match_certified_lane(
+            profile_id="unknown",
+            alias="unknown",
+            provider="unknown",
+            model="unknown",
+        )
+        assert result is None
+
+    def test_all_none_returns_none(self):
+        assert match_certified_lane() is None

--- a/tests/test_diversity_archive.py
+++ b/tests/test_diversity_archive.py
@@ -1,6 +1,19 @@
-"""Tests for dharma_swarm.diversity_archive -- MAP-Elites diversity grid."""
+"""Tests for dharma_swarm.diversity_archive — MAP-Elites quality-diversity archive.
+
+Validates:
+- BehaviorDescriptor validation
+- DiversityArchive bin computation, add/replace, diversity-aware sampling
+- Coverage and stats queries
+- best_per_dimension fallback logic
+- Serialization round-trip (to_dict / from_dict)
+- Async persistence (persist / load)
+"""
+
+from __future__ import annotations
 
 import json
+import math
+from pathlib import Path
 
 import pytest
 
@@ -12,196 +25,242 @@ from dharma_swarm.diversity_archive import (
 
 
 # ---------------------------------------------------------------------------
-# Helpers
+# BehaviorDescriptor
 # ---------------------------------------------------------------------------
 
 
-def _bd(**kwargs: float) -> BehaviorDescriptor:
-    """Shorthand for creating a BehaviorDescriptor."""
-    return BehaviorDescriptor(dimensions=kwargs)
+class TestBehaviorDescriptor:
+    def test_validate_dimensions_all_present_and_in_range(self):
+        bd = BehaviorDescriptor(dimensions={"speed": 0.5, "risk": 0.0, "cost": 1.0})
+        assert bd.validate_dimensions(["speed", "risk", "cost"]) is True
+
+    def test_validate_dimensions_missing_key(self):
+        bd = BehaviorDescriptor(dimensions={"speed": 0.5})
+        assert bd.validate_dimensions(["speed", "risk"]) is False
+
+    def test_validate_dimensions_out_of_range(self):
+        bd = BehaviorDescriptor(dimensions={"speed": 1.5})
+        assert bd.validate_dimensions(["speed"]) is False
+
+    def test_validate_dimensions_negative(self):
+        bd = BehaviorDescriptor(dimensions={"speed": -0.1})
+        assert bd.validate_dimensions(["speed"]) is False
+
+    def test_validate_dimensions_empty_expected(self):
+        bd = BehaviorDescriptor(dimensions={"speed": 0.5})
+        assert bd.validate_dimensions([]) is True
+
+    def test_validate_dimensions_boundary_values(self):
+        bd = BehaviorDescriptor(dimensions={"a": 0.0, "b": 1.0})
+        assert bd.validate_dimensions(["a", "b"]) is True
 
 
 # ---------------------------------------------------------------------------
-# Archive creation
+# DiversityArchive — init and validation
 # ---------------------------------------------------------------------------
 
 
-def test_create_archive():
-    archive = DiversityArchive(
-        dimensions=["speed", "risk"], bins_per_dimension=5, seed=42,
-    )
-    assert archive.dimensions == ["speed", "risk"]
-    assert archive.bins_per_dimension == 5
-    assert archive.coverage() == 0.0
+class TestDiversityArchiveInit:
+    def test_requires_at_least_one_dimension(self):
+        with pytest.raises(ValueError, match="At least one"):
+            DiversityArchive(dimensions=[])
 
+    def test_bins_per_dimension_minimum_two(self):
+        archive = DiversityArchive(dimensions=["x"], bins_per_dimension=1)
+        assert archive.bins_per_dimension == 2
 
-def test_create_archive_no_dimensions():
-    with pytest.raises(ValueError, match="At least one"):
-        DiversityArchive(dimensions=[])
+    def test_default_persist_path(self):
+        archive = DiversityArchive(dimensions=["x"])
+        assert "diversity_archive.json" in str(archive.persist_path)
 
-
-def test_create_archive_clamps_bins():
-    archive = DiversityArchive(dimensions=["x"], bins_per_dimension=1)
-    assert archive.bins_per_dimension >= 2
-
-
-# ---------------------------------------------------------------------------
-# add candidate
-# ---------------------------------------------------------------------------
-
-
-def test_add_candidate_to_empty_grid():
-    archive = DiversityArchive(
-        dimensions=["speed", "risk"], bins_per_dimension=5, seed=1,
-    )
-    inserted = archive.add(
-        candidate_id="c1",
-        candidate_payload={"code": "v1"},
-        fitness=0.8,
-        behavior=_bd(speed=0.5, risk=0.3),
-    )
-    assert inserted is True
-    assert archive.coverage() > 0.0
-
-
-def test_add_multiple_different_cells():
-    archive = DiversityArchive(
-        dimensions=["x", "y"], bins_per_dimension=5, seed=2,
-    )
-    archive.add("a", {}, 0.5, _bd(x=0.1, y=0.1))
-    archive.add("b", {}, 0.6, _bd(x=0.9, y=0.9))
-    assert archive.coverage() == pytest.approx(2.0 / 25.0)
+    def test_custom_persist_path(self, tmp_path):
+        p = tmp_path / "custom.json"
+        archive = DiversityArchive(dimensions=["x"], persist_path=p)
+        assert archive.persist_path == p
 
 
 # ---------------------------------------------------------------------------
-# Replacement on fitter
+# Bin computation
 # ---------------------------------------------------------------------------
 
 
-def test_replacement_on_fitter():
-    archive = DiversityArchive(
-        dimensions=["x"], bins_per_dimension=5, seed=3,
-    )
-    archive.add("weak", {}, 0.3, _bd(x=0.5))
-    archive.add("strong", {"upgraded": True}, 0.9, _bd(x=0.5))
+class TestBinComputation:
+    def test_to_bin_boundaries(self):
+        archive = DiversityArchive(dimensions=["x"], bins_per_dimension=5)
+        assert archive._to_bin(0.0) == 0
+        assert archive._to_bin(1.0) == 4  # clamped to max bin
+        assert archive._to_bin(0.5) == 2
 
-    cell = archive.get_cell(_bd(x=0.5))
-    assert cell is not None
-    assert cell.candidate_id == "strong"
-    assert cell.fitness == 0.9
-    assert cell.candidate_payload == {"upgraded": True}
+    def test_to_bin_clamps_negative(self):
+        archive = DiversityArchive(dimensions=["x"], bins_per_dimension=5)
+        assert archive._to_bin(-0.5) == 0
 
+    def test_to_bin_clamps_above_one(self):
+        archive = DiversityArchive(dimensions=["x"], bins_per_dimension=5)
+        assert archive._to_bin(1.5) == 4
 
-# ---------------------------------------------------------------------------
-# No replacement on weaker
-# ---------------------------------------------------------------------------
+    def test_descriptor_to_key_multi_dim(self):
+        archive = DiversityArchive(dimensions=["a", "b"], bins_per_dimension=4)
+        bd = BehaviorDescriptor(dimensions={"a": 0.0, "b": 1.0})
+        key = archive._descriptor_to_key(bd)
+        assert key == (0, 3)
 
-
-def test_no_replacement_on_weaker():
-    archive = DiversityArchive(
-        dimensions=["x"], bins_per_dimension=5, seed=4,
-    )
-    archive.add("strong", {}, 0.9, _bd(x=0.5))
-    replaced = archive.add("weak", {}, 0.2, _bd(x=0.5))
-
-    assert replaced is False
-    cell = archive.get_cell(_bd(x=0.5))
-    assert cell is not None
-    assert cell.candidate_id == "strong"
-
-
-def test_no_replacement_on_equal_fitness():
-    archive = DiversityArchive(
-        dimensions=["x"], bins_per_dimension=5, seed=5,
-    )
-    archive.add("first", {}, 0.5, _bd(x=0.5))
-    replaced = archive.add("second", {}, 0.5, _bd(x=0.5))
-    assert replaced is False
-    cell = archive.get_cell(_bd(x=0.5))
-    assert cell is not None
-    assert cell.candidate_id == "first"
+    def test_descriptor_to_key_missing_dim_defaults_zero(self):
+        archive = DiversityArchive(dimensions=["a", "b"], bins_per_dimension=4)
+        bd = BehaviorDescriptor(dimensions={"a": 0.5})
+        key = archive._descriptor_to_key(bd)
+        assert key[1] == 0  # missing "b" defaults to 0.0 → bin 0
 
 
 # ---------------------------------------------------------------------------
-# sample_diverse
+# Add / replace logic
 # ---------------------------------------------------------------------------
 
 
-def test_sample_diverse_empty():
-    archive = DiversityArchive(dimensions=["x", "y"], seed=6)
-    assert archive.sample_diverse(5) == []
+class TestAddReplace:
+    def test_add_to_empty_cell(self):
+        archive = DiversityArchive(dimensions=["x"], bins_per_dimension=5, seed=42)
+        bd = BehaviorDescriptor(dimensions={"x": 0.3})
+        inserted = archive.add("c1", {"data": "hello"}, 0.8, bd, generation=1)
+        assert inserted is True
+        cell = archive.get_cell(bd)
+        assert cell is not None
+        assert cell.candidate_id == "c1"
+        assert cell.fitness == 0.8
+        assert cell.generation == 1
 
+    def test_replace_with_higher_fitness(self):
+        archive = DiversityArchive(dimensions=["x"], bins_per_dimension=5, seed=42)
+        bd = BehaviorDescriptor(dimensions={"x": 0.3})
+        archive.add("c1", {}, 0.5, bd)
+        replaced = archive.add("c2", {}, 0.9, bd)
+        assert replaced is True
+        cell = archive.get_cell(bd)
+        assert cell is not None
+        assert cell.candidate_id == "c2"
 
-def test_sample_diverse_single_cell():
-    archive = DiversityArchive(dimensions=["x"], bins_per_dimension=5, seed=7)
-    archive.add("only", {}, 0.5, _bd(x=0.5))
-    result = archive.sample_diverse(3)
-    assert len(result) == 1
-    assert result[0].candidate_id == "only"
+    def test_no_replace_with_lower_fitness(self):
+        archive = DiversityArchive(dimensions=["x"], bins_per_dimension=5, seed=42)
+        bd = BehaviorDescriptor(dimensions={"x": 0.3})
+        archive.add("c1", {}, 0.9, bd)
+        replaced = archive.add("c2", {}, 0.5, bd)
+        assert replaced is False
+        cell = archive.get_cell(bd)
+        assert cell is not None
+        assert cell.candidate_id == "c1"
 
+    def test_no_replace_with_equal_fitness(self):
+        archive = DiversityArchive(dimensions=["x"], bins_per_dimension=5, seed=42)
+        bd = BehaviorDescriptor(dimensions={"x": 0.3})
+        archive.add("c1", {}, 0.7, bd)
+        replaced = archive.add("c2", {}, 0.7, bd)
+        assert replaced is False
 
-def test_sample_diverse_maximizes_spread():
-    archive = DiversityArchive(
-        dimensions=["x", "y"], bins_per_dimension=10, seed=8,
-    )
-    # Place candidates at corners and center
-    archive.add("corner_00", {}, 0.5, _bd(x=0.0, y=0.0))
-    archive.add("corner_01", {}, 0.5, _bd(x=0.0, y=0.99))
-    archive.add("corner_10", {}, 0.5, _bd(x=0.99, y=0.0))
-    archive.add("corner_11", {}, 0.5, _bd(x=0.99, y=0.99))
-    archive.add("center", {}, 0.9, _bd(x=0.5, y=0.5))  # Fittest
+    def test_different_bins_independent(self):
+        archive = DiversityArchive(dimensions=["x"], bins_per_dimension=5, seed=42)
+        bd1 = BehaviorDescriptor(dimensions={"x": 0.1})
+        bd2 = BehaviorDescriptor(dimensions={"x": 0.9})
+        archive.add("c1", {}, 0.5, bd1)
+        archive.add("c2", {}, 0.5, bd2)
+        assert archive.get_cell(bd1).candidate_id == "c1"
+        assert archive.get_cell(bd2).candidate_id == "c2"
 
-    # Sampling 3 should give the fittest + 2 farthest corners
-    result = archive.sample_diverse(3)
-    assert len(result) == 3
-    # The fittest (center) should be picked first
-    assert result[0].candidate_id == "center"
-    # The next two should be from opposite corners
-    ids = {r.candidate_id for r in result}
-    assert "center" in ids
-
-
-def test_sample_diverse_respects_n():
-    archive = DiversityArchive(
-        dimensions=["x"], bins_per_dimension=10, seed=9,
-    )
-    for i in range(8):
-        archive.add(f"c{i}", {}, 0.1 * (i + 1), _bd(x=i / 10.0))
-    result = archive.sample_diverse(3)
-    assert len(result) == 3
+    def test_get_cell_returns_none_for_empty(self):
+        archive = DiversityArchive(dimensions=["x"], bins_per_dimension=5)
+        bd = BehaviorDescriptor(dimensions={"x": 0.5})
+        assert archive.get_cell(bd) is None
 
 
 # ---------------------------------------------------------------------------
-# coverage
+# Diversity-aware sampling
 # ---------------------------------------------------------------------------
 
 
-def test_coverage_empty():
-    archive = DiversityArchive(dimensions=["a", "b"], bins_per_dimension=5)
-    assert archive.coverage() == 0.0
+class TestDiverseSampling:
+    def test_sample_empty_archive(self):
+        archive = DiversityArchive(dimensions=["x"], bins_per_dimension=5)
+        assert archive.sample_diverse(3) == []
+
+    def test_sample_more_than_available(self):
+        archive = DiversityArchive(dimensions=["x"], bins_per_dimension=5, seed=42)
+        bd = BehaviorDescriptor(dimensions={"x": 0.5})
+        archive.add("c1", {}, 0.8, bd)
+        result = archive.sample_diverse(10)
+        assert len(result) == 1
+
+    def test_sample_starts_with_fittest(self):
+        archive = DiversityArchive(dimensions=["x"], bins_per_dimension=10, seed=42)
+        archive.add("low", {}, 0.2, BehaviorDescriptor(dimensions={"x": 0.1}))
+        archive.add("high", {}, 0.9, BehaviorDescriptor(dimensions={"x": 0.5}))
+        archive.add("mid", {}, 0.5, BehaviorDescriptor(dimensions={"x": 0.9}))
+        result = archive.sample_diverse(3)
+        assert result[0].candidate_id == "high"
+
+    def test_sample_maximizes_spread(self):
+        archive = DiversityArchive(dimensions=["x"], bins_per_dimension=10, seed=42)
+        archive.add("a", {}, 0.5, BehaviorDescriptor(dimensions={"x": 0.0}))
+        archive.add("b", {}, 0.9, BehaviorDescriptor(dimensions={"x": 0.5}))
+        archive.add("c", {}, 0.5, BehaviorDescriptor(dimensions={"x": 1.0}))
+        result = archive.sample_diverse(3)
+        assert len(result) == 3
+        ids = {r.candidate_id for r in result}
+        assert ids == {"a", "b", "c"}
+
+    def test_sample_zero_returns_empty(self):
+        archive = DiversityArchive(dimensions=["x"], bins_per_dimension=5, seed=42)
+        archive.add("c1", {}, 0.5, BehaviorDescriptor(dimensions={"x": 0.5}))
+        assert archive.sample_diverse(0) == []
 
 
-def test_coverage_full_1d():
-    archive = DiversityArchive(
-        dimensions=["x"], bins_per_dimension=3, seed=10,
-    )
-    # Fill all 3 bins
-    archive.add("a", {}, 0.5, _bd(x=0.0))   # bin 0
-    archive.add("b", {}, 0.5, _bd(x=0.5))   # bin 1
-    archive.add("c", {}, 0.5, _bd(x=0.99))  # bin 2
-    assert archive.coverage() == pytest.approx(1.0)
+# ---------------------------------------------------------------------------
+# Bin distance
+# ---------------------------------------------------------------------------
 
 
-def test_coverage_partial_2d():
-    archive = DiversityArchive(
-        dimensions=["x", "y"], bins_per_dimension=4, seed=11,
-    )
-    # 4x4 = 16 total cells, place in 4
-    archive.add("a", {}, 0.5, _bd(x=0.0, y=0.0))
-    archive.add("b", {}, 0.5, _bd(x=0.5, y=0.5))
-    archive.add("c", {}, 0.5, _bd(x=0.99, y=0.99))
-    archive.add("d", {}, 0.5, _bd(x=0.0, y=0.99))
-    assert archive.coverage() == pytest.approx(4.0 / 16.0)
+class TestBinDistance:
+    def test_same_point(self):
+        assert DiversityArchive._bin_distance((0, 0), (0, 0)) == 0.0
+
+    def test_unit_distance(self):
+        assert DiversityArchive._bin_distance((0,), (1,)) == 1.0
+
+    def test_euclidean_2d(self):
+        dist = DiversityArchive._bin_distance((0, 0), (3, 4))
+        assert math.isclose(dist, 5.0)
+
+
+# ---------------------------------------------------------------------------
+# Coverage and stats
+# ---------------------------------------------------------------------------
+
+
+class TestCoverageAndStats:
+    def test_coverage_empty(self):
+        archive = DiversityArchive(dimensions=["x", "y"], bins_per_dimension=3)
+        assert archive.coverage() == 0.0
+
+    def test_coverage_partial(self):
+        archive = DiversityArchive(dimensions=["x"], bins_per_dimension=5, seed=42)
+        archive.add("c1", {}, 0.5, BehaviorDescriptor(dimensions={"x": 0.1}))
+        archive.add("c2", {}, 0.5, BehaviorDescriptor(dimensions={"x": 0.9}))
+        assert archive.coverage() == 2.0 / 5.0
+
+    def test_stats_empty(self):
+        archive = DiversityArchive(dimensions=["x"], bins_per_dimension=5)
+        s = archive.stats()
+        assert s["occupied"] == 0
+        assert s["mean_fitness"] == 0.0
+        assert s["diversity_score"] == 0.0
+
+    def test_stats_populated(self):
+        archive = DiversityArchive(dimensions=["x"], bins_per_dimension=5, seed=42)
+        archive.add("c1", {}, 0.4, BehaviorDescriptor(dimensions={"x": 0.1}))
+        archive.add("c2", {}, 0.8, BehaviorDescriptor(dimensions={"x": 0.9}))
+        s = archive.stats()
+        assert s["occupied"] == 2
+        assert s["max_fitness"] == 0.8
+        assert s["min_fitness"] == 0.4
+        assert s["diversity_score"] > 0.0
 
 
 # ---------------------------------------------------------------------------
@@ -209,140 +268,145 @@ def test_coverage_partial_2d():
 # ---------------------------------------------------------------------------
 
 
-def test_best_per_dimension():
-    archive = DiversityArchive(
-        dimensions=["speed", "risk"], bins_per_dimension=5, seed=12,
-    )
-    archive.add("slow_safe", {}, 0.3, _bd(speed=0.1, risk=0.1))
-    archive.add("fast_risky", {}, 0.7, _bd(speed=0.99, risk=0.99))
-    archive.add("fast_safe", {}, 0.9, _bd(speed=0.99, risk=0.1))
+class TestBestPerDimension:
+    def test_unknown_dimension_raises(self):
+        archive = DiversityArchive(dimensions=["x"], bins_per_dimension=5)
+        with pytest.raises(ValueError, match="Unknown dimension"):
+            archive.best_per_dimension("y")
 
-    best_speed = archive.best_per_dimension("speed")
-    assert best_speed is not None
-    # fast_safe has highest fitness among speed=max_bin
-    assert best_speed.candidate_id == "fast_safe"
+    def test_best_at_max_bin(self):
+        archive = DiversityArchive(dimensions=["x"], bins_per_dimension=5, seed=42)
+        archive.add("low_x", {}, 0.3, BehaviorDescriptor(dimensions={"x": 0.1}))
+        archive.add("high_x", {}, 0.9, BehaviorDescriptor(dimensions={"x": 0.95}))
+        best = archive.best_per_dimension("x")
+        assert best is not None
+        assert best.candidate_id == "high_x"
 
+    def test_fallback_to_highest_occupied_bin(self):
+        archive = DiversityArchive(dimensions=["x"], bins_per_dimension=5, seed=42)
+        archive.add("mid", {}, 0.7, BehaviorDescriptor(dimensions={"x": 0.5}))
+        best = archive.best_per_dimension("x")
+        assert best is not None
+        assert best.candidate_id == "mid"
 
-def test_best_per_dimension_unknown():
-    archive = DiversityArchive(dimensions=["x"], seed=13)
-    with pytest.raises(ValueError, match="Unknown dimension"):
-        archive.best_per_dimension("nonexistent")
-
-
-def test_best_per_dimension_fallback():
-    archive = DiversityArchive(
-        dimensions=["x"], bins_per_dimension=5, seed=14,
-    )
-    # Only populate low bins
-    archive.add("low", {}, 0.5, _bd(x=0.1))
-    best = archive.best_per_dimension("x")
-    assert best is not None
-    assert best.candidate_id == "low"
+    def test_empty_archive_returns_none(self):
+        archive = DiversityArchive(dimensions=["x"], bins_per_dimension=5)
+        assert archive.best_per_dimension("x") is None
 
 
 # ---------------------------------------------------------------------------
-# stats
+# Serialization round-trip
 # ---------------------------------------------------------------------------
 
 
-def test_stats_empty():
-    archive = DiversityArchive(dimensions=["a", "b"], bins_per_dimension=3)
-    s = archive.stats()
-    assert s["occupied"] == 0
-    assert s["coverage_pct"] == 0.0
-    assert s["mean_fitness"] == 0.0
-    assert s["total_cells"] == 9
+class TestSerialization:
+    def test_to_dict_and_from_dict_round_trip(self):
+        archive = DiversityArchive(
+            dimensions=["speed", "risk"],
+            bins_per_dimension=4,
+            seed=42,
+        )
+        archive.add(
+            "c1", {"code": "v1"}, 0.75,
+            BehaviorDescriptor(dimensions={"speed": 0.3, "risk": 0.8}),
+            generation=5,
+        )
+        archive.add(
+            "c2", {"code": "v2"}, 0.6,
+            BehaviorDescriptor(dimensions={"speed": 0.9, "risk": 0.1}),
+            generation=7,
+        )
 
+        data = archive.to_dict()
+        restored = DiversityArchive.from_dict(data, seed=42)
 
-def test_stats_populated():
-    archive = DiversityArchive(
-        dimensions=["x", "y"], bins_per_dimension=5, seed=15,
-    )
-    archive.add("a", {}, 0.4, _bd(x=0.1, y=0.1))
-    archive.add("b", {}, 0.8, _bd(x=0.9, y=0.9))
-    s = archive.stats()
-    assert s["occupied"] == 2
-    assert s["total_cells"] == 25
-    assert s["coverage_pct"] == pytest.approx(8.0)
-    assert s["mean_fitness"] == pytest.approx(0.6)
-    assert s["max_fitness"] == pytest.approx(0.8)
-    assert s["min_fitness"] == pytest.approx(0.4)
-    assert s["diversity_score"] >= 0.0
+        assert restored.dimensions == ["speed", "risk"]
+        assert restored.bins_per_dimension == 4
+        assert len(restored._grid) == 2
 
+        cell = restored.get_cell(BehaviorDescriptor(dimensions={"speed": 0.3, "risk": 0.8}))
+        assert cell is not None
+        assert cell.candidate_id == "c1"
+        assert cell.fitness == 0.75
 
-# ---------------------------------------------------------------------------
-# Serialization
-# ---------------------------------------------------------------------------
+    def test_to_dict_empty(self):
+        archive = DiversityArchive(dimensions=["x"], bins_per_dimension=3)
+        data = archive.to_dict()
+        assert data["grid"] == {}
 
-
-def test_serialization_roundtrip():
-    archive = DiversityArchive(
-        dimensions=["speed", "risk", "complexity"],
-        bins_per_dimension=4,
-        seed=16,
-    )
-    archive.add("a", {"code": "v1"}, 0.7, _bd(speed=0.3, risk=0.5, complexity=0.2))
-    archive.add("b", {"code": "v2"}, 0.9, _bd(speed=0.8, risk=0.1, complexity=0.9))
-
-    data = archive.to_dict()
-    restored = DiversityArchive.from_dict(data, seed=16)
-
-    assert restored.dimensions == archive.dimensions
-    assert restored.bins_per_dimension == archive.bins_per_dimension
-    assert len(restored._grid) == len(archive._grid)
-
-    # Verify content matches
-    original_stats = archive.stats()
-    restored_stats = restored.stats()
-    assert original_stats["occupied"] == restored_stats["occupied"]
-    assert original_stats["mean_fitness"] == restored_stats["mean_fitness"]
-
-
-def test_serialization_json_valid():
-    archive = DiversityArchive(dimensions=["x"], bins_per_dimension=3, seed=17)
-    archive.add("c1", {"data": 42}, 0.5, _bd(x=0.5))
-    data = archive.to_dict()
-    text = json.dumps(data)
-    assert isinstance(json.loads(text), dict)
-
-
-async def test_persist_and_load(tmp_path):
-    path = tmp_path / "diversity.json"
-    archive = DiversityArchive(
-        dimensions=["a", "b"],
-        bins_per_dimension=5,
-        persist_path=path,
-        seed=18,
-    )
-    archive.add("x", {"val": 1}, 0.6, _bd(a=0.2, b=0.8))
-    archive.add("y", {"val": 2}, 0.9, _bd(a=0.7, b=0.3))
-
-    saved_path = await archive.persist()
-    assert saved_path.exists()
-
-    loaded = await DiversityArchive.load(
-        dimensions=["a", "b"],
-        bins_per_dimension=5,
-        persist_path=path,
-        seed=18,
-    )
-    assert loaded.stats()["occupied"] == 2
-    cell = loaded.get_cell(_bd(a=0.7, b=0.3))
-    assert cell is not None
-    assert cell.candidate_id == "y"
+    def test_from_dict_empty_grid(self):
+        data = {"dimensions": ["x"], "bins_per_dimension": 3, "grid": {}}
+        archive = DiversityArchive.from_dict(data)
+        assert len(archive._grid) == 0
 
 
 # ---------------------------------------------------------------------------
-# BehaviorDescriptor
+# Async persistence
 # ---------------------------------------------------------------------------
 
 
-def test_behavior_descriptor_validate_dimensions():
-    bd = _bd(x=0.5, y=0.3)
-    assert bd.validate_dimensions(["x", "y"]) is True
-    assert bd.validate_dimensions(["x", "y", "z"]) is False
+class TestAsyncPersistence:
+    async def test_persist_and_load(self, tmp_path):
+        path = tmp_path / "archive.json"
+        archive = DiversityArchive(
+            dimensions=["a", "b"],
+            bins_per_dimension=3,
+            persist_path=path,
+            seed=42,
+        )
+        archive.add("c1", {"v": 1}, 0.8, BehaviorDescriptor(dimensions={"a": 0.5, "b": 0.5}))
+
+        saved_path = await archive.persist()
+        assert saved_path == path
+        assert path.exists()
+
+        loaded = await DiversityArchive.load(
+            dimensions=["a", "b"],
+            bins_per_dimension=3,
+            persist_path=path,
+            seed=42,
+        )
+        assert len(loaded._grid) == 1
+        cell = loaded.get_cell(BehaviorDescriptor(dimensions={"a": 0.5, "b": 0.5}))
+        assert cell is not None
+        assert cell.candidate_id == "c1"
+
+    async def test_load_nonexistent_creates_empty(self, tmp_path):
+        path = tmp_path / "missing.json"
+        archive = await DiversityArchive.load(
+            dimensions=["x"],
+            bins_per_dimension=5,
+            persist_path=path,
+        )
+        assert len(archive._grid) == 0
+        assert archive.persist_path == path
 
 
-def test_behavior_descriptor_out_of_range():
-    bd = BehaviorDescriptor(dimensions={"x": 1.5})
-    assert bd.validate_dimensions(["x"]) is False
+# ---------------------------------------------------------------------------
+# Diversity score computation
+# ---------------------------------------------------------------------------
+
+
+class TestDiversityScore:
+    def test_single_cell_returns_zero(self):
+        archive = DiversityArchive(dimensions=["x"], bins_per_dimension=5, seed=42)
+        archive.add("c1", {}, 0.5, BehaviorDescriptor(dimensions={"x": 0.5}))
+        assert archive._compute_diversity_score() == 0.0
+
+    def test_two_distant_cells_positive(self):
+        archive = DiversityArchive(dimensions=["x"], bins_per_dimension=5, seed=42)
+        archive.add("c1", {}, 0.5, BehaviorDescriptor(dimensions={"x": 0.0}))
+        archive.add("c2", {}, 0.5, BehaviorDescriptor(dimensions={"x": 1.0}))
+        score = archive._compute_diversity_score()
+        assert score > 0.0
+
+    def test_two_adjacent_cells_lower_than_distant(self):
+        archive_close = DiversityArchive(dimensions=["x"], bins_per_dimension=10, seed=42)
+        archive_close.add("c1", {}, 0.5, BehaviorDescriptor(dimensions={"x": 0.0}))
+        archive_close.add("c2", {}, 0.5, BehaviorDescriptor(dimensions={"x": 0.1}))
+
+        archive_far = DiversityArchive(dimensions=["x"], bins_per_dimension=10, seed=42)
+        archive_far.add("c1", {}, 0.5, BehaviorDescriptor(dimensions={"x": 0.0}))
+        archive_far.add("c2", {}, 0.5, BehaviorDescriptor(dimensions={"x": 1.0}))
+
+        assert archive_close._compute_diversity_score() < archive_far._compute_diversity_score()

--- a/tests/test_guardian_runtime_checks.py
+++ b/tests/test_guardian_runtime_checks.py
@@ -1,0 +1,287 @@
+"""Tests for dharma_swarm.guardian_runtime_checks — runtime warning probes.
+
+Validates:
+- run_guardian_warning_checks: stale report detection, unregistered state dirs
+- runtime_context_bundle_injection_findings: context bundle security scanning
+- runtime_rows_missing_context: missing context bundle counts
+- runtime_context_status_counts: unhealthy status aggregation
+- Helper functions: _runtime_table_names, _runtime_table_columns, _json_load
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+import pytest
+
+from dharma_swarm.guardian_runtime_checks import (
+    GuardianRuntimeFinding,
+    run_guardian_warning_checks,
+    runtime_context_bundle_injection_findings,
+    runtime_rows_missing_context,
+    runtime_context_status_counts,
+    _REGISTERED_DHARMA_TOP_LEVEL_DIRS,
+)
+
+
+# ---------------------------------------------------------------------------
+# GuardianRuntimeFinding model
+# ---------------------------------------------------------------------------
+
+
+class TestGuardianRuntimeFinding:
+    def test_construction(self):
+        f = GuardianRuntimeFinding(
+            severity="WARNING",
+            check="test_check",
+            title="Test",
+            detail="Details here",
+        )
+        assert f.severity == "WARNING"
+        assert f.file == ""
+        assert f.line == 0
+
+    def test_with_file_and_line(self):
+        f = GuardianRuntimeFinding(
+            severity="BLOCKER",
+            check="mm02",
+            title="Enum coercion",
+            detail="Bare string",
+            file="orchestrate_live.py",
+            line=1247,
+            fix_hint="Use AgentRole()",
+        )
+        assert f.file == "orchestrate_live.py"
+        assert f.line == 1247
+
+
+# ---------------------------------------------------------------------------
+# run_guardian_warning_checks
+# ---------------------------------------------------------------------------
+
+
+class TestGuardianWarningChecks:
+    async def test_no_findings_on_clean_state(self, tmp_path):
+        src_root = tmp_path / "dharma_swarm"
+        src_root.mkdir()
+        (src_root / "__init__.py").write_text("")
+        state_dir = tmp_path / ".dharma"
+        state_dir.mkdir()
+        findings = await run_guardian_warning_checks(src_root, state_dir)
+        assert findings == []
+
+    async def test_stale_report_detected(self, tmp_path):
+        src_root = tmp_path / "dharma_swarm"
+        src_root.mkdir()
+        (src_root / "__init__.py").write_text("")
+        report = tmp_path / "GUARDIAN_REPORT.md"
+        report.write_text("# Old report")
+        old_time = time.time() - 48 * 3600
+        import os
+        os.utime(str(report), (old_time, old_time))
+
+        state_dir = tmp_path / ".dharma"
+        state_dir.mkdir()
+
+        findings = await run_guardian_warning_checks(src_root, state_dir)
+        stale = [f for f in findings if "stale" in f.title.lower()]
+        assert len(stale) == 1
+        assert stale[0].severity == "WARNING"
+
+    async def test_fresh_report_no_finding(self, tmp_path):
+        src_root = tmp_path / "dharma_swarm"
+        src_root.mkdir()
+        (src_root / "__init__.py").write_text("")
+        report = tmp_path / "GUARDIAN_REPORT.md"
+        report.write_text("# Fresh report")
+
+        state_dir = tmp_path / ".dharma"
+        state_dir.mkdir()
+
+        findings = await run_guardian_warning_checks(src_root, state_dir)
+        stale = [f for f in findings if "stale" in f.title.lower()]
+        assert len(stale) == 0
+
+    async def test_unregistered_state_dir_detected(self, tmp_path):
+        src_root = tmp_path / "dharma_swarm"
+        src_root.mkdir()
+        (src_root / "__init__.py").write_text("")
+        state_dir = tmp_path / ".dharma"
+        state_dir.mkdir()
+        (state_dir / "unknown_dir").mkdir()
+
+        findings = await run_guardian_warning_checks(src_root, state_dir)
+        unreg = [f for f in findings if "unregistered" in f.title.lower()]
+        assert len(unreg) == 1
+        assert "unknown_dir" in unreg[0].detail
+
+    async def test_registered_dirs_not_flagged(self, tmp_path):
+        src_root = tmp_path / "dharma_swarm"
+        src_root.mkdir()
+        (src_root / "__init__.py").write_text("")
+        state_dir = tmp_path / ".dharma"
+        state_dir.mkdir()
+        for name in ["evolution", "memory", "witness"]:
+            (state_dir / name).mkdir()
+
+        findings = await run_guardian_warning_checks(src_root, state_dir)
+        unreg = [f for f in findings if "unregistered" in f.title.lower()]
+        assert len(unreg) == 0
+
+    async def test_hidden_dirs_ignored(self, tmp_path):
+        src_root = tmp_path / "dharma_swarm"
+        src_root.mkdir()
+        (src_root / "__init__.py").write_text("")
+        state_dir = tmp_path / ".dharma"
+        state_dir.mkdir()
+        (state_dir / ".hidden").mkdir()
+
+        findings = await run_guardian_warning_checks(src_root, state_dir)
+        unreg = [f for f in findings if "unregistered" in f.title.lower()]
+        assert len(unreg) == 0
+
+    async def test_nonexistent_state_dir_no_crash(self, tmp_path):
+        src_root = tmp_path / "dharma_swarm"
+        src_root.mkdir()
+        (src_root / "__init__.py").write_text("")
+        state_dir = tmp_path / "nonexistent"
+
+        findings = await run_guardian_warning_checks(src_root, state_dir)
+        assert isinstance(findings, list)
+
+
+# ---------------------------------------------------------------------------
+# Registered dirs completeness
+# ---------------------------------------------------------------------------
+
+
+class TestRegisteredDirs:
+    def test_known_dirs_present(self):
+        expected = {"evolution", "memory", "witness", "stigmergy", "guardian", "tasks"}
+        assert expected <= _REGISTERED_DHARMA_TOP_LEVEL_DIRS
+
+    def test_all_entries_lowercase(self):
+        for d in _REGISTERED_DHARMA_TOP_LEVEL_DIRS:
+            assert d == d.lower(), f"Entry {d!r} not lowercase"
+
+
+# ---------------------------------------------------------------------------
+# runtime_context_bundle_injection_findings
+# ---------------------------------------------------------------------------
+
+
+class TestContextBundleInjectionFindings:
+    def _create_db_with_context_bundles(self, db: sqlite3.Connection) -> None:
+        db.execute("""
+            CREATE TABLE context_bundles (
+                bundle_id TEXT PRIMARY KEY,
+                rendered_text TEXT,
+                metadata_json TEXT,
+                created_at TEXT,
+                run_id TEXT DEFAULT '',
+                session_id TEXT DEFAULT '',
+                task_id TEXT DEFAULT ''
+            )
+        """)
+        db.commit()
+
+    def test_no_table_returns_empty(self, tmp_path):
+        db = sqlite3.connect(str(tmp_path / "test.db"))
+        result = runtime_context_bundle_injection_findings(
+            db, datetime.now(timezone.utc).isoformat()
+        )
+        assert result == []
+        db.close()
+
+    def test_empty_table_returns_empty(self, tmp_path):
+        db = sqlite3.connect(str(tmp_path / "test.db"))
+        self._create_db_with_context_bundles(db)
+        result = runtime_context_bundle_injection_findings(
+            db, "2020-01-01T00:00:00"
+        )
+        assert result == []
+        db.close()
+
+    def test_blocked_metadata_detected(self, tmp_path):
+        db = sqlite3.connect(str(tmp_path / "test.db"))
+        self._create_db_with_context_bundles(db)
+        metadata = json.dumps({
+            "context_scan": {"status": "blocked", "findings": ["injection detected"]}
+        })
+        db.execute(
+            "INSERT INTO context_bundles (bundle_id, rendered_text, metadata_json, created_at) "
+            "VALUES (?, ?, ?, ?)",
+            ("b1", "some text", metadata, "2026-01-01T00:00:00"),
+        )
+        db.commit()
+        result = runtime_context_bundle_injection_findings(db, "2020-01-01T00:00:00")
+        assert len(result) == 1
+        assert result[0][0] == "b1"
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# runtime_rows_missing_context
+# ---------------------------------------------------------------------------
+
+
+class TestRuntimeRowsMissingContext:
+    def test_no_tables_returns_zero(self, tmp_path):
+        db = sqlite3.connect(str(tmp_path / "test.db"))
+        count = runtime_rows_missing_context(
+            db, "task_claims", "claimed_at", "2020-01-01"
+        )
+        assert count == 0
+        db.close()
+
+    def test_unsupported_table_returns_zero(self, tmp_path):
+        db = sqlite3.connect(str(tmp_path / "test.db"))
+        db.execute("CREATE TABLE some_other (id TEXT)")
+        db.execute("CREATE TABLE context_bundles (bundle_id TEXT)")
+        db.commit()
+        count = runtime_rows_missing_context(
+            db, "some_other", "created_at", "2020-01-01"
+        )
+        assert count == 0
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# runtime_context_status_counts
+# ---------------------------------------------------------------------------
+
+
+class TestRuntimeContextStatusCounts:
+    def test_no_tables_returns_empty(self, tmp_path):
+        db = sqlite3.connect(str(tmp_path / "test.db"))
+        counts = runtime_context_status_counts(db, "2020-01-01")
+        assert counts == {}
+        db.close()
+
+    def test_counts_unhealthy_statuses(self, tmp_path):
+        db = sqlite3.connect(str(tmp_path / "test.db"))
+        db.execute("""
+            CREATE TABLE task_claims (
+                claim_id TEXT,
+                claimed_at TEXT,
+                metadata_json TEXT,
+                status TEXT DEFAULT 'claimed',
+                session_id TEXT DEFAULT '',
+                task_id TEXT DEFAULT ''
+            )
+        """)
+        for i, status in enumerate(["failed", "failed", "missing_runtime_state"]):
+            metadata = json.dumps({"context_bundle_status": status})
+            db.execute(
+                "INSERT INTO task_claims (claim_id, claimed_at, metadata_json) VALUES (?, ?, ?)",
+                (f"c{i}", "2026-01-01T00:00:00", metadata),
+            )
+        db.commit()
+        counts = runtime_context_status_counts(db, "2020-01-01")
+        assert counts.get("failed", 0) == 2
+        assert counts.get("missing_runtime_state", 0) == 1
+        db.close()

--- a/tests/test_model_hierarchy.py
+++ b/tests/test_model_hierarchy.py
@@ -1,0 +1,319 @@
+"""Tests for dharma_swarm.model_hierarchy — canonical provider hierarchy.
+
+Validates:
+- Tier membership and ordering
+- _ordered_unique deduplication
+- Lane role assignments
+- default_model / get_tier / is_free lookups
+- heuristic_score edge cases (empty, refusal, code, JSON, latency)
+- get_live_order with seed fallback, EWMA ranking, circuit breaker filtering
+- provider_tier_label / dump_hierarchy convenience formatters
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from dharma_swarm.model_hierarchy import (
+    ALL_TIERS,
+    CANONICAL_SEED_ORDER,
+    DEFAULT_MODELS,
+    TIER_CHEAP,
+    TIER_FREE,
+    TIER_PAID,
+    TIER_PAID_API,
+    TIER_SUBSCRIPTION,
+    LaneRole,
+    _ordered_unique,
+    default_model,
+    dump_hierarchy,
+    get_live_order,
+    get_tier,
+    heuristic_score,
+    is_free,
+    provider_lane_role,
+    provider_tier_label,
+)
+from dharma_swarm.models import LLMResponse, ProviderType
+
+
+# ---------------------------------------------------------------------------
+# Tier definitions
+# ---------------------------------------------------------------------------
+
+
+class TestTierDefinitions:
+    def test_free_tier_not_empty(self):
+        assert len(TIER_FREE) > 0
+
+    def test_cheap_tier_not_empty(self):
+        assert len(TIER_CHEAP) > 0
+
+    def test_subscription_tier_contains_claude_code(self):
+        assert ProviderType.CLAUDE_CODE in TIER_SUBSCRIPTION
+
+    def test_paid_api_contains_anthropic(self):
+        assert ProviderType.ANTHROPIC in TIER_PAID_API
+
+    def test_paid_is_subscription_plus_api(self):
+        assert TIER_PAID == TIER_SUBSCRIPTION + TIER_PAID_API
+
+    def test_canonical_seed_order_covers_all_tiers(self):
+        all_providers = set(TIER_FREE) | set(TIER_CHEAP) | set(TIER_SUBSCRIPTION) | set(TIER_PAID_API)
+        seed_set = set(CANONICAL_SEED_ORDER)
+        assert all_providers == seed_set
+
+    def test_canonical_seed_order_no_duplicates(self):
+        assert len(CANONICAL_SEED_ORDER) == len(set(CANONICAL_SEED_ORDER))
+
+    def test_all_tiers_dict_keys(self):
+        assert set(ALL_TIERS.keys()) == {"free", "cheap", "subscription", "paid_api", "paid"}
+
+
+# ---------------------------------------------------------------------------
+# _ordered_unique
+# ---------------------------------------------------------------------------
+
+
+class TestOrderedUnique:
+    def test_removes_duplicates_preserves_order(self):
+        result = _ordered_unique((ProviderType.OLLAMA, ProviderType.GROQ, ProviderType.OLLAMA))
+        assert result == (ProviderType.OLLAMA, ProviderType.GROQ)
+
+    def test_empty_input(self):
+        assert _ordered_unique(()) == ()
+
+    def test_no_duplicates_unchanged(self):
+        result = _ordered_unique((ProviderType.OLLAMA, ProviderType.GROQ))
+        assert result == (ProviderType.OLLAMA, ProviderType.GROQ)
+
+
+# ---------------------------------------------------------------------------
+# Lane roles
+# ---------------------------------------------------------------------------
+
+
+class TestLaneRoles:
+    def test_codex_is_primary_driver(self):
+        assert provider_lane_role(ProviderType.CODEX) == LaneRole.PRIMARY_DRIVER
+
+    def test_openrouter_is_research_delegate(self):
+        assert provider_lane_role(ProviderType.OPENROUTER) == LaneRole.RESEARCH_DELEGATE
+
+    def test_nvidia_nim_is_challenger(self):
+        assert provider_lane_role(ProviderType.NVIDIA_NIM) == LaneRole.CHALLENGER
+
+    def test_unknown_provider_defaults_to_general_support(self):
+        # If a new ProviderType is added but not in _LANE_ROLES, it should default
+        for p in ProviderType:
+            role = provider_lane_role(p)
+            assert isinstance(role, LaneRole)
+
+
+# ---------------------------------------------------------------------------
+# Lookups: get_tier, is_free, default_model
+# ---------------------------------------------------------------------------
+
+
+class TestLookups:
+    def test_get_tier_free(self):
+        assert get_tier(ProviderType.OLLAMA) == "free"
+
+    def test_get_tier_cheap(self):
+        assert get_tier(ProviderType.MISTRAL) == "cheap"
+
+    def test_get_tier_subscription(self):
+        assert get_tier(ProviderType.CLAUDE_CODE) == "subscription"
+
+    def test_get_tier_paid_api(self):
+        assert get_tier(ProviderType.ANTHROPIC) == "paid_api"
+
+    def test_is_free_true(self):
+        assert is_free(ProviderType.OLLAMA) is True
+
+    def test_is_free_false(self):
+        assert is_free(ProviderType.ANTHROPIC) is False
+
+    def test_default_model_known_provider(self):
+        model = default_model(ProviderType.OLLAMA)
+        assert isinstance(model, str)
+        assert len(model) > 0
+
+    def test_default_model_every_provider_has_entry(self):
+        for p in ProviderType:
+            model = default_model(p)
+            assert isinstance(model, str)
+
+    def test_default_models_dict_matches_all_seed_order(self):
+        for p in CANONICAL_SEED_ORDER:
+            assert p in DEFAULT_MODELS, f"{p} missing from DEFAULT_MODELS"
+
+
+# ---------------------------------------------------------------------------
+# heuristic_score
+# ---------------------------------------------------------------------------
+
+
+class TestHeuristicScore:
+    def _make_response(self, content: str) -> LLMResponse:
+        return LLMResponse(content=content, model="test", provider="test")
+
+    def test_empty_content_returns_zero(self):
+        assert heuristic_score(self._make_response("")) == 0.0
+
+    def test_whitespace_only_returns_zero(self):
+        assert heuristic_score(self._make_response("   ")) == 0.0
+
+    def test_normal_content_positive_score(self):
+        score = heuristic_score(self._make_response(
+            "Here is a detailed analysis. First, we consider the architecture. "
+            "However, there are trade-offs to note. Therefore we recommend approach B."
+        ))
+        assert 0.0 < score <= 1.0
+
+    def test_refusal_heavily_penalized(self):
+        refusal = heuristic_score(self._make_response(
+            "I cannot help with that request. As an AI, I must decline."
+        ))
+        normal = heuristic_score(self._make_response(
+            "Here is the answer to your question with detailed reasoning."
+        ))
+        assert refusal < normal
+
+    def test_expected_code_with_code_blocks(self):
+        score = heuristic_score(
+            self._make_response("```python\nprint('hello')\n```\nThis code prints hello."),
+            expected_code=True,
+        )
+        assert score > 0.3
+
+    def test_expected_code_without_code_blocks(self):
+        with_code = heuristic_score(
+            self._make_response("```python\nprint('hello')\n```\nExplanation follows."),
+            expected_code=True,
+        )
+        without_code = heuristic_score(
+            self._make_response("The function prints hello to stdout."),
+            expected_code=True,
+        )
+        assert with_code > without_code
+
+    def test_expected_json_valid(self):
+        score = heuristic_score(
+            self._make_response('{"key": "value", "count": 42}'),
+            expected_json=True,
+        )
+        assert score > 0.3
+
+    def test_expected_json_invalid(self):
+        valid = heuristic_score(
+            self._make_response('{"key": "value"}'),
+            expected_json=True,
+        )
+        invalid = heuristic_score(
+            self._make_response("This is not JSON at all"),
+            expected_json=True,
+        )
+        assert valid > invalid
+
+    def test_latency_bonus_fast(self):
+        fast = heuristic_score(
+            self._make_response("Good answer with some depth and reasoning."),
+            latency_ms=100.0,
+            max_latency_ms=30000.0,
+        )
+        slow = heuristic_score(
+            self._make_response("Good answer with some depth and reasoning."),
+            latency_ms=29000.0,
+            max_latency_ms=30000.0,
+        )
+        assert fast > slow
+
+    def test_score_always_in_range(self):
+        for content in [
+            "x",
+            "a " * 1000,
+            "I cannot help. As an AI, I apologize.",
+            '{"valid": true}',
+            "```python\ncode\n```",
+        ]:
+            score = heuristic_score(self._make_response(content))
+            assert 0.0 <= score <= 1.0
+
+    def test_zero_max_latency_neutral(self):
+        score = heuristic_score(
+            self._make_response("Test content for scoring."),
+            latency_ms=100.0,
+            max_latency_ms=0.0,
+        )
+        assert 0.0 <= score <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# get_live_order
+# ---------------------------------------------------------------------------
+
+
+class TestGetLiveOrder:
+    def test_seed_order_fallback(self):
+        order = get_live_order()
+        assert order == list(CANONICAL_SEED_ORDER)
+
+    def test_custom_candidates(self):
+        candidates = (ProviderType.OLLAMA, ProviderType.GROQ)
+        order = get_live_order(candidates=candidates)
+        assert set(order) == set(candidates)
+
+    def test_with_routing_memory_reranks(self):
+        mock_memory = MagicMock()
+        mock_memory.rank_candidates.return_value = (
+            [ProviderType.GROQ, ProviderType.OLLAMA],
+            {},
+        )
+        order = get_live_order(
+            routing_memory=mock_memory,
+            candidates=(ProviderType.OLLAMA, ProviderType.GROQ),
+        )
+        assert order[0] == ProviderType.GROQ
+
+    def test_with_routing_memory_empty_ranked_uses_seed(self):
+        mock_memory = MagicMock()
+        mock_memory.rank_candidates.return_value = ([], {})
+        order = get_live_order(routing_memory=mock_memory)
+        assert order == list(CANONICAL_SEED_ORDER)
+
+    def test_circuit_breaker_moves_open_to_end(self):
+        mock_cb = MagicMock()
+
+        def mock_get(key):
+            breaker = MagicMock()
+            if key == f"provider:{ProviderType.OLLAMA.value}":
+                breaker.state.value = "open"
+            else:
+                breaker.state.value = "closed"
+            return breaker
+
+        mock_cb.get = mock_get
+        candidates = (ProviderType.OLLAMA, ProviderType.GROQ, ProviderType.CEREBRAS)
+        order = get_live_order(circuit_breakers=mock_cb, candidates=candidates)
+        assert order[-1] == ProviderType.OLLAMA
+        assert order[0] != ProviderType.OLLAMA
+
+
+# ---------------------------------------------------------------------------
+# Convenience formatters
+# ---------------------------------------------------------------------------
+
+
+class TestConvenience:
+    def test_provider_tier_label_format(self):
+        label = provider_tier_label(ProviderType.OLLAMA)
+        assert "[FREE" in label.upper()
+        assert ProviderType.OLLAMA.value in label
+
+    def test_dump_hierarchy_contains_all_tiers(self):
+        output = dump_hierarchy()
+        for tier_name in ALL_TIERS:
+            assert tier_name.upper() in output

--- a/tests/test_pending_proposals.py
+++ b/tests/test_pending_proposals.py
@@ -1,0 +1,116 @@
+"""Tests for dharma_swarm.pending_proposals — Shakti/Darwin queue substrate.
+
+Validates:
+- append_pending_proposal single-item append
+- append_pending_proposals batch append
+- File creation on first write
+- JSONL format correctness (one valid JSON per line)
+- Custom path support
+- Empty batch returns 0
+- Idempotent directory creation
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from dharma_swarm.pending_proposals import (
+    append_pending_proposal,
+    append_pending_proposals,
+)
+
+
+class TestAppendPendingProposal:
+    def test_single_append_creates_file(self, tmp_path):
+        path = tmp_path / "proposals.jsonl"
+        proposal = {"type": "mutation", "target": "cascade.py", "fitness": 0.8}
+        result = append_pending_proposal(proposal, path=path)
+        assert result == proposal
+        assert path.exists()
+
+    def test_single_append_jsonl_format(self, tmp_path):
+        path = tmp_path / "proposals.jsonl"
+        proposal = {"id": "p1", "source": "shakti"}
+        append_pending_proposal(proposal, path=path)
+        lines = path.read_text().strip().splitlines()
+        assert len(lines) == 1
+        parsed = json.loads(lines[0])
+        assert parsed["id"] == "p1"
+
+    def test_multiple_single_appends(self, tmp_path):
+        path = tmp_path / "proposals.jsonl"
+        append_pending_proposal({"id": "p1"}, path=path)
+        append_pending_proposal({"id": "p2"}, path=path)
+        append_pending_proposal({"id": "p3"}, path=path)
+        lines = path.read_text().strip().splitlines()
+        assert len(lines) == 3
+        ids = [json.loads(line)["id"] for line in lines]
+        assert ids == ["p1", "p2", "p3"]
+
+    def test_creates_parent_directories(self, tmp_path):
+        path = tmp_path / "deep" / "nested" / "proposals.jsonl"
+        append_pending_proposal({"test": True}, path=path)
+        assert path.exists()
+
+    def test_returns_dict_copy(self, tmp_path):
+        path = tmp_path / "proposals.jsonl"
+        original = {"key": "value"}
+        result = append_pending_proposal(original, path=path)
+        assert result == original
+        assert result is not original
+
+
+class TestAppendPendingProposals:
+    def test_batch_append(self, tmp_path):
+        path = tmp_path / "proposals.jsonl"
+        proposals = [
+            {"id": "b1", "type": "refactor"},
+            {"id": "b2", "type": "optimize"},
+            {"id": "b3", "type": "test"},
+        ]
+        count = append_pending_proposals(proposals, path=path)
+        assert count == 3
+        lines = path.read_text().strip().splitlines()
+        assert len(lines) == 3
+
+    def test_empty_batch_returns_zero(self, tmp_path):
+        path = tmp_path / "proposals.jsonl"
+        count = append_pending_proposals([], path=path)
+        assert count == 0
+        assert not path.exists()
+
+    def test_batch_creates_parent_directories(self, tmp_path):
+        path = tmp_path / "sub" / "proposals.jsonl"
+        append_pending_proposals([{"x": 1}], path=path)
+        assert path.exists()
+
+    def test_batch_appends_to_existing(self, tmp_path):
+        path = tmp_path / "proposals.jsonl"
+        append_pending_proposals([{"id": "first"}], path=path)
+        append_pending_proposals([{"id": "second"}, {"id": "third"}], path=path)
+        lines = path.read_text().strip().splitlines()
+        assert len(lines) == 3
+
+    def test_each_line_valid_json(self, tmp_path):
+        path = tmp_path / "proposals.jsonl"
+        proposals = [
+            {"complex": {"nested": True}, "list": [1, 2, 3]},
+            {"unicode": "テスト"},
+        ]
+        append_pending_proposals(proposals, path=path)
+        for line in path.read_text().strip().splitlines():
+            parsed = json.loads(line)
+            assert isinstance(parsed, dict)
+
+    def test_generator_input(self, tmp_path):
+        path = tmp_path / "proposals.jsonl"
+
+        def gen():
+            for i in range(5):
+                yield {"id": f"g{i}"}
+
+        count = append_pending_proposals(gen(), path=path)
+        assert count == 5

--- a/tests/test_world_actions.py
+++ b/tests/test_world_actions.py
@@ -1,0 +1,251 @@
+"""Tests for dharma_swarm.world_actions — world-facing action primitives.
+
+Validates:
+- WorldActionResult construction and to_json()
+- _run subprocess wrapper
+- _git_changed_paths helper
+- _slug text normalization
+- github_clone_repo destination checks
+- github_commit_push error paths
+- create_website_scaffold file generation
+- publish_markdown_artifact with manifest
+- spawn_sub_swarm_spec JSON output
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from dharma_swarm.world_actions import (
+    WorldActionResult,
+    _slug,
+    create_website_scaffold,
+    github_clone_repo,
+    publish_markdown_artifact,
+    spawn_sub_swarm_spec,
+)
+
+
+# ---------------------------------------------------------------------------
+# WorldActionResult
+# ---------------------------------------------------------------------------
+
+
+class TestWorldActionResult:
+    def test_construction_defaults(self):
+        r = WorldActionResult(success=True, action="test", message="ok")
+        assert r.success is True
+        assert r.path == ""
+        assert r.url == ""
+        assert r.metadata is None
+
+    def test_to_json_round_trip(self):
+        r = WorldActionResult(
+            success=True,
+            action="clone",
+            message="done",
+            path="/tmp/repo",
+            url="https://github.com/test",
+            metadata={"branch": "main"},
+        )
+        parsed = json.loads(r.to_json())
+        assert parsed["success"] is True
+        assert parsed["action"] == "clone"
+        assert parsed["metadata"]["branch"] == "main"
+
+    def test_to_json_none_metadata(self):
+        r = WorldActionResult(success=False, action="fail", message="err")
+        parsed = json.loads(r.to_json())
+        assert parsed["metadata"] is None
+
+
+# ---------------------------------------------------------------------------
+# _slug helper
+# ---------------------------------------------------------------------------
+
+
+class TestSlug:
+    def test_simple_text(self):
+        assert _slug("Hello World") == "hello-world"
+
+    def test_special_characters(self):
+        assert _slug("My Report! (v2.0)") == "my-report-v2-0"
+
+    def test_empty_string(self):
+        assert _slug("") == "artifact"
+
+    def test_only_special_chars(self):
+        assert _slug("!!!") == "artifact"
+
+    def test_already_slug(self):
+        assert _slug("hello-world") == "hello-world"
+
+
+# ---------------------------------------------------------------------------
+# github_clone_repo
+# ---------------------------------------------------------------------------
+
+
+class TestGithubCloneRepo:
+    def test_existing_non_empty_dir_fails(self, tmp_path):
+        dest = tmp_path / "repo"
+        dest.mkdir()
+        (dest / "file.txt").write_text("exists")
+        result = github_clone_repo("https://github.com/test/repo.git", str(dest))
+        assert result.success is False
+        assert "not empty" in result.message.lower()
+
+    def test_clone_failure_returns_error(self, tmp_path):
+        dest = tmp_path / "repo"
+        with patch("dharma_swarm.world_actions._run") as mock_run:
+            mock_run.return_value = (128, "", "fatal: repository not found")
+            result = github_clone_repo("https://github.com/test/repo.git", str(dest))
+        assert result.success is False
+        assert "fatal" in result.message.lower() or "not found" in result.message.lower()
+
+    def test_clone_success(self, tmp_path):
+        dest = tmp_path / "repo"
+        with patch("dharma_swarm.world_actions._run") as mock_run:
+            mock_run.return_value = (0, "Cloning into...", "")
+            result = github_clone_repo("https://github.com/test/repo.git", str(dest))
+        assert result.success is True
+        assert result.action == "github_clone_repo"
+
+
+# ---------------------------------------------------------------------------
+# create_website_scaffold
+# ---------------------------------------------------------------------------
+
+
+class TestCreateWebsiteScaffold:
+    def test_creates_html_and_css(self, tmp_path):
+        result = create_website_scaffold(
+            str(tmp_path / "site"), "Test Site", "A test purpose"
+        )
+        assert result.success is True
+        site_dir = tmp_path / "site"
+        assert (site_dir / "index.html").exists()
+        assert (site_dir / "styles.css").exists()
+
+    def test_html_contains_site_name(self, tmp_path):
+        create_website_scaffold(str(tmp_path / "s"), "My Portal", "purpose")
+        html = (tmp_path / "s" / "index.html").read_text()
+        assert "My Portal" in html
+
+    def test_html_contains_purpose(self, tmp_path):
+        create_website_scaffold(str(tmp_path / "s"), "Site", "Welfare optimization")
+        html = (tmp_path / "s" / "index.html").read_text()
+        assert "Welfare optimization" in html
+
+    def test_css_contains_styles(self, tmp_path):
+        create_website_scaffold(str(tmp_path / "s"), "Site", "purpose")
+        css = (tmp_path / "s" / "styles.css").read_text()
+        assert "body" in css
+        assert "--bg" in css
+
+    def test_custom_theme(self, tmp_path):
+        result = create_website_scaffold(str(tmp_path / "s"), "Site", "p", theme="dark")
+        assert result.metadata["theme"] == "dark"
+        html = (tmp_path / "s" / "index.html").read_text()
+        assert "dark" in html
+
+    def test_creates_nested_directories(self, tmp_path):
+        result = create_website_scaffold(
+            str(tmp_path / "deep" / "nested" / "site"), "Site", "purpose"
+        )
+        assert result.success is True
+
+
+# ---------------------------------------------------------------------------
+# publish_markdown_artifact
+# ---------------------------------------------------------------------------
+
+
+class TestPublishMarkdownArtifact:
+    def test_publishes_with_manifest(self, tmp_path):
+        src = tmp_path / "report.md"
+        src.write_text("# Report\nContent here.")
+        out_dir = tmp_path / "artifacts"
+
+        result = publish_markdown_artifact(str(src), str(out_dir))
+        assert result.success is True
+        assert (out_dir / "report.md").exists()
+
+        manifest_files = list(out_dir.glob("*.manifest.json"))
+        assert len(manifest_files) == 1
+        manifest = json.loads(manifest_files[0].read_text())
+        assert manifest["kind"] == "markdown_artifact"
+
+    def test_custom_artifact_name(self, tmp_path):
+        src = tmp_path / "draft.md"
+        src.write_text("# Draft")
+        out_dir = tmp_path / "out"
+
+        result = publish_markdown_artifact(str(src), str(out_dir), artifact_name="final.md")
+        assert result.success is True
+        assert (out_dir / "final.md").exists()
+
+    def test_missing_source_fails(self, tmp_path):
+        result = publish_markdown_artifact(str(tmp_path / "nope.md"), str(tmp_path / "out"))
+        assert result.success is False
+        assert "missing" in result.message.lower()
+
+    def test_preserves_content(self, tmp_path):
+        content = "# Test\n\nSome **bold** text.\n"
+        src = tmp_path / "test.md"
+        src.write_text(content)
+        out_dir = tmp_path / "out"
+
+        publish_markdown_artifact(str(src), str(out_dir))
+        published = (out_dir / "test.md").read_text()
+        assert published == content
+
+
+# ---------------------------------------------------------------------------
+# spawn_sub_swarm_spec
+# ---------------------------------------------------------------------------
+
+
+class TestSpawnSubSwarmSpec:
+    def test_creates_spec_file(self, tmp_path):
+        result = spawn_sub_swarm_spec(
+            str(tmp_path), "Research Mission", "Explore quantum computing"
+        )
+        assert result.success is True
+        spec_files = list(tmp_path.glob("*.subswarm.json"))
+        assert len(spec_files) == 1
+
+    def test_spec_contains_mission_data(self, tmp_path):
+        spawn_sub_swarm_spec(
+            str(tmp_path), "Alpha Mission", "Do important things"
+        )
+        spec_files = list(tmp_path.glob("*.subswarm.json"))
+        spec = json.loads(spec_files[0].read_text())
+        assert spec["mission_name"] == "Alpha Mission"
+        assert spec["thesis"] == "Do important things"
+        assert spec["status"] == "ready"
+
+    def test_default_roles(self, tmp_path):
+        spawn_sub_swarm_spec(str(tmp_path), "Mission", "thesis")
+        spec_files = list(tmp_path.glob("*.subswarm.json"))
+        spec = json.loads(spec_files[0].read_text())
+        assert "cartographer" in spec["roles"]
+        assert "validator" in spec["roles"]
+
+    def test_custom_roles(self, tmp_path):
+        spawn_sub_swarm_spec(
+            str(tmp_path), "Mission", "thesis",
+            roles=["leader", "researcher"],
+        )
+        spec_files = list(tmp_path.glob("*.subswarm.json"))
+        spec = json.loads(spec_files[0].read_text())
+        assert spec["roles"] == ["leader", "researcher"]
+
+    def test_slug_in_filename(self, tmp_path):
+        spawn_sub_swarm_spec(str(tmp_path), "My Special Mission!", "thesis")
+        spec_files = list(tmp_path.glob("*.subswarm.json"))
+        assert any("my-special-mission" in f.name for f in spec_files)


### PR DESCRIPTION
Clean replacement for PR #90 after PR #91 was merged first.

Why this branch exists:
- PR #91 carried the phase 2-6 cold-lane coverage plus an extra isolation fix and has now been merged.
- The original PR #90 branch was cumulative and duplicated those phase 2-6 files without the final isolation commit.
- This branch keeps only PR #90's seven critical-substrate contribution on top of current `main`.

Changed scope:
- `tests/test_algedonic_activation.py`
- `tests/test_certified_lanes.py`
- `tests/test_diversity_archive.py`
- `tests/test_guardian_runtime_checks.py`
- `tests/test_model_hierarchy.py`
- `tests/test_pending_proposals.py`
- `tests/test_world_actions.py`

Verification:
- `pytest -q tests/test_diversity_archive.py tests/test_model_hierarchy.py tests/test_pending_proposals.py tests/test_algedonic_activation.py tests/test_certified_lanes.py tests/test_world_actions.py tests/test_guardian_runtime_checks.py`
- Result: 208 passed, 1 warning.
- Commit hooks passed: test hygiene, contract tests, uplift guards, gitleaks, semgrep warn-only, whitespace/EOF/merge-conflict/large-file checks.