### PR TITLE
feat(provenance): add signal fanout and derivation lineage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,7 +143,7 @@ bash run_operator.sh
 
 ## Navigation
 
-See `NAVIGATION.md` for the full module map (500 modules, 12 architectural layers).
+See [`docs/architecture/NAVIGATION.md`](docs/architecture/NAVIGATION.md) for the full module map (500+ modules, 12 architectural layers).
 See `README.md` for repo map and common commands.
 See `foundations/` for the 10-pillar intellectual genome.
 

--- a/INTERFACE_MISMATCH_MAP.md
+++ b/INTERFACE_MISMATCH_MAP.md
@@ -27,9 +27,12 @@
 | NEW-04: agent_runner → telic_seam dispatch gap | DEGRADED | ✅RESOLVED | `record_dispatch` + `record_gate_decision` added at task start in agent_runner |
 | NEW-05: task_board ↔ runtime_state split lifecycle | — | ⚠️ GUARDED | `run_task_consistency_guard` added to guardian_crew — detects COMPLETED tasks with still-OPEN claims |
 | NEW-07: 54 stores lack common trace_id | — | ⚠️ PARTIAL | `trace_id` column added to task_board, runtime_state (claims+runs), telemetry_plane (routing, policy, economic) |
-| NEW-08: 12 independent record_outcome() | — | ⚠️ PARTIAL | TelicSeam emits `SIGNAL_OUTCOME_RECORDED` / `SIGNAL_VALUE_EVENT_RECORDED` to signal_bus for canonical fanout |
+| NEW-08: 12 independent record_outcome() | ⚠️ PARTIAL | ⚠️ PARTIAL+ | TelicSeam emits signals + SignalBus subscriber pattern added for automatic fanout |
+| NEW-09: orchestrator → TelicSeam registry_path kwarg | — | ✅ FIXED | `orchestrator.py:154` used `registry_path=` but TelicSeam accepts `path=`. TypeError at runtime. |
+| NEW-10: lineage edges lack delegation chain | — | ✅ FIXED | `LineageEdge.delegated_by` + `trace_id` fields added; `agent_runner.spawn_worker` records delegation lineage |
+| NEW-11: TelicSeam singleton missing signal_bus | — | ✅ FIXED | `get_seam()` now passes `signal_bus=SignalBus.get()` to singleton |
 
-**Net change:** 7 resolved, 5 fixed prior sessions, 3 new entries (NEW-05 guarded, NEW-07/NEW-08 partially resolved), 0 open BLOCKERs, 7 structural degraded remain.
+**Net change:** 10 resolved, 5 fixed prior sessions, 6 new entries (NEW-05 guarded, NEW-07/NEW-08 partially resolved, NEW-09/10/11 fixed), 0 open BLOCKERs, 5 structural degraded remain.
 
 ---
 

--- a/dharma_swarm/agent_runner.py
+++ b/dharma_swarm/agent_runner.py
@@ -2751,7 +2751,34 @@ class AgentRunner:
             parent_agent=self._config.name,
             **kwargs,
         )
-        return await self._worker_spawner.spawn(spec, provider=self._provider)
+        result = await self._worker_spawner.spawn(spec, provider=self._provider)
+
+        # Record derivation lineage: parent→worker delegation chain
+        try:
+            from dharma_swarm.correlation_context import get_correlation
+            from dharma_swarm.lineage import LineageEdge
+
+            corr = get_correlation()
+            worker_id = result.worker_id if result else ""
+            from dharma_swarm.telic_seam import get_seam
+            ontology_path = _resolve_ontology_path(
+                None, self._config, self._ontology_path,
+            )
+            if ontology_path is not None:
+                seam = get_seam(ontology_path)
+                seam.lineage.record(LineageEdge(
+                    task_id=task_title,
+                    agent=worker_id or worker_type,
+                    delegated_by=self._config.name,
+                    operation="worker_delegation",
+                    trace_id=corr.trace_id,
+                    input_artifacts=[f"parent:{self._config.name}"],
+                    output_artifacts=[f"worker:{worker_id or worker_type}"],
+                ))
+        except Exception:
+            logger.debug("Derivation lineage recording failed", exc_info=True)
+
+        return result
 
     def _record_router_feedback(
         self,

--- a/dharma_swarm/lineage.py
+++ b/dharma_swarm/lineage.py
@@ -51,16 +51,23 @@ class LineageEdge(BaseModel):
 
     This is the atomic unit of provenance: task X consumed [A, B] and
     produced [C, D] at time T, executed by agent Y in pipeline Z.
+
+    Derivation support (otel-agent-provenance):
+      delegated_by — When agent B was delegated work by agent A,
+      this field records A's identity so the output is traceable
+      back through the delegation chain.
     """
     edge_id: str = Field(default_factory=_new_id)
     task_id: str
     input_artifacts: list[str] = Field(default_factory=list)
     output_artifacts: list[str] = Field(default_factory=list)
     agent: str = ""
+    delegated_by: str = ""
     pipeline_id: str = ""
     pipeline_label: str = ""
     block_id: str = ""
     operation: str = ""  # e.g., "compute_rv", "archive", "design"
+    trace_id: str = ""
     timestamp: str = Field(default_factory=lambda: _utc_now().isoformat())
     metadata: dict[str, Any] = Field(default_factory=dict)
 
@@ -101,10 +108,12 @@ CREATE TABLE IF NOT EXISTS lineage_edges (
     edge_id TEXT PRIMARY KEY,
     task_id TEXT NOT NULL,
     agent TEXT DEFAULT '',
+    delegated_by TEXT DEFAULT '',
     pipeline_id TEXT DEFAULT '',
     pipeline_label TEXT DEFAULT '',
     block_id TEXT DEFAULT '',
     operation TEXT DEFAULT '',
+    trace_id TEXT DEFAULT '',
     timestamp TEXT NOT NULL,
     metadata TEXT DEFAULT '{}'
 );
@@ -167,6 +176,14 @@ class LineageGraph:
     def _init_db(self) -> None:
         with self._conn() as conn:
             conn.executescript(_SCHEMA)
+            for col in ("delegated_by", "trace_id"):
+                try:
+                    conn.execute(
+                        f"ALTER TABLE lineage_edges ADD COLUMN {col}"
+                        " TEXT DEFAULT ''"
+                    )
+                except Exception:
+                    pass
 
     @contextmanager
     def _conn(self):
@@ -186,13 +203,16 @@ class LineageGraph:
         with self._conn() as conn:
             conn.execute(
                 """INSERT INTO lineage_edges
-                   (edge_id, task_id, agent, pipeline_id, pipeline_label,
-                    block_id, operation, timestamp, metadata)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                   (edge_id, task_id, agent, delegated_by,
+                    pipeline_id, pipeline_label,
+                    block_id, operation, trace_id, timestamp, metadata)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     edge.edge_id, edge.task_id, edge.agent,
+                    edge.delegated_by,
                     edge.pipeline_id, edge.pipeline_label,
-                    edge.block_id, edge.operation, edge.timestamp,
+                    edge.block_id, edge.operation, edge.trace_id,
+                    edge.timestamp,
                     json.dumps(edge.metadata),
                 ),
             )
@@ -255,6 +275,12 @@ class LineageGraph:
 
     # ── Querying ──────────────────────────────────────────────────────
 
+    _EDGE_COLS = (
+        "edge_id, task_id, agent, delegated_by, pipeline_id,"
+        " pipeline_label, block_id, operation, trace_id,"
+        " timestamp, metadata"
+    )
+
     def _row_to_edge(self, row: tuple) -> LineageEdge:
         """Convert a DB row + its inputs/outputs to a LineageEdge."""
         edge_id = row[0]
@@ -271,16 +297,21 @@ class LineageGraph:
                     (edge_id,),
                 ).fetchall()
             ]
+        # Column order: edge_id(0), task_id(1), agent(2), delegated_by(3),
+        #   pipeline_id(4), pipeline_label(5), block_id(6), operation(7),
+        #   trace_id(8), timestamp(9), metadata(10)
         return LineageEdge(
             edge_id=row[0],
             task_id=row[1],
             agent=row[2] or "",
-            pipeline_id=row[3] or "",
-            pipeline_label=row[4] or "",
-            block_id=row[5] or "",
-            operation=row[6] or "",
-            timestamp=row[7],
-            metadata=json.loads(row[8]) if row[8] else {},
+            delegated_by=row[3] or "",
+            pipeline_id=row[4] or "",
+            pipeline_label=row[5] or "",
+            block_id=row[6] or "",
+            operation=row[7] or "",
+            trace_id=row[8] or "",
+            timestamp=row[9],
+            metadata=json.loads(row[10]) if row[10] else {},
             input_artifacts=inputs,
             output_artifacts=outputs,
         )
@@ -289,7 +320,8 @@ class LineageGraph:
         """Retrieve a single edge by ID."""
         with self._conn() as conn:
             row = conn.execute(
-                "SELECT * FROM lineage_edges WHERE edge_id = ?", (edge_id,)
+                f"SELECT {self._EDGE_COLS} FROM lineage_edges WHERE edge_id = ?",
+                (edge_id,),
             ).fetchone()
         if row is None:
             return None
@@ -299,7 +331,8 @@ class LineageGraph:
         """Get all lineage edges for a task."""
         with self._conn() as conn:
             rows = conn.execute(
-                "SELECT * FROM lineage_edges WHERE task_id = ? ORDER BY timestamp",
+                f"SELECT {self._EDGE_COLS} FROM lineage_edges"
+                " WHERE task_id = ? ORDER BY timestamp",
                 (task_id,),
             ).fetchall()
         return [self._row_to_edge(r) for r in rows]
@@ -308,7 +341,8 @@ class LineageGraph:
         """Get all lineage edges for a pipeline execution."""
         with self._conn() as conn:
             rows = conn.execute(
-                "SELECT * FROM lineage_edges WHERE pipeline_id = ? ORDER BY timestamp",
+                f"SELECT {self._EDGE_COLS} FROM lineage_edges"
+                " WHERE pipeline_id = ? ORDER BY timestamp",
                 (pipeline_id,),
             ).fetchall()
         return [self._row_to_edge(r) for r in rows]
@@ -327,7 +361,8 @@ class LineageGraph:
         with self._conn() as conn:
             placeholders = ",".join("?" * len(edge_ids))
             rows = conn.execute(
-                f"SELECT * FROM lineage_edges WHERE edge_id IN ({placeholders})",
+                f"SELECT {self._EDGE_COLS} FROM lineage_edges"
+                f" WHERE edge_id IN ({placeholders})",
                 edge_ids,
             ).fetchall()
         return [self._row_to_edge(r) for r in rows]
@@ -346,7 +381,8 @@ class LineageGraph:
         with self._conn() as conn:
             placeholders = ",".join("?" * len(edge_ids))
             rows = conn.execute(
-                f"SELECT * FROM lineage_edges WHERE edge_id IN ({placeholders})",
+                f"SELECT {self._EDGE_COLS} FROM lineage_edges"
+                f" WHERE edge_id IN ({placeholders})",
                 edge_ids,
             ).fetchall()
         return [self._row_to_edge(r) for r in rows]

--- a/dharma_swarm/orchestrator.py
+++ b/dharma_swarm/orchestrator.py
@@ -147,11 +147,15 @@ class Orchestrator:
         """Prefer a state-local ontology seam over the global singleton."""
         try:
             from dharma_swarm.ontology_runtime import get_shared_registry
+            from dharma_swarm.signal_bus import SignalBus
             from dharma_swarm.telic_seam import TelicSeam
 
             ontology_db = self._runtime_root() / "ontology.db"
             registry = get_shared_registry(path=ontology_db)
-            return TelicSeam(registry=registry, registry_path=ontology_db)
+            return TelicSeam(
+                registry=registry, path=ontology_db,
+                signal_bus=SignalBus.get(),
+            )
         except Exception:
             logger.debug("Failed to initialize local telic seam", exc_info=True)
             return None

--- a/dharma_swarm/signal_bus.py
+++ b/dharma_swarm/signal_bus.py
@@ -15,6 +15,7 @@ Thread-safe via asyncio primitives (designed for single event loop).
 
 from __future__ import annotations
 
+import logging
 import time
 from collections import deque
 from typing import Any
@@ -62,6 +63,41 @@ class SignalBus:
     def __init__(self, ttl_seconds: float = 300.0) -> None:
         self.ttl_seconds = ttl_seconds
         self._events: deque[tuple[float, dict[str, Any]]] = deque()
+        self._subscribers: dict[str, list[Any]] = {}
+
+    # ------------------------------------------------------------------
+    # Subscriber pattern — register callbacks for specific signal types
+    # ------------------------------------------------------------------
+
+    def subscribe(
+        self,
+        event_type: str,
+        callback: Any,
+    ) -> None:
+        """Register a callback for a specific signal type.
+
+        The callback is invoked synchronously on emit(). It receives the
+        full event dict. Exceptions in callbacks are logged but never
+        propagate — subscribers cannot break the emitter.
+
+        Example::
+
+            bus.subscribe("OUTCOME_RECORDED", lambda e: print(e["task_id"]))
+        """
+        self._subscribers.setdefault(event_type, []).append(callback)
+
+    def unsubscribe(
+        self,
+        event_type: str,
+        callback: Any,
+    ) -> None:
+        """Remove a previously registered callback."""
+        listeners = self._subscribers.get(event_type)
+        if listeners:
+            try:
+                listeners.remove(callback)
+            except ValueError:
+                pass
 
     def emit(self, event: dict[str, Any]) -> None:
         """Emit a signal event.
@@ -75,6 +111,15 @@ class SignalBus:
             bus.emit({"type": "ANOMALY_DETECTED", "severity": "high"})
         """
         self._events.append((time.monotonic(), event))
+        event_type = event.get("type", "")
+        for cb in self._subscribers.get(event_type, []):
+            try:
+                cb(event)
+            except Exception:
+                logging.getLogger(__name__).debug(
+                    "SignalBus subscriber error for %s", event_type,
+                    exc_info=True,
+                )
 
     def drain(
         self,

--- a/dharma_swarm/telic_seam.py
+++ b/dharma_swarm/telic_seam.py
@@ -304,12 +304,14 @@ class TelicSeam:
                 input_artifacts.extend(task.depends_on)
             output_artifacts = [f"outcome:{obj.id}"]
 
+            corr = get_correlation()
             self._lineage.record(LineageEdge(
                 task_id=task.id,
                 input_artifacts=input_artifacts,
                 output_artifacts=output_artifacts,
                 agent=agent_id,
                 operation="task_execution",
+                trace_id=corr.trace_id,
                 metadata={
                     "success": success,
                     "proposal_id": proposal_id or "",
@@ -319,7 +321,6 @@ class TelicSeam:
 
             # Emit canonical outcome signal for cross-store fanout
             if self._signal_bus is not None:
-                corr = get_correlation()
                 self._signal_bus.emit({
                     "type": SIGNAL_OUTCOME_RECORDED,
                     "outcome_id": obj.id,
@@ -762,10 +763,13 @@ _SEAM: TelicSeam | None = None
 
 
 def get_seam(path: str | Path | None = None) -> TelicSeam:
-    """Get or create the module-level TelicSeam singleton."""
+    """Get or create the module-level TelicSeam singleton.
+
+    Automatically wires the SignalBus singleton for outcome fanout.
+    """
     global _SEAM
     if _SEAM is None or getattr(_SEAM, "_path", None) != path:
-        _SEAM = TelicSeam(path=path)
+        _SEAM = TelicSeam(path=path, signal_bus=SignalBus.get())
     return _SEAM
 
 

--- a/docs/interface_mismatches.yaml
+++ b/docs/interface_mismatches.yaml
@@ -131,11 +131,47 @@ mismatches:
     description: >
       TelicSeam now emits SIGNAL_OUTCOME_RECORDED and
       SIGNAL_VALUE_EVENT_RECORDED to signal_bus for canonical fanout.
+      SignalBus.subscribe() added for automatic callback dispatch.
       Other 11 consumers not yet subscribed. Fanout infrastructure ready.
 
+  - id: NEW-09
+    title: "orchestrator → TelicSeam registry_path kwarg TypeError"
+    severity: BLOCKER
+    status: RESOLVED
+    caller: orchestrator.py:154
+    callee: telic_seam.py:61
+    description: >
+      orchestrator._init_telic_seam() called TelicSeam(registry_path=...)
+      but __init__ only accepts path=. TypeError at runtime prevented all
+      ontology recording from the orchestrator. Fixed: registry_path → path.
+
+  - id: NEW-10
+    title: "lineage edges lack delegation chain metadata"
+    severity: DEGRADED
+    status: RESOLVED
+    caller: agent_runner.py (spawn_worker)
+    callee: lineage.py (LineageEdge)
+    description: >
+      When agent A delegates to worker B via spawn_worker(), no lineage
+      edge recorded the delegation relationship. Added delegated_by and
+      trace_id fields to LineageEdge + schema. agent_runner.spawn_worker
+      now records a worker_delegation lineage edge.
+
+  - id: NEW-11
+    title: "TelicSeam singleton (get_seam) missing signal_bus"
+    severity: DEGRADED
+    status: RESOLVED
+    caller: agent_runner.py (via get_seam())
+    callee: telic_seam.py (get_seam singleton)
+    description: >
+      get_seam() created TelicSeam(path=...) without signal_bus, so
+      outcome events emitted by agent_runner's seam instance were never
+      broadcast to signal_bus subscribers. Fixed: get_seam() now passes
+      signal_bus=SignalBus.get().
+
 # Summary counts:
-# Total entries: 13
-# RESOLVED: 6 (MM-12, MM-17, MM-18, NEW-01, NEW-02, NEW-04)
+# Total entries: 16
+# RESOLVED: 9 (MM-12, MM-17, MM-18, NEW-01, NEW-02, NEW-04, NEW-09, NEW-10, NEW-11)
 # STILL_LIVE/OPEN: 4 (MM-02, MM-05, MM-07, MM-13)
 # GUARDED: 1 (NEW-05)
 # PARTIAL: 2 (NEW-07, NEW-08)

--- a/tests/test_lineage.py
+++ b/tests/test_lineage.py
@@ -350,3 +350,77 @@ class TestPersistence:
         assert hub.total_objects() == 0
 
         hub.close()
+
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# Derivation metadata
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+class TestDerivation:
+    def test_delegated_by_stored_and_retrieved(self, graph):
+        edge = LineageEdge(
+            task_id="delegated_task",
+            input_artifacts=["parent:conductor"],
+            output_artifacts=["worker:researcher_01"],
+            agent="researcher_01",
+            delegated_by="conductor",
+            operation="worker_delegation",
+        )
+        edge_id = graph.record(edge)
+        retrieved = graph.get_edge(edge_id)
+        assert retrieved is not None
+        assert retrieved.delegated_by == "conductor"
+        assert retrieved.agent == "researcher_01"
+
+    def test_trace_id_stored_and_retrieved(self, graph):
+        edge = LineageEdge(
+            task_id="traced_task",
+            input_artifacts=["x"],
+            output_artifacts=["y"],
+            agent="agent_a",
+            trace_id="tr_abc123",
+            operation="compute",
+        )
+        edge_id = graph.record(edge)
+        retrieved = graph.get_edge(edge_id)
+        assert retrieved is not None
+        assert retrieved.trace_id == "tr_abc123"
+
+    def test_delegation_chain_traversal(self, graph):
+        """A→B→C delegation chain is fully traversable."""
+        graph.record(LineageEdge(
+            task_id="t1",
+            input_artifacts=["parent:A"],
+            output_artifacts=["worker:B"],
+            agent="B", delegated_by="A",
+            operation="worker_delegation",
+            trace_id="tr_chain",
+        ))
+        graph.record(LineageEdge(
+            task_id="t2",
+            input_artifacts=["parent:B"],
+            output_artifacts=["worker:C"],
+            agent="C", delegated_by="B",
+            operation="worker_delegation",
+            trace_id="tr_chain",
+        ))
+        # C's output traces back through B to A
+        b_edges = [e for e in graph.edges_for_task("t1") if e.delegated_by == "A"]
+        c_edges = [e for e in graph.edges_for_task("t2") if e.delegated_by == "B"]
+        assert len(b_edges) == 1
+        assert len(c_edges) == 1
+        assert b_edges[0].agent == "B"
+        assert c_edges[0].agent == "C"
+
+    def test_default_empty_derivation_fields(self, graph):
+        """Edges without delegation still work — fields default to empty."""
+        edge = LineageEdge(
+            task_id="normal_task",
+            input_artifacts=["a"],
+            output_artifacts=["b"],
+        )
+        edge_id = graph.record(edge)
+        retrieved = graph.get_edge(edge_id)
+        assert retrieved.delegated_by == ""
+        assert retrieved.trace_id == ""

--- a/tests/test_signal_bus.py
+++ b/tests/test_signal_bus.py
@@ -72,3 +72,62 @@ class TestSignalBus:
         bus = SignalBus()
         assert bus.drain() == []
         assert bus.drain(["ANYTHING"]) == []
+
+    # ------------------------------------------------------------------
+    # Subscriber pattern tests
+    # ------------------------------------------------------------------
+
+    def test_subscribe_fires_on_emit(self):
+        bus = SignalBus()
+        received: list[dict] = []
+        bus.subscribe("OUTCOME_RECORDED", lambda e: received.append(e))
+        bus.emit({"type": "OUTCOME_RECORDED", "task_id": "t1"})
+        assert len(received) == 1
+        assert received[0]["task_id"] == "t1"
+
+    def test_subscribe_only_matching_type(self):
+        bus = SignalBus()
+        received: list[dict] = []
+        bus.subscribe("OUTCOME_RECORDED", lambda e: received.append(e))
+        bus.emit({"type": "OTHER_EVENT", "val": 1})
+        assert len(received) == 0
+
+    def test_multiple_subscribers(self):
+        bus = SignalBus()
+        a: list[dict] = []
+        b: list[dict] = []
+        bus.subscribe("X", lambda e: a.append(e))
+        bus.subscribe("X", lambda e: b.append(e))
+        bus.emit({"type": "X"})
+        assert len(a) == 1
+        assert len(b) == 1
+
+    def test_subscriber_error_does_not_break_emit(self):
+        bus = SignalBus()
+        received: list[dict] = []
+
+        def bad_cb(e):
+            raise ValueError("boom")
+
+        bus.subscribe("X", bad_cb)
+        bus.subscribe("X", lambda e: received.append(e))
+        bus.emit({"type": "X"})
+        # Second subscriber still fires despite first raising
+        assert len(received) == 1
+        # Event still in deque
+        assert bus.pending_count == 1
+
+    def test_unsubscribe(self):
+        bus = SignalBus()
+        received: list[dict] = []
+        cb = lambda e: received.append(e)
+        bus.subscribe("X", cb)
+        bus.emit({"type": "X"})
+        assert len(received) == 1
+        bus.unsubscribe("X", cb)
+        bus.emit({"type": "X"})
+        assert len(received) == 1  # no new callback
+
+    def test_unsubscribe_nonexistent_is_noop(self):
+        bus = SignalBus()
+        bus.unsubscribe("X", lambda e: None)  # should not raise


### PR DESCRIPTION
Clean replacement for PR #88 after PR #74 was squash-merged.

Why this branch exists:
- PR #88 was built on top of PR #74 and cannot be merged cleanly after #74 landed via squash.
- A current-main merge of #88 conflicts in `INTERFACE_MISMATCH_MAP.md`, `dharma_swarm/telic_seam.py`, and `docs/interface_mismatches.yaml`.
- This branch applies only the actual #88 delta from `origin/devin/1777903781-provenance-wiring-mm17-mm18` to `origin/devin/1777938416-provenance-fanout-derivation`, preserving newer `main` work such as operator-brief watcher/CLI, witness docs, and test-coverage additions.

Changed scope:
- `dharma_swarm/signal_bus.py`: subscriber fanout
- `dharma_swarm/telic_seam.py`: singleton signal bus wiring
- `dharma_swarm/orchestrator.py`: `path=` constructor fix and signal bus wiring
- `dharma_swarm/lineage.py`: delegation metadata and explicit selects
- `dharma_swarm/agent_runner.py`: worker delegation lineage recording
- mismatch docs/tests and `CLAUDE.md` pointer fix

Verification:
- `pytest -q tests/test_signal_bus.py tests/test_lineage.py tests/test_telic_seam.py tests/test_correlation_context.py tests/test_agent_runner.py` -> 157 passed, 3 warnings.
- `pytest -q tests/test_orchestrator.py tests/test_ginko_orchestrator.py` -> 51 passed, 1 warning.
- Commit hooks passed with `DHARMA_UPLIFT_ACK=impact-checked`: test hygiene, contract tests, uplift guards, gitleaks, semgrep warn-only, whitespace/EOF, merge-conflict, large-file, YAML.

Note: ContextPlus static analysis was attempted against the isolated worktree and timed out after 120s, so the deterministic gate for this branch is the pytest/hooks evidence above.