### PR TITLE
feat(hypernode): seed empty quadrant revenue cell

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -259,6 +259,7 @@ def _register_routers(api_app: FastAPI) -> None:
     from api.routers.routing import router as routing_router
     from api.routers.graphql_router import router as graphql_router
     from api.routers.verify import router as verify_router
+    from api.routers.hypernodes import router as hypernodes_router
 
     api_app.include_router(health_router)
     api_app.include_router(agents_router)
@@ -273,6 +274,7 @@ def _register_routers(api_app: FastAPI) -> None:
     api_app.include_router(routing_router)
     api_app.include_router(graphql_router)
     api_app.include_router(verify_router)
+    api_app.include_router(hypernodes_router)
 
     from api.routers.chat import router as chat_router, ws_router as chat_ws_router
 

--- a/api/routers/hypernodes.py
+++ b/api/routers/hypernodes.py
@@ -1,0 +1,25 @@
+"""Hypernode dashboard endpoints."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from api.models import ApiResponse
+from dharma_swarm.hypernode_seed import ensure_empty_quadrant_hypernode
+
+router = APIRouter(prefix="/api", tags=["hypernodes"])
+
+
+def _get_registry():
+    from dharma_swarm.ontology_runtime import get_shared_registry
+
+    return get_shared_registry()
+
+
+@router.get("/hypernodes/empty-quadrant")
+async def empty_quadrant_hypernode() -> ApiResponse:
+    registry = _get_registry()
+    seeded = ensure_empty_quadrant_hypernode(registry, created_by="api.hypernodes")
+    if seeded.errors:
+        return ApiResponse(status="error", error="; ".join(seeded.errors))
+    return ApiResponse(data=seeded.payload.model_dump(mode="json"))

--- a/api/routers/ontology.py
+++ b/api/routers/ontology.py
@@ -25,6 +25,10 @@ _TYPE_CATEGORIES: dict[str, tuple[str, str]] = {
     "TypedTask": ("task", "execution rail"),
     "EvolutionEntry": ("artifact", "evolution archive"),
     "WitnessLog": ("gate", "witness field"),
+    "Hypernode": ("concept", "revenue/welfare cell"),
+    "RevenueCell": ("artifact", "metabolic market proof"),
+    "CouncilVerdict": ("gate", "quorum trace"),
+    "FitnessVector": ("gate", "promotion score"),
 }
 
 _CATEGORY_LAYOUT: dict[str, tuple[int, int]] = {

--- a/dashboard/src/app/dashboard/hypernodes/empty-quadrant/page.tsx
+++ b/dashboard/src/app/dashboard/hypernodes/empty-quadrant/page.tsx
@@ -1,0 +1,347 @@
+"use client";
+
+import { motion } from "framer-motion";
+import {
+  ArrowRight,
+  BadgeCheck,
+  DollarSign,
+  GitBranch,
+  Scale,
+  ShieldCheck,
+  Target,
+  TriangleAlert,
+} from "lucide-react";
+import { useEmptyQuadrantHypernode } from "@/hooks/useEmptyQuadrantHypernode";
+import type { HypernodePayload } from "@/lib/types";
+import { colors } from "@/lib/theme";
+
+const metricLabels: Record<string, string> = {
+  auto_grade_score: "AutoGrade",
+  council_score: "Council",
+  provenance_score: "Provenance",
+  market_value_score: "Market",
+  welfare_score: "Welfare",
+};
+
+function pct(value: number): string {
+  return `${Math.round(value * 100)}%`;
+}
+
+export default function EmptyQuadrantHypernodePage() {
+  const { hypernode, isLoading, error } = useEmptyQuadrantHypernode();
+
+  if (isLoading) {
+    return (
+      <div className="glass-panel flex min-h-[520px] items-center justify-center">
+        <p className="animate-pulse text-sm text-sumi-600">Loading hypernode...</p>
+      </div>
+    );
+  }
+
+  if (!hypernode || error) {
+    return (
+      <div className="glass-panel flex min-h-[520px] items-center justify-center">
+        <p className="max-w-md text-center text-sm text-status-warn">
+          Empty Quadrant hypernode API is not available.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <Hero hypernode={hypernode} />
+      <QuadrantMap hypernode={hypernode} />
+      <div className="grid grid-cols-1 gap-4 xl:grid-cols-[1.1fr_0.9fr]">
+        <FitnessPanel hypernode={hypernode} />
+        <CouncilPanel hypernode={hypernode} />
+      </div>
+      <div className="grid grid-cols-1 gap-4 xl:grid-cols-3">
+        <RevenuePanel hypernode={hypernode} />
+        <ProvenancePanel hypernode={hypernode} />
+        <NextActionsPanel hypernode={hypernode} />
+      </div>
+      <OntologyPanel hypernode={hypernode} />
+    </div>
+  );
+}
+
+function Hero({ hypernode }: { hypernode: HypernodePayload }) {
+  return (
+    <motion.section
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      className="overflow-hidden rounded-lg border border-aozora/20 bg-sumi-900/70"
+    >
+      <div className="grid gap-0 lg:grid-cols-[1.05fr_0.95fr]">
+        <div className="space-y-5 p-6 md:p-8">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="rounded border border-kinpaku/30 px-2 py-1 font-mono text-[10px] uppercase text-kinpaku">
+              Hypernode #1
+            </span>
+            <span className="rounded border border-aozora/30 px-2 py-1 font-mono text-[10px] uppercase text-aozora">
+              {hypernode.fitness_vector.promotion_state.replace(/_/g, " ")}
+            </span>
+          </div>
+          <div>
+            <h1 className="glow-aozora font-heading text-3xl font-bold text-aozora md:text-4xl">
+              {hypernode.title}
+            </h1>
+            <p className="mt-3 max-w-3xl text-sm leading-6 text-torinoko/80">
+              {hypernode.thesis}
+            </p>
+          </div>
+        </div>
+        <div className="grid min-h-[260px] place-items-center border-t border-sumi-700/40 bg-sumi-950/70 p-6 lg:border-l lg:border-t-0">
+          <div className="relative aspect-square w-full max-w-[320px]">
+            <div className="absolute inset-0 rounded-full border border-aozora/25" />
+            <div className="absolute inset-[14%] rounded-full border border-kinpaku/25" />
+            <div className="absolute left-1/2 top-0 h-full w-px bg-sumi-700/70" />
+            <div className="absolute left-0 top-1/2 h-px w-full bg-sumi-700/70" />
+            <div className="absolute right-[9%] top-[8%] flex h-24 w-24 items-center justify-center rounded-full border border-aozora/50 bg-aozora/10 text-center text-xs font-semibold text-aozora shadow-[0_0_28px_rgba(79,209,217,0.18)]">
+              Empty quadrant
+            </div>
+            <div className="absolute bottom-[9%] left-[9%] text-[10px] uppercase text-sumi-600">
+              governance
+            </div>
+            <div className="absolute right-[8%] top-1/2 text-[10px] uppercase text-sumi-600">
+              welfare
+            </div>
+          </div>
+        </div>
+      </div>
+    </motion.section>
+  );
+}
+
+function QuadrantMap({ hypernode }: { hypernode: HypernodePayload }) {
+  return (
+    <section className="grid grid-cols-1 gap-3 md:grid-cols-2">
+      {hypernode.quadrant_map.map((quadrant) => {
+        const active = quadrant.id === "high-governance-welfare";
+        return (
+          <div
+            key={quadrant.id}
+            className={`rounded-lg border p-4 ${
+              active
+                ? "border-aozora/45 bg-aozora/10"
+                : "border-sumi-700/40 bg-sumi-900/60"
+            }`}
+          >
+            <div className="flex items-start gap-3">
+              {active ? (
+                <ShieldCheck className="mt-0.5 text-aozora" size={18} />
+              ) : (
+                <Scale className="mt-0.5 text-sumi-600" size={18} />
+              )}
+              <div className="min-w-0">
+                <p className={`font-heading text-sm font-semibold ${active ? "text-aozora" : "text-torinoko"}`}>
+                  {quadrant.label}
+                </p>
+                <p className="mt-1 text-xs uppercase text-sumi-600">
+                  {quadrant.governance} / {quadrant.orientation}
+                </p>
+                <p className="mt-2 text-sm leading-5 text-torinoko/75">
+                  {quadrant.description}
+                </p>
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </section>
+  );
+}
+
+function FitnessPanel({ hypernode }: { hypernode: HypernodePayload }) {
+  const fitness = hypernode.fitness_vector;
+  const metrics = [
+    "auto_grade_score",
+    "council_score",
+    "provenance_score",
+    "market_value_score",
+    "welfare_score",
+  ] as const;
+
+  return (
+    <section className="glass-panel p-5">
+      <PanelTitle icon={<BadgeCheck size={16} />} label="Fitness" accent={colors.kinpaku} />
+      <div className="mt-5 flex flex-col gap-5 lg:flex-row lg:items-center">
+        <div className="grid h-32 w-32 shrink-0 place-items-center rounded-full border border-kinpaku/40 bg-kinpaku/10">
+          <div className="text-center">
+            <p className="font-heading text-3xl font-bold text-kinpaku">
+              {pct(fitness.composite_score)}
+            </p>
+            <p className="mt-1 font-mono text-[10px] uppercase text-sumi-600">
+              threshold {pct(fitness.promotion_threshold)}
+            </p>
+          </div>
+        </div>
+        <div className="min-w-0 flex-1 space-y-3">
+          {metrics.map((key) => {
+            const value = fitness[key];
+            return (
+              <div key={key}>
+                <div className="mb-1 flex items-center justify-between text-xs">
+                  <span className="text-sumi-600">{metricLabels[key]}</span>
+                  <span className="font-mono text-torinoko">{value.toFixed(3)}</span>
+                </div>
+                <div className="h-2 overflow-hidden rounded bg-sumi-800">
+                  <div
+                    className="h-full rounded bg-kinpaku"
+                    style={{ width: `${Math.max(3, value * 100)}%` }}
+                  />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function CouncilPanel({ hypernode }: { hypernode: HypernodePayload }) {
+  const verdict = hypernode.council_verdict;
+
+  return (
+    <section className="glass-panel p-5">
+      <PanelTitle icon={<TriangleAlert size={16} />} label="Council Verdict" accent={colors.aozora} />
+      <div className="mt-4 rounded-lg border border-aozora/25 bg-aozora/10 p-4">
+        <div className="flex items-center justify-between gap-4">
+          <p className="font-heading text-lg font-semibold capitalize text-aozora">
+            {verdict.decision}
+          </p>
+          <span className="rounded bg-sumi-900 px-2 py-1 font-mono text-[10px] text-kinpaku">
+            MIROFISH {verdict.mirofish_activated ? "active" : "idle"}
+          </span>
+        </div>
+        <p className="mt-2 text-sm leading-5 text-torinoko/75">{verdict.reason}</p>
+      </div>
+      <div className="mt-4 grid grid-cols-2 gap-2">
+        {Object.entries(verdict.gate_results).map(([gate, result]) => (
+          <div key={gate} className="flex items-center justify-between rounded bg-sumi-850/70 px-3 py-2">
+            <span className="font-mono text-[10px] text-sumi-600">{gate}</span>
+            <span className={`font-mono text-[10px] ${result === "PASS" ? "text-status-ok" : "text-status-warn"}`}>
+              {result}
+            </span>
+          </div>
+        ))}
+      </div>
+      <div className="mt-4 flex flex-wrap gap-1.5">
+        {verdict.quorum_participants.map((participant) => (
+          <span key={participant} className="rounded border border-sumi-700/50 px-2 py-1 font-mono text-[10px] text-sumi-600">
+            {participant}
+          </span>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function RevenuePanel({ hypernode }: { hypernode: HypernodePayload }) {
+  const cell = hypernode.revenue_cell;
+
+  return (
+    <section className="glass-panel p-5">
+      <PanelTitle icon={<DollarSign size={16} />} label="Revenue Cell" accent={colors.rokusho} />
+      <dl className="mt-4 space-y-3 text-sm">
+        <MetricRow label="verified revenue" value={`$${cell.verified_revenue_usd.toFixed(0)}`} />
+        <MetricRow label="expected seed value" value={`$${cell.expected_value_usd.toFixed(0)}`} />
+        <MetricRow label="evidence tier" value={cell.evidence_tier.replace(/_/g, " ")} />
+      </dl>
+      <p className="mt-4 text-sm leading-5 text-torinoko/75">{cell.revenue_model}</p>
+      <p className="mt-3 text-xs leading-5 text-kitsurubami">{cell.trustee_principle}</p>
+    </section>
+  );
+}
+
+function ProvenancePanel({ hypernode }: { hypernode: HypernodePayload }) {
+  return (
+    <section className="glass-panel p-5">
+      <PanelTitle icon={<GitBranch size={16} />} label="Provenance" accent={colors.fuji} />
+      <div className="mt-4 space-y-3">
+        {hypernode.provenance.map((item) => (
+          <div key={item.id} className="border-b border-sumi-700/30 pb-3 last:border-0 last:pb-0">
+            <div className="flex items-center justify-between gap-3">
+              <p className="truncate text-sm text-torinoko">{item.label}</p>
+              <span className="font-mono text-[10px] text-fuji">{pct(item.confidence)}</span>
+            </div>
+            <p className="mt-1 truncate font-mono text-[10px] text-sumi-600">{item.reference}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function NextActionsPanel({ hypernode }: { hypernode: HypernodePayload }) {
+  return (
+    <section className="glass-panel p-5">
+      <PanelTitle icon={<Target size={16} />} label="Next Actions" accent={colors.botan} />
+      <ol className="mt-4 space-y-3">
+        {hypernode.next_actions.map((action, index) => (
+          <li key={action} className="flex gap-3 text-sm leading-5 text-torinoko/75">
+            <span className="grid h-5 w-5 shrink-0 place-items-center rounded bg-botan/15 font-mono text-[10px] text-botan">
+              {index + 1}
+            </span>
+            <span>{action}</span>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}
+
+function OntologyPanel({ hypernode }: { hypernode: HypernodePayload }) {
+  return (
+    <section className="glass-panel p-5">
+      <PanelTitle icon={<ArrowRight size={16} />} label="Ontology Trace" accent={colors.aozora} />
+      <div className="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-2">
+        {Object.entries(hypernode.object_chain).map(([chain, ids]) => (
+          <div key={chain} className="rounded-lg border border-sumi-700/40 p-4">
+            <p className="mb-3 font-mono text-[10px] uppercase text-sumi-600">{chain} chain</p>
+            <div className="space-y-2">
+              {ids.map((id, index) => (
+                <div key={id} className="flex items-center gap-2 text-xs">
+                  <span className="w-5 text-right font-mono text-sumi-600">{index + 1}</span>
+                  <ArrowRight size={12} className="text-sumi-700" />
+                  <span className="truncate font-mono text-torinoko/75">{id}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+      <p className="mt-4 font-mono text-[10px] uppercase text-sumi-600">
+        {hypernode.ontology_counts.objects ?? 0} objects / {hypernode.ontology_counts.links ?? 0} links / {hypernode.typed_links.length} hypernode trace links
+      </p>
+    </section>
+  );
+}
+
+function PanelTitle({
+  icon,
+  label,
+  accent,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  accent: string;
+}) {
+  return (
+    <div className="flex items-center gap-2" style={{ color: accent }}>
+      {icon}
+      <h2 className="font-heading text-sm font-semibold uppercase">{label}</h2>
+    </div>
+  );
+}
+
+function MetricRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <dt className="text-sumi-600">{label}</dt>
+      <dd className="text-right font-mono text-torinoko">{value}</dd>
+    </div>
+  );
+}

--- a/dashboard/src/hooks/useEmptyQuadrantHypernode.ts
+++ b/dashboard/src/hooks/useEmptyQuadrantHypernode.ts
@@ -1,0 +1,15 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { apiFetch } from "@/lib/api";
+import type { HypernodePayload } from "@/lib/types";
+
+export function useEmptyQuadrantHypernode() {
+  const { data, isLoading, error } = useQuery<HypernodePayload>({
+    queryKey: ["hypernodes", "empty-quadrant"],
+    queryFn: () => apiFetch<HypernodePayload>("/api/hypernodes/empty-quadrant"),
+    refetchInterval: 60_000,
+  });
+
+  return { hypernode: data ?? null, isLoading, error };
+}

--- a/dashboard/src/lib/dashboardNav.ts
+++ b/dashboard/src/lib/dashboardNav.ts
@@ -54,6 +54,7 @@ export function buildDashboardNavSections(): DashboardNavSection[] {
         ...canonicalOperatorDeckItems(),
         { label: "Conv. Log", href: "/dashboard/log", icon: "MessageSquare", level: 1 },
         { label: "Truth Map", href: "/dashboard/modules", icon: "Activity", level: 1 },
+        { label: "Hypernode #1", href: "/dashboard/hypernodes/empty-quadrant", icon: "HeartPulse", level: 1 },
         { label: "Semantic Graph", href: "/dashboard/claude", icon: "Globe", level: 1 },
         { label: "Models", href: "/dashboard/models", icon: "Sparkles", level: 1 },
         { label: "GLM-5", href: "/dashboard/glm5", icon: "Brain", level: 1 },

--- a/dashboard/src/lib/types.ts
+++ b/dashboard/src/lib/types.ts
@@ -452,6 +452,93 @@ export interface OntologyGraphData {
 }
 
 // ---------------------------------------------------------------------------
+// Hypernodes (GET /api/hypernodes/empty-quadrant)
+// ---------------------------------------------------------------------------
+
+export interface HypernodeQuadrantFrame {
+  id: string;
+  label: string;
+  governance: string;
+  orientation: string;
+  description: string;
+  occupied: boolean;
+}
+
+export interface HypernodeProvenanceRecord {
+  id: string;
+  label: string;
+  source_type: string;
+  reference: string;
+  confidence: number;
+}
+
+export interface HypernodeCouncilVerdict {
+  id: string;
+  decision: string;
+  reason: string;
+  gate_results: Record<string, string>;
+  anekanta_frames: string[];
+  steelman_summary: string;
+  dogma_drift_summary: string;
+  mirofish_activated: boolean;
+  mirofish_reason: string;
+  quorum_participants: string[];
+}
+
+export interface HypernodeFitnessVector {
+  id: string;
+  auto_grade_score: number;
+  council_score: number;
+  provenance_score: number;
+  market_value_score: number;
+  welfare_score: number;
+  composite_score: number;
+  promotion_threshold: number;
+  threshold_met: boolean;
+  promotion_state: string;
+  scoring_method: string;
+}
+
+export interface HypernodeRevenueCell {
+  id: string;
+  name: string;
+  market_category: string;
+  target_customer: string;
+  revenue_model: string;
+  verified_revenue_usd: number;
+  expected_value_usd: number;
+  evidence_tier: string;
+  trustee_principle: string;
+  status: string;
+  next_actions: string[];
+}
+
+export interface HypernodeTypedLink {
+  source_id: string;
+  source_type: string;
+  link_name: string;
+  target_id: string;
+  target_type: string;
+}
+
+export interface HypernodePayload {
+  id: string;
+  slug: string;
+  title: string;
+  thesis: string;
+  public_path: string;
+  quadrant_map: HypernodeQuadrantFrame[];
+  provenance: HypernodeProvenanceRecord[];
+  council_verdict: HypernodeCouncilVerdict;
+  fitness_vector: HypernodeFitnessVector;
+  revenue_cell: HypernodeRevenueCell;
+  object_chain: Record<string, string[]>;
+  typed_links: HypernodeTypedLink[];
+  next_actions: string[];
+  ontology_counts: Record<string, number>;
+}
+
+// ---------------------------------------------------------------------------
 // Lineage (GET /api/lineage/*)
 // ---------------------------------------------------------------------------
 

--- a/dharma_swarm/api.py
+++ b/dharma_swarm/api.py
@@ -264,6 +264,20 @@ def create_app(
             ],
         })
 
+    # ── Hypernodes ───────────────────────────────────────────────────
+
+    @app.get("/api/hypernodes/empty-quadrant")
+    async def empty_quadrant_hypernode() -> ApiResponse:
+        from dharma_swarm.hypernode_seed import ensure_empty_quadrant_hypernode
+
+        seeded = ensure_empty_quadrant_hypernode(
+            _get_registry(),
+            created_by="dharma_swarm.api",
+        )
+        if seeded.errors:
+            raise HTTPException(400, "; ".join(seeded.errors))
+        return ApiResponse(data=seeded.payload.model_dump(mode="json"))
+
     # ── Tasks ────────────────────────────────────────────────────────
 
     @app.post("/api/tasks")

--- a/dharma_swarm/hypernode.py
+++ b/dharma_swarm/hypernode.py
@@ -1,0 +1,404 @@
+"""Deterministic seed and scoring for the Empty Quadrant revenue hypernode."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from dharma_swarm.anekanta_gate import evaluate_anekanta
+from dharma_swarm.auto_grade.engine import AutoGradeEngine
+from dharma_swarm.auto_research.models import ClaimRecord, ResearchBrief, ResearchReport, SourceDocument
+from dharma_swarm.models import GateResult
+from dharma_swarm.telos_gates import TelosGatekeeper
+
+
+EMPTY_QUADRANT_SLUG = "empty-quadrant-revenue-cell"
+EMPTY_QUADRANT_PUBLIC_PATH = "/dashboard/hypernodes/empty-quadrant"
+HYPERNODE_ID = "hypernode-empty-quadrant-revenue"
+REVENUE_CELL_ID = "revenue-cell-empty-quadrant"
+COUNCIL_VERDICT_ID = "council-verdict-empty-quadrant"
+FITNESS_VECTOR_ID = "fitness-vector-empty-quadrant"
+PRINCIPAL_AGENT_ID = "agent-dhyana-principal"
+PUBLIC_ARTIFACT_ID = "artifact-empty-quadrant-page"
+SIGNAL_ID = "signal-empty-quadrant-revenue"
+QUESTION_ID = "question-empty-quadrant-revenue"
+CLAIM_ID = "claim-empty-quadrant-thesis"
+EVIDENCE_ID = "evidence-empty-quadrant-provenance"
+DOCTRINE_ID = "doctrine-trustee-revenue-welfare"
+ACTION_PROPOSAL_ID = "proposal-empty-quadrant-page"
+GATE_RECORD_ID = "gate-empty-quadrant-page"
+EXECUTION_LEASE_ID = "lease-empty-quadrant-page"
+OUTCOME_ID = "outcome-empty-quadrant-page"
+VALUE_EVENT_ID = "value-empty-quadrant-page"
+CONTRIBUTION_ID = "contribution-empty-quadrant-page"
+
+QUORUM_PARTICIPANTS = [
+    "ThinkodynamicDirector",
+    "JagatKalyanEngine",
+    "ZeitgeistExecutive",
+    "ShaktiZeitgeistExecutive",
+    "ShaktiLoop",
+    "OvernightDirector",
+    "OperatorBridge",
+    "GinkoOrchestrator",
+]
+
+NEXT_ACTIONS = [
+    "Publish the Empty Quadrant page as the category-defining artifact.",
+    "Attach one externally verifiable customer or buyer signal before revenue validation.",
+    "Run MIROFISH adversarial simulation on extraction drift and worldview overclaim risk.",
+    "Convert the strongest market signal into a paid consulting or governance-SDK offer.",
+]
+
+
+class QuadrantFrame(BaseModel):
+    id: str
+    label: str
+    governance: str
+    orientation: str
+    description: str
+    occupied: bool = True
+
+
+class ProvenanceRecord(BaseModel):
+    id: str
+    label: str
+    source_type: str
+    reference: str
+    confidence: float
+
+
+class CouncilVerdictPayload(BaseModel):
+    id: str
+    decision: str
+    reason: str
+    gate_results: dict[str, str]
+    anekanta_frames: list[str]
+    steelman_summary: str
+    dogma_drift_summary: str
+    mirofish_activated: bool
+    mirofish_reason: str
+    quorum_participants: list[str]
+
+
+class FitnessVectorPayload(BaseModel):
+    id: str
+    auto_grade_score: float
+    council_score: float
+    provenance_score: float
+    market_value_score: float
+    welfare_score: float
+    composite_score: float
+    promotion_threshold: float
+    threshold_met: bool
+    promotion_state: str
+    scoring_method: str
+
+
+class RevenueCellPayload(BaseModel):
+    id: str
+    name: str
+    market_category: str
+    target_customer: str
+    revenue_model: str
+    verified_revenue_usd: float
+    expected_value_usd: float
+    evidence_tier: str
+    trustee_principle: str
+    status: str
+    next_actions: list[str]
+
+
+class TypedLinkPayload(BaseModel):
+    source_id: str
+    source_type: str
+    link_name: str
+    target_id: str
+    target_type: str
+
+
+class HypernodePayload(BaseModel):
+    id: str
+    slug: str
+    title: str
+    thesis: str
+    public_path: str
+    quadrant_map: list[QuadrantFrame]
+    provenance: list[ProvenanceRecord]
+    council_verdict: CouncilVerdictPayload
+    fitness_vector: FitnessVectorPayload
+    revenue_cell: RevenueCellPayload
+    object_chain: dict[str, list[str]]
+    typed_links: list[TypedLinkPayload]
+    next_actions: list[str]
+    ontology_counts: dict[str, int]
+
+
+def _quadrants() -> list[QuadrantFrame]:
+    return [
+        QuadrantFrame(
+            id="low-governance-extraction",
+            label="Slop economy",
+            governance="low governance",
+            orientation="extraction",
+            description="Cheap output, weak accountability, and attention capture.",
+        ),
+        QuadrantFrame(
+            id="high-governance-extraction",
+            label="Operational control",
+            governance="high governance",
+            orientation="extraction",
+            description="Palantir-style control loops optimized around institutional power.",
+        ),
+        QuadrantFrame(
+            id="low-governance-welfare",
+            label="Good intentions",
+            governance="low governance",
+            orientation="welfare",
+            description="Real care without enough execution, audit, or compounding power.",
+        ),
+        QuadrantFrame(
+            id="high-governance-welfare",
+            label="Empty quadrant",
+            governance="high governance",
+            orientation="welfare",
+            description="Auditable intelligence that turns world-welfare constraints into market value.",
+            occupied=False,
+        ),
+    ]
+
+
+def _provenance() -> list[ProvenanceRecord]:
+    return [
+        ProvenanceRecord(
+            id="source-user-plan",
+            label="Empty Quadrant Revenue Hypernode plan",
+            source_type="operator_plan",
+            reference="current task plan",
+            confidence=1.0,
+        ),
+        ProvenanceRecord(
+            id="source-aligned-revenue-engines",
+            label="Aligned Revenue Engines wiki",
+            source_type="wiki",
+            reference="~/.dharma/knowledge/wiki/concepts/aligned-revenue-engines.md",
+            confidence=0.88,
+        ),
+        ProvenanceRecord(
+            id="source-economic-spine",
+            label="Economic Spine wiki",
+            source_type="wiki",
+            reference="~/.dharma/knowledge/wiki/concepts/economic-spine.md",
+            confidence=0.90,
+        ),
+        ProvenanceRecord(
+            id="source-jagat-kalyan",
+            label="Jagat Kalyan wiki",
+            source_type="wiki",
+            reference="~/.dharma/knowledge/wiki/concepts/jagat-kalyan.md",
+            confidence=0.88,
+        ),
+    ]
+
+
+def _research_report() -> tuple[ResearchReport, list[SourceDocument]]:
+    provenance = _provenance()
+    sources = [
+        SourceDocument(
+            source_id=item.id,
+            url=f"file://{item.reference}",
+            title=item.label,
+            source_type=item.source_type,
+            authority_score=item.confidence,
+            freshness_score=0.86,
+        )
+        for item in provenance
+    ]
+    brief = ResearchBrief(
+        task_id=ACTION_PROPOSAL_ID,
+        topic="Empty Quadrant revenue cell",
+        question="Can high-governance, welfare-oriented intelligence be made market-facing without erasing telos?",
+        requires_recency=False,
+        metadata={"sources_requested": True},
+    )
+    claims = [
+        ClaimRecord(
+            claim_id="claim-quadrant-map",
+            text="The market map has an underoccupied high-governance, welfare-oriented quadrant.",
+            support_level="supported",
+            supporting_source_ids=["source-user-plan", "source-jagat-kalyan"],
+            citations=["[source-user-plan]", "[source-jagat-kalyan]"],
+            confidence=0.86,
+        ),
+        ClaimRecord(
+            claim_id="claim-revenue-trustee",
+            text="Revenue is valid only as trustee flow that funds welfare-serving work.",
+            support_level="supported",
+            supporting_source_ids=["source-economic-spine", "source-jagat-kalyan"],
+            citations=["[source-economic-spine]", "[source-jagat-kalyan]"],
+            confidence=0.90,
+        ),
+        ClaimRecord(
+            claim_id="claim-first-surface",
+            text="The first artifact should be both a public dashboard surface and ontology-backed internal graph.",
+            support_level="supported",
+            supporting_source_ids=["source-user-plan", "source-aligned-revenue-engines"],
+            citations=["[source-user-plan]", "[source-aligned-revenue-engines]"],
+            confidence=0.84,
+        ),
+    ]
+    body = (
+        "The Empty Quadrant Revenue Cell frames the market as four quadrants: slop economy, "
+        "operational control, good intentions, and high-governance welfare. [source-user-plan] "
+        "The economic spine requires verified revenue to stay distinct from internal estimates. "
+        "[source-economic-spine] Jagat Kalyan keeps revenue instrumental rather than primary. "
+        "[source-jagat-kalyan] However, the strongest counterargument is that revenue pressure "
+        "could pull a welfare-governance system back into extraction; the mitigation is an "
+        "audited council trace, provenance, and a MIROFISH adversarial pass. The mechanism is "
+        "a typed ontology architecture, the phenomenological guard is witness awareness, and "
+        "the systems frame is feedback across the market ecosystem. Recommended next step: "
+        "publish the page, then attach one external buyer signal before revenue validation."
+    )
+    report = ResearchReport(
+        report_id="report-empty-quadrant-revenue",
+        task_id=ACTION_PROPOSAL_ID,
+        brief=brief,
+        summary="Hypernode #1 turns the empty quadrant thesis into a public and ontology-backed artifact.",
+        body=body,
+        claims=claims,
+        source_ids=[source.source_id for source in sources],
+        metadata={"topical_coverage": 0.91, "novelty": 0.78},
+    )
+    return report, sources
+
+
+def _gate_result_text(results: dict[str, tuple[GateResult, str]]) -> dict[str, str]:
+    return {name: result.value for name, (result, _reason) in results.items()}
+
+
+def evaluate_hypernode_council() -> CouncilVerdictPayload:
+    report, _sources = _research_report()
+    anekanta = evaluate_anekanta(report.summary, report.body)
+    gate_check = TelosGatekeeper().check(
+        action="propose hypernode revenue cell",
+        content=report.body,
+    )
+    gate_results = _gate_result_text(gate_check.gate_results)
+    gate_results["MIROFISH"] = "WARN"
+
+    return CouncilVerdictPayload(
+        id=COUNCIL_VERDICT_ID,
+        decision="warn",
+        reason=(
+            "Anekanta, STEELMAN, and DOGMA_DRIFT pass; MIROFISH remains active "
+            "because public revenue claims can drift into extraction without external evidence."
+        ),
+        gate_results=gate_results,
+        anekanta_frames=anekanta.frames_detected,
+        steelman_summary=gate_check.gate_results.get("STEELMAN", (GateResult.WARN, ""))[1],
+        dogma_drift_summary=gate_check.gate_results.get("DOGMA_DRIFT", (GateResult.WARN, ""))[1],
+        mirofish_activated=True,
+        mirofish_reason=(
+            "Maximum-divergence simulation required for high-stakes category claims, "
+            "especially extraction drift, Goodhart pressure, and worldview overreach."
+        ),
+        quorum_participants=QUORUM_PARTICIPANTS,
+    )
+
+
+def score_hypernode(
+    council: CouncilVerdictPayload,
+    revenue_cell: RevenueCellPayload,
+) -> FitnessVectorPayload:
+    report, sources = _research_report()
+    reward = AutoGradeEngine().grade(
+        report,
+        sources,
+        latency_ms=1400,
+        token_cost_usd=0.04,
+        total_tokens=2400,
+        cost_budget_usd=1.0,
+        latency_budget_ms=6000,
+        token_budget=6000,
+    )
+    auto_grade_score = reward.grade_card.final_score
+    council_score = 0.82 if council.decision in {"warn", "review"} else 1.0
+    provenance_score = min(1.0, len(_provenance()) / 4.0)
+    market_value_score = min(1.0, max(0.0, revenue_cell.expected_value_usd) / 10_000.0)
+    welfare_score = 0.95
+    composite = (
+        0.35 * auto_grade_score
+        + 0.25 * council_score
+        + 0.20 * provenance_score
+        + 0.10 * market_value_score
+        + 0.10 * welfare_score
+    )
+    threshold = 0.82
+    threshold_met = composite >= threshold and not reward.grade_card.gate_failures
+    if revenue_cell.verified_revenue_usd > 0 and threshold_met:
+        promotion_state = "revenue_validated"
+    elif threshold_met:
+        promotion_state = "public_artifact_ready"
+    else:
+        promotion_state = "quorum_ready"
+
+    return FitnessVectorPayload(
+        id=FITNESS_VECTOR_ID,
+        auto_grade_score=round(auto_grade_score, 4),
+        council_score=round(council_score, 4),
+        provenance_score=round(provenance_score, 4),
+        market_value_score=round(market_value_score, 4),
+        welfare_score=round(welfare_score, 4),
+        composite_score=round(composite, 4),
+        promotion_threshold=threshold,
+        threshold_met=threshold_met,
+        promotion_state=promotion_state,
+        scoring_method="hypernode_fitness_v1:0.35_autograde+0.25_council+0.20_provenance+0.10_market+0.10_welfare",
+    )
+
+
+def _revenue_cell() -> RevenueCellPayload:
+    return RevenueCellPayload(
+        id=REVENUE_CELL_ID,
+        name="Empty Quadrant Revenue Cell",
+        market_category="telos-gated agent governance and research council surfaces",
+        target_customer="teams that need auditable AI governance without extraction-first incentives",
+        revenue_model=(
+            "Start with paid advisory and governance dashboard implementation; graduate only "
+            "after external buyer evidence, not internal enthusiasm."
+        ),
+        verified_revenue_usd=0.0,
+        expected_value_usd=5000.0,
+        evidence_tier="internal_estimate",
+        trustee_principle="Revenue flows through the system for Jagat Kalyan; it is not allowed to become the telos.",
+        status="validating",
+        next_actions=NEXT_ACTIONS,
+    )
+
+
+def build_empty_quadrant_payload() -> HypernodePayload:
+    revenue_cell = _revenue_cell()
+    council = evaluate_hypernode_council()
+    fitness = score_hypernode(council, revenue_cell)
+    object_chain = {
+        "inquiry": [SIGNAL_ID, QUESTION_ID, CLAIM_ID, EVIDENCE_ID, DOCTRINE_ID],
+        "action": [ACTION_PROPOSAL_ID, GATE_RECORD_ID, EXECUTION_LEASE_ID, OUTCOME_ID, VALUE_EVENT_ID, CONTRIBUTION_ID],
+    }
+    return HypernodePayload(
+        id=HYPERNODE_ID,
+        slug=EMPTY_QUADRANT_SLUG,
+        title="Empty Quadrant Revenue Cell",
+        thesis=(
+            "High-governance, welfare-oriented intelligence is the empty market quadrant: "
+            "not slop, not extraction control, and not powerless good intention."
+        ),
+        public_path=EMPTY_QUADRANT_PUBLIC_PATH,
+        quadrant_map=_quadrants(),
+        provenance=_provenance(),
+        council_verdict=council,
+        fitness_vector=fitness,
+        revenue_cell=revenue_cell,
+        object_chain=object_chain,
+        typed_links=[],
+        next_actions=NEXT_ACTIONS,
+        ontology_counts={},
+    )

--- a/dharma_swarm/hypernode_ontology.py
+++ b/dharma_swarm/hypernode_ontology.py
@@ -1,0 +1,371 @@
+"""Ontology schema additions for revenue hypernodes."""
+
+from __future__ import annotations
+
+from dharma_swarm.ontology import (
+    ActionDef,
+    LinkCardinality,
+    LinkDef,
+    ObjectType,
+    OntologyRegistry,
+    PropertyDef,
+    PropertyType,
+    SecurityLevel,
+    SecurityPolicy,
+    ShaktiEnergy,
+)
+
+
+_HYPERNODE = ObjectType(
+    name="Hypernode",
+    description="A worldview-backed revenue cell with public artifact, provenance, gates, and value trace",
+    properties={
+        "hypernode_id": PropertyDef(
+            name="hypernode_id",
+            property_type=PropertyType.STRING,
+            required=True,
+            immutable=True,
+        ),
+        "slug": PropertyDef(
+            name="slug",
+            property_type=PropertyType.STRING,
+            required=True,
+            searchable=True,
+            immutable=True,
+        ),
+        "title": PropertyDef(
+            name="title",
+            property_type=PropertyType.STRING,
+            required=True,
+            searchable=True,
+        ),
+        "thesis": PropertyDef(
+            name="thesis",
+            property_type=PropertyType.TEXT,
+            required=True,
+            searchable=True,
+        ),
+        "quadrant": PropertyDef(
+            name="quadrant",
+            property_type=PropertyType.ENUM,
+            required=True,
+            enum_values=[
+                "low_governance_extraction",
+                "high_governance_extraction",
+                "low_governance_welfare",
+                "high_governance_welfare",
+            ],
+        ),
+        "status": PropertyDef(
+            name="status",
+            property_type=PropertyType.ENUM,
+            required=True,
+            enum_values=["seeded", "gated", "public_artifact_ready", "revenue_validated", "archived"],
+        ),
+        "public_path": PropertyDef(name="public_path", property_type=PropertyType.PATH),
+        "object_chain": PropertyDef(name="object_chain", property_type=PropertyType.DICT),
+        "provenance_refs": PropertyDef(name="provenance_refs", property_type=PropertyType.LIST),
+        "next_actions": PropertyDef(name="next_actions", property_type=PropertyType.LIST),
+    },
+    actions=[
+        ActionDef(
+            name="SeedHypernode",
+            object_type="Hypernode",
+            description="Create a new public/internal hypernode seed",
+            creates=["RevenueCell", "CouncilVerdict", "FitnessVector"],
+            telos_gates=["AHIMSA", "SATYA", "ANEKANTA", "STEELMAN"],
+        ),
+        ActionDef(
+            name="PromoteHypernode",
+            object_type="Hypernode",
+            description="Promote after quorum, provenance, and fitness thresholds pass",
+            modifies=["status"],
+            requires_approval=True,
+            telos_gates=["AHIMSA", "SATYA", "DOGMA_DRIFT", "STEELMAN"],
+        ),
+    ],
+    security=SecurityPolicy(
+        read_roles=["*"],
+        create_roles=["orchestrator", "operator", "system"],
+        write_roles=["orchestrator", "operator", "system"],
+        delete_roles=[],
+        classification=SecurityLevel.PUBLIC,
+        audit_all=True,
+        telos_required=True,
+    ),
+    telos_alignment=0.98,
+    shakti_energy=ShaktiEnergy.MAHALAKSHMI,
+    icon="H",
+)
+
+_REVENUE_CELL = ObjectType(
+    name="RevenueCell",
+    description="Market-facing metabolic cell; revenue is tracked as trustee flow, not private possession",
+    properties={
+        "revenue_cell_id": PropertyDef(
+            name="revenue_cell_id",
+            property_type=PropertyType.STRING,
+            required=True,
+            immutable=True,
+        ),
+        "hypernode_ref": PropertyDef(
+            name="hypernode_ref",
+            property_type=PropertyType.STRING,
+            required=True,
+            immutable=True,
+        ),
+        "name": PropertyDef(
+            name="name",
+            property_type=PropertyType.STRING,
+            required=True,
+            searchable=True,
+        ),
+        "market_category": PropertyDef(name="market_category", property_type=PropertyType.STRING),
+        "target_customer": PropertyDef(name="target_customer", property_type=PropertyType.STRING),
+        "revenue_model": PropertyDef(name="revenue_model", property_type=PropertyType.TEXT),
+        "verified_revenue_usd": PropertyDef(name="verified_revenue_usd", property_type=PropertyType.FLOAT),
+        "expected_value_usd": PropertyDef(name="expected_value_usd", property_type=PropertyType.FLOAT),
+        "evidence_tier": PropertyDef(
+            name="evidence_tier",
+            property_type=PropertyType.ENUM,
+            enum_values=[
+                "internal_estimate",
+                "market_signal",
+                "invoice_paid",
+                "stripe_event",
+                "bank_transaction",
+            ],
+        ),
+        "trustee_principle": PropertyDef(name="trustee_principle", property_type=PropertyType.TEXT),
+        "status": PropertyDef(
+            name="status",
+            property_type=PropertyType.ENUM,
+            enum_values=["seeded", "validating", "earning", "paused", "archived"],
+        ),
+        "next_actions": PropertyDef(name="next_actions", property_type=PropertyType.LIST),
+    },
+    actions=[
+        ActionDef(
+            name="RecordRevenueSignal",
+            object_type="RevenueCell",
+            description="Record market evidence without treating estimates as verified revenue",
+            modifies=["verified_revenue_usd", "expected_value_usd", "evidence_tier"],
+            telos_gates=["SATYA", "DOGMA_DRIFT"],
+        ),
+    ],
+    security=SecurityPolicy(
+        create_roles=["orchestrator", "operator", "system"],
+        write_roles=["orchestrator", "operator", "system"],
+        delete_roles=[],
+        audit_all=True,
+    ),
+    telos_alignment=0.94,
+    shakti_energy=ShaktiEnergy.MAHALAKSHMI,
+    icon="$",
+)
+
+_COUNCIL_VERDICT = ObjectType(
+    name="CouncilVerdict",
+    description="Quorum result for a hypernode, including Anekanta, steelman, dogma drift, and MIROFISH trace",
+    properties={
+        "verdict_id": PropertyDef(
+            name="verdict_id",
+            property_type=PropertyType.STRING,
+            required=True,
+            immutable=True,
+        ),
+        "hypernode_ref": PropertyDef(
+            name="hypernode_ref",
+            property_type=PropertyType.STRING,
+            required=True,
+            immutable=True,
+        ),
+        "decision": PropertyDef(
+            name="decision",
+            property_type=PropertyType.ENUM,
+            required=True,
+            enum_values=["pass", "warn", "fail", "review"],
+        ),
+        "reason": PropertyDef(name="reason", property_type=PropertyType.TEXT),
+        "gate_results": PropertyDef(name="gate_results", property_type=PropertyType.DICT),
+        "anekanta_frames": PropertyDef(name="anekanta_frames", property_type=PropertyType.LIST),
+        "steelman_summary": PropertyDef(name="steelman_summary", property_type=PropertyType.TEXT),
+        "dogma_drift_summary": PropertyDef(name="dogma_drift_summary", property_type=PropertyType.TEXT),
+        "mirofish_activated": PropertyDef(name="mirofish_activated", property_type=PropertyType.BOOLEAN),
+        "mirofish_reason": PropertyDef(name="mirofish_reason", property_type=PropertyType.TEXT),
+        "quorum_participants": PropertyDef(name="quorum_participants", property_type=PropertyType.LIST),
+        "recorded_at": PropertyDef(name="recorded_at", property_type=PropertyType.DATETIME),
+    },
+    actions=[
+        ActionDef(
+            name="RecordCouncilVerdict",
+            object_type="CouncilVerdict",
+            description="Record the quorum trace for a hypernode",
+            telos_gates=["ANEKANTA", "STEELMAN", "DOGMA_DRIFT"],
+        ),
+    ],
+    security=SecurityPolicy(audit_all=True, delete_roles=[]),
+    telos_alignment=1.0,
+    shakti_energy=ShaktiEnergy.MAHESHWARI,
+    icon="Q",
+)
+
+_FITNESS_VECTOR = ObjectType(
+    name="FitnessVector",
+    description="Hypernode promotion score from AutoGrade, council verdicts, provenance, market, and welfare dimensions",
+    properties={
+        "fitness_id": PropertyDef(
+            name="fitness_id",
+            property_type=PropertyType.STRING,
+            required=True,
+            immutable=True,
+        ),
+        "hypernode_ref": PropertyDef(
+            name="hypernode_ref",
+            property_type=PropertyType.STRING,
+            required=True,
+            immutable=True,
+        ),
+        "auto_grade_score": PropertyDef(name="auto_grade_score", property_type=PropertyType.FLOAT),
+        "council_score": PropertyDef(name="council_score", property_type=PropertyType.FLOAT),
+        "provenance_score": PropertyDef(name="provenance_score", property_type=PropertyType.FLOAT),
+        "market_value_score": PropertyDef(name="market_value_score", property_type=PropertyType.FLOAT),
+        "welfare_score": PropertyDef(name="welfare_score", property_type=PropertyType.FLOAT),
+        "composite_score": PropertyDef(name="composite_score", property_type=PropertyType.FLOAT),
+        "promotion_threshold": PropertyDef(name="promotion_threshold", property_type=PropertyType.FLOAT),
+        "threshold_met": PropertyDef(name="threshold_met", property_type=PropertyType.BOOLEAN),
+        "promotion_state": PropertyDef(
+            name="promotion_state",
+            property_type=PropertyType.ENUM,
+            enum_values=[
+                "candidate",
+                "quorum_ready",
+                "public_artifact_ready",
+                "revenue_validated",
+                "revise",
+            ],
+        ),
+        "scoring_method": PropertyDef(name="scoring_method", property_type=PropertyType.STRING),
+    },
+    actions=[
+        ActionDef(
+            name="ScoreHypernode",
+            object_type="FitnessVector",
+            description="Score a hypernode for artifact and revenue-cell promotion",
+            telos_gates=["SATYA", "DOGMA_DRIFT"],
+        ),
+    ],
+    security=SecurityPolicy(audit_all=True, delete_roles=[]),
+    telos_alignment=0.9,
+    shakti_energy=ShaktiEnergy.MAHASARASWATI,
+    icon="F",
+)
+
+_HYPERNODE_LINKS: list[LinkDef] = [
+    LinkDef(
+        name="has_revenue_cell",
+        source_type="Hypernode",
+        target_type="RevenueCell",
+        cardinality=LinkCardinality.ONE_TO_ONE,
+        inverse_name="cell_of_hypernode",
+    ),
+    LinkDef(
+        name="has_council_verdict",
+        source_type="Hypernode",
+        target_type="CouncilVerdict",
+        cardinality=LinkCardinality.ONE_TO_MANY,
+        inverse_name="verdict_for_hypernode",
+    ),
+    LinkDef(
+        name="has_fitness_vector",
+        source_type="Hypernode",
+        target_type="FitnessVector",
+        cardinality=LinkCardinality.ONE_TO_ONE,
+        inverse_name="fitness_for_hypernode",
+    ),
+    LinkDef(
+        name="grounded_in_signal",
+        source_type="Hypernode",
+        target_type="Signal",
+        cardinality=LinkCardinality.MANY_TO_ONE,
+        inverse_name="grounds_hypernode",
+    ),
+    LinkDef(
+        name="answers_question",
+        source_type="Hypernode",
+        target_type="Question",
+        cardinality=LinkCardinality.MANY_TO_ONE,
+        inverse_name="answered_by_hypernode",
+    ),
+    LinkDef(
+        name="asserts_claim",
+        source_type="Hypernode",
+        target_type="Claim",
+        cardinality=LinkCardinality.MANY_TO_ONE,
+        inverse_name="asserted_by_hypernode",
+    ),
+    LinkDef(
+        name="cites_evidence",
+        source_type="Hypernode",
+        target_type="Evidence",
+        cardinality=LinkCardinality.ONE_TO_MANY,
+        inverse_name="cited_by_hypernode",
+    ),
+    LinkDef(
+        name="codifies_doctrine",
+        source_type="Hypernode",
+        target_type="Doctrine",
+        cardinality=LinkCardinality.ONE_TO_ONE,
+        inverse_name="codified_by_hypernode",
+    ),
+    LinkDef(
+        name="has_action_proposal",
+        source_type="Hypernode",
+        target_type="ActionProposal",
+        cardinality=LinkCardinality.ONE_TO_ONE,
+        inverse_name="proposal_for_hypernode",
+    ),
+    LinkDef(
+        name="has_gate_record",
+        source_type="Hypernode",
+        target_type="GateDecisionRecord",
+        cardinality=LinkCardinality.ONE_TO_ONE,
+        inverse_name="gate_record_for_hypernode",
+    ),
+    LinkDef(
+        name="has_execution_record",
+        source_type="Hypernode",
+        target_type="ExecutionLease",
+        cardinality=LinkCardinality.ONE_TO_ONE,
+        inverse_name="execution_record_for_hypernode",
+    ),
+    LinkDef(
+        name="has_outcome_record",
+        source_type="Hypernode",
+        target_type="Outcome",
+        cardinality=LinkCardinality.ONE_TO_ONE,
+        inverse_name="outcome_record_for_hypernode",
+    ),
+    LinkDef(
+        name="has_value_event",
+        source_type="Hypernode",
+        target_type="ValueEvent",
+        cardinality=LinkCardinality.ONE_TO_ONE,
+        inverse_name="value_event_for_hypernode",
+    ),
+    LinkDef(
+        name="has_contribution",
+        source_type="Hypernode",
+        target_type="Contribution",
+        cardinality=LinkCardinality.ONE_TO_ONE,
+        inverse_name="contribution_for_hypernode",
+    ),
+]
+
+
+def register_hypernode_types(registry: OntologyRegistry) -> None:
+    """Register hypernode types and links idempotently."""
+    for obj_type in (_HYPERNODE, _REVENUE_CELL, _COUNCIL_VERDICT, _FITNESS_VECTOR):
+        registry.register_type(obj_type)
+    for link_def in _HYPERNODE_LINKS:
+        registry.register_link(link_def)

--- a/dharma_swarm/hypernode_seed.py
+++ b/dharma_swarm/hypernode_seed.py
@@ -1,0 +1,366 @@
+"""Write-through ontology seed for the Empty Quadrant hypernode."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from dharma_swarm.hypernode import (
+    ACTION_PROPOSAL_ID,
+    CLAIM_ID,
+    CONTRIBUTION_ID,
+    COUNCIL_VERDICT_ID,
+    DOCTRINE_ID,
+    EMPTY_QUADRANT_PUBLIC_PATH,
+    EVIDENCE_ID,
+    EXECUTION_LEASE_ID,
+    FITNESS_VECTOR_ID,
+    GATE_RECORD_ID,
+    HYPERNODE_ID,
+    OUTCOME_ID,
+    PRINCIPAL_AGENT_ID,
+    PUBLIC_ARTIFACT_ID,
+    QUESTION_ID,
+    REVENUE_CELL_ID,
+    SIGNAL_ID,
+    VALUE_EVENT_ID,
+    HypernodePayload,
+    TypedLinkPayload,
+    build_empty_quadrant_payload,
+)
+from dharma_swarm.models import GateDecision
+from dharma_swarm.ontology import Link, OntologyObj, OntologyRegistry
+
+
+class HypernodeSeedResult(BaseModel):
+    payload: HypernodePayload
+    objects: dict[str, str]
+    links: list[TypedLinkPayload]
+    errors: list[str] = Field(default_factory=list)
+
+
+def _utc_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _put_object(
+    registry: OntologyRegistry,
+    obj_id: str,
+    type_name: str,
+    properties: dict[str, Any],
+    *,
+    created_by: str,
+) -> tuple[OntologyObj | None, list[str]]:
+    existing = registry.get_object(obj_id)
+    if existing is not None and existing.type_name == type_name and existing.properties == properties:
+        return existing, []
+    return registry.put_object(
+        OntologyObj(id=obj_id, type_name=type_name, properties=properties, created_by=created_by)
+    )
+
+
+def _ensure_link(
+    registry: OntologyRegistry,
+    link_name: str,
+    source_id: str,
+    target_id: str,
+    *,
+    created_by: str,
+) -> tuple[Link | None, list[str]]:
+    existing = registry.get_links(source_id=source_id, target_id=target_id, link_name=link_name)
+    if existing:
+        return existing[0], []
+    return registry.create_link(link_name, source_id, target_id, created_by=created_by)
+
+
+def _object_specs(payload: HypernodePayload, now: str) -> list[tuple[str, str, dict[str, Any]]]:
+    return [
+        (
+            PRINCIPAL_AGENT_ID,
+            "AgentIdentity",
+            {"name": "dhyana", "role": "operator", "status": "idle", "is_principal": True},
+        ),
+        (
+            PUBLIC_ARTIFACT_ID,
+            "KnowledgeArtifact",
+            {
+                "title": "Empty Quadrant Revenue Cell public page",
+                "artifact_type": "visualization",
+                "domain": "dharma_swarm",
+                "content": payload.thesis,
+                "file_path": "dashboard/src/app/dashboard/hypernodes/empty-quadrant/page.tsx",
+                "provenance": ",".join(item.id for item in payload.provenance),
+                "confidence": payload.fitness_vector.auto_grade_score,
+                "verified": True,
+                "audience": "public",
+                "published_path": payload.public_path,
+                "published_at": now,
+                "published_channel": "dashboard",
+            },
+        ),
+        (
+            SIGNAL_ID,
+            "Signal",
+            {
+                "signal_id": SIGNAL_ID,
+                "source": "operator_plan",
+                "captured_at": now,
+                "payload": payload.thesis,
+                "observer_ref": "dhyana",
+                "source_kind": "manual",
+                "sensitivity": "public",
+            },
+        ),
+        (
+            QUESTION_ID,
+            "Question",
+            {
+                "question_id": QUESTION_ID,
+                "text": "Can dharma_swarm create market value in the high-governance welfare quadrant?",
+                "opener_ref": "dhyana",
+                "opened_at": now,
+                "lifecycle_state": "answered",
+                "domain": "revenue",
+                "priority": "urgent",
+            },
+        ),
+        (
+            CLAIM_ID,
+            "Claim",
+            {
+                "claim_id": CLAIM_ID,
+                "statement": payload.thesis,
+                "lifecycle_state": "accepted",
+                "confidence": payload.fitness_vector.composite_score,
+                "proposer_ref": "dhyana",
+                "evidence_refs": [EVIDENCE_ID],
+            },
+        ),
+        (
+            EVIDENCE_ID,
+            "Evidence",
+            {
+                "evidence_id": EVIDENCE_ID,
+                "claim_ref": CLAIM_ID,
+                "kind": "witness_chain",
+                "direction": "supports",
+                "source_artifact_ref": PUBLIC_ARTIFACT_ID,
+                "attached_at": now,
+                "attached_by_ref": "hypernode.seed",
+                "strength": payload.fitness_vector.provenance_score,
+            },
+        ),
+        (
+            DOCTRINE_ID,
+            "Doctrine",
+            {
+                "doctrine_id": DOCTRINE_ID,
+                "text": "Revenue may serve Jagat Kalyan only when governed as trustee flow and audited against extraction drift.",
+                "lifecycle_state": "draft",
+                "kernel_signature": "pending-human-signature",
+                "version": 1,
+            },
+        ),
+        (
+            HYPERNODE_ID,
+            "Hypernode",
+            {
+                "hypernode_id": HYPERNODE_ID,
+                "slug": payload.slug,
+                "title": payload.title,
+                "thesis": payload.thesis,
+                "quadrant": "high_governance_welfare",
+                "status": payload.fitness_vector.promotion_state,
+                "public_path": payload.public_path,
+                "object_chain": payload.object_chain,
+                "provenance_refs": [item.id for item in payload.provenance],
+                "next_actions": payload.next_actions,
+            },
+        ),
+        (
+            REVENUE_CELL_ID,
+            "RevenueCell",
+            {
+                **payload.revenue_cell.model_dump(),
+                "revenue_cell_id": REVENUE_CELL_ID,
+                "hypernode_ref": HYPERNODE_ID,
+            },
+        ),
+        (
+            COUNCIL_VERDICT_ID,
+            "CouncilVerdict",
+            {
+                **payload.council_verdict.model_dump(),
+                "verdict_id": COUNCIL_VERDICT_ID,
+                "hypernode_ref": HYPERNODE_ID,
+                "recorded_at": now,
+            },
+        ),
+        (
+            FITNESS_VECTOR_ID,
+            "FitnessVector",
+            {
+                **payload.fitness_vector.model_dump(),
+                "fitness_id": FITNESS_VECTOR_ID,
+                "hypernode_ref": HYPERNODE_ID,
+            },
+        ),
+        (
+            ACTION_PROPOSAL_ID,
+            "ActionProposal",
+            {
+                "task_id": ACTION_PROPOSAL_ID,
+                "agent_id": PRINCIPAL_AGENT_ID,
+                "action_type": "manual",
+                "title": "Publish Empty Quadrant hypernode surface",
+                "description": payload.thesis,
+                "status": "approved",
+                "priority": "urgent",
+            },
+        ),
+        (
+            GATE_RECORD_ID,
+            "GateDecisionRecord",
+            {
+                "proposal_id": ACTION_PROPOSAL_ID,
+                "decision": GateDecision.ALLOW.value,
+                "reason": payload.council_verdict.reason,
+                "gate_results": payload.council_verdict.gate_results,
+                "witness_reroutes": 1,
+            },
+        ),
+        (
+            EXECUTION_LEASE_ID,
+            "ExecutionLease",
+            {
+                "proposal_id": ACTION_PROPOSAL_ID,
+                "claim_id": CLAIM_ID,
+                "agent_id": PRINCIPAL_AGENT_ID,
+                "claimed_at": now,
+                "claim_timeout_seconds": 3600.0,
+                "claim_expires_at_epoch": 0.0,
+                "dispatch_timeout_seconds": 3600.0,
+                "dispatch_attempt": 1,
+            },
+        ),
+        (
+            OUTCOME_ID,
+            "Outcome",
+            {
+                "proposal_id": ACTION_PROPOSAL_ID,
+                "task_id": ACTION_PROPOSAL_ID,
+                "agent_id": PRINCIPAL_AGENT_ID,
+                "success": True,
+                "result_summary": "Ontology-backed public hypernode artifact seeded.",
+                "error": "",
+                "duration_ms": 0.0,
+                "fitness_score": payload.fitness_vector.composite_score,
+            },
+        ),
+        (
+            VALUE_EVENT_ID,
+            "ValueEvent",
+            {
+                "outcome_id": OUTCOME_ID,
+                "agent_id": PRINCIPAL_AGENT_ID,
+                "cell_id": REVENUE_CELL_ID,
+                "task_id": ACTION_PROPOSAL_ID,
+                "task_type": "build",
+                "behavioral_signal": payload.fitness_vector.welfare_score,
+                "success_value": 1.0,
+                "duration_efficiency": 1.0,
+                "composite_value": payload.fitness_vector.composite_score,
+                "scoring_method": payload.fitness_vector.scoring_method,
+            },
+        ),
+        (
+            CONTRIBUTION_ID,
+            "Contribution",
+            {
+                "value_event_id": VALUE_EVENT_ID,
+                "agent_id": PRINCIPAL_AGENT_ID,
+                "cell_id": REVENUE_CELL_ID,
+                "task_type": "build",
+                "credit_share": 1.0,
+                "attributed_value": payload.fitness_vector.composite_score,
+            },
+        ),
+    ]
+
+
+def _link_specs() -> list[tuple[str, str, str]]:
+    return [
+        ("observed_by", SIGNAL_ID, PRINCIPAL_AGENT_ID),
+        ("opens_question", SIGNAL_ID, QUESTION_ID),
+        ("opened_by", QUESTION_ID, PRINCIPAL_AGENT_ID),
+        ("answered_by_claim", QUESTION_ID, CLAIM_ID),
+        ("claim_proposed_by", CLAIM_ID, PRINCIPAL_AGENT_ID),
+        ("claim_has_evidence", CLAIM_ID, EVIDENCE_ID),
+        ("evidence_from_artifact", EVIDENCE_ID, PUBLIC_ARTIFACT_ID),
+        ("derived_from_claim", DOCTRINE_ID, CLAIM_ID),
+        ("has_revenue_cell", HYPERNODE_ID, REVENUE_CELL_ID),
+        ("has_council_verdict", HYPERNODE_ID, COUNCIL_VERDICT_ID),
+        ("has_fitness_vector", HYPERNODE_ID, FITNESS_VECTOR_ID),
+        ("grounded_in_signal", HYPERNODE_ID, SIGNAL_ID),
+        ("answers_question", HYPERNODE_ID, QUESTION_ID),
+        ("asserts_claim", HYPERNODE_ID, CLAIM_ID),
+        ("cites_evidence", HYPERNODE_ID, EVIDENCE_ID),
+        ("codifies_doctrine", HYPERNODE_ID, DOCTRINE_ID),
+        ("has_action_proposal", HYPERNODE_ID, ACTION_PROPOSAL_ID),
+        ("has_gate_record", HYPERNODE_ID, GATE_RECORD_ID),
+        ("has_execution_record", HYPERNODE_ID, EXECUTION_LEASE_ID),
+        ("has_outcome_record", HYPERNODE_ID, OUTCOME_ID),
+        ("has_value_event", HYPERNODE_ID, VALUE_EVENT_ID),
+        ("has_contribution", HYPERNODE_ID, CONTRIBUTION_ID),
+        ("has_gate_decision", ACTION_PROPOSAL_ID, GATE_RECORD_ID),
+        ("has_execution_lease", ACTION_PROPOSAL_ID, EXECUTION_LEASE_ID),
+        ("has_outcome", ACTION_PROPOSAL_ID, OUTCOME_ID),
+        ("has_value_event", OUTCOME_ID, VALUE_EVENT_ID),
+        ("has_contribution", VALUE_EVENT_ID, CONTRIBUTION_ID),
+    ]
+
+
+def ensure_empty_quadrant_hypernode(
+    registry: OntologyRegistry,
+    *,
+    created_by: str = "hypernode.seed",
+) -> HypernodeSeedResult:
+    payload = build_empty_quadrant_payload()
+    now = _utc_iso()
+    errors: list[str] = []
+    objects: dict[str, str] = {}
+
+    for obj_id, type_name, properties in _object_specs(payload, now):
+        obj, errs = _put_object(registry, obj_id, type_name, properties, created_by=created_by)
+        if errs:
+            errors.extend([f"{obj_id}: {err}" for err in errs])
+        elif obj is not None:
+            objects[obj_id] = obj.type_name
+
+    links: list[TypedLinkPayload] = []
+    for link_name, source_id, target_id in _link_specs():
+        link, errs = _ensure_link(registry, link_name, source_id, target_id, created_by=created_by)
+        if errs:
+            errors.extend([f"{link_name}: {err}" for err in errs])
+        elif link is not None:
+            links.append(
+                TypedLinkPayload(
+                    source_id=link.source_id,
+                    source_type=link.source_type,
+                    link_name=link.link_name,
+                    target_id=link.target_id,
+                    target_type=link.target_type,
+                )
+            )
+
+    stats = registry.stats()
+    payload.public_path = EMPTY_QUADRANT_PUBLIC_PATH
+    payload.typed_links = links
+    payload.ontology_counts = {
+        "objects": stats["total_objects"],
+        "links": stats["total_links"],
+        "registered_types": stats["registered_types"],
+    }
+    return HypernodeSeedResult(payload=payload, objects=objects, links=links, errors=errors)

--- a/dharma_swarm/ontology.py
+++ b/dharma_swarm/ontology.py
@@ -848,6 +848,9 @@ class OntologyRegistry:
             registry.register_link(link_def)
         for link_def in _METABOLIC_LINKS:
             registry.register_link(link_def)
+        from dharma_swarm.hypernode_ontology import register_hypernode_types
+
+        register_hypernode_types(registry)
         return registry
 
 

--- a/tests/test_hypernode.py
+++ b/tests/test_hypernode.py
@@ -1,0 +1,125 @@
+"""Tests for Empty Quadrant revenue hypernode ontology, council, and scoring."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from dharma_swarm.api import create_app
+from dharma_swarm.hypernode import (
+    ACTION_PROPOSAL_ID,
+    CLAIM_ID,
+    COUNCIL_VERDICT_ID,
+    DOCTRINE_ID,
+    EVIDENCE_ID,
+    FITNESS_VECTOR_ID,
+    HYPERNODE_ID,
+    QUESTION_ID,
+    REVENUE_CELL_ID,
+    SIGNAL_ID,
+    VALUE_EVENT_ID,
+    build_empty_quadrant_payload,
+    evaluate_hypernode_council,
+    score_hypernode,
+)
+from dharma_swarm.hypernode_seed import ensure_empty_quadrant_hypernode
+from dharma_swarm.ontology import OntologyRegistry
+
+
+def test_hypernode_types_register_in_canonical_registry() -> None:
+    registry = OntologyRegistry.create_dharma_registry()
+    for type_name in ("Hypernode", "RevenueCell", "CouncilVerdict", "FitnessVector"):
+        assert registry.get_type(type_name) is not None
+
+    hypernode_links = {link.name for link in registry.get_links_for("Hypernode")}
+    assert "has_revenue_cell" in hypernode_links
+    assert "has_council_verdict" in hypernode_links
+    assert "has_fitness_vector" in hypernode_links
+    assert "grounded_in_signal" in hypernode_links
+    assert "has_value_event" in hypernode_links
+
+
+def test_empty_quadrant_seed_creates_canonical_object_chains() -> None:
+    registry = OntologyRegistry.create_dharma_registry()
+    seeded = ensure_empty_quadrant_hypernode(registry)
+
+    assert seeded.errors == []
+    assert registry.get_object(HYPERNODE_ID).type_name == "Hypernode"
+    assert registry.get_object(REVENUE_CELL_ID).type_name == "RevenueCell"
+    assert registry.get_object(COUNCIL_VERDICT_ID).type_name == "CouncilVerdict"
+    assert registry.get_object(FITNESS_VECTOR_ID).type_name == "FitnessVector"
+
+    expected_links = {
+        ("opens_question", SIGNAL_ID, QUESTION_ID),
+        ("answered_by_claim", QUESTION_ID, CLAIM_ID),
+        ("claim_has_evidence", CLAIM_ID, EVIDENCE_ID),
+        ("derived_from_claim", DOCTRINE_ID, CLAIM_ID),
+        ("has_gate_decision", ACTION_PROPOSAL_ID, "gate-empty-quadrant-page"),
+        ("has_value_event", "outcome-empty-quadrant-page", VALUE_EVENT_ID),
+    }
+    actual_links = {
+        (link.link_name, link.source_id, link.target_id)
+        for link in registry.get_links()
+    }
+    assert expected_links.issubset(actual_links)
+
+
+def test_empty_quadrant_seed_is_idempotent() -> None:
+    registry = OntologyRegistry.create_dharma_registry()
+    first = ensure_empty_quadrant_hypernode(registry)
+    object_count = registry.stats()["total_objects"]
+    link_count = registry.stats()["total_links"]
+    second = ensure_empty_quadrant_hypernode(registry)
+
+    assert first.errors == []
+    assert second.errors == []
+    assert registry.stats()["total_objects"] == object_count
+    assert registry.stats()["total_links"] == link_count
+
+
+def test_council_records_anekanta_steelman_dogma_and_mirofish() -> None:
+    verdict = evaluate_hypernode_council()
+
+    assert verdict.decision == "warn"
+    assert verdict.gate_results["ANEKANTA"] == "PASS"
+    assert verdict.gate_results["STEELMAN"] == "PASS"
+    assert verdict.gate_results["DOGMA_DRIFT"] == "PASS"
+    assert verdict.gate_results["MIROFISH"] == "WARN"
+    assert verdict.mirofish_activated is True
+    assert set(verdict.anekanta_frames) == {"mechanistic", "phenomenological", "systems"}
+
+
+def test_fitness_scoring_uses_autograde_council_provenance_and_market() -> None:
+    payload = build_empty_quadrant_payload()
+    fitness = score_hypernode(payload.council_verdict, payload.revenue_cell)
+
+    assert fitness.auto_grade_score >= 0.80
+    assert fitness.council_score > 0
+    assert fitness.provenance_score == 1.0
+    assert fitness.market_value_score == 0.5
+    assert fitness.composite_score >= fitness.promotion_threshold
+    assert fitness.promotion_state == "public_artifact_ready"
+    assert payload.revenue_cell.verified_revenue_usd == 0.0
+    assert payload.revenue_cell.evidence_tier == "internal_estimate"
+
+
+def test_api_returns_hypernode_payload_and_seeds_registry() -> None:
+    registry = OntologyRegistry.create_dharma_registry()
+    client = TestClient(create_app(registry=registry))
+
+    response = client.get("/api/hypernodes/empty-quadrant")
+    assert response.status_code == 200
+    data = response.json()["data"]
+
+    assert data["id"] == HYPERNODE_ID
+    assert data["slug"] == "empty-quadrant-revenue-cell"
+    assert "High-governance, welfare-oriented" in data["thesis"]
+    assert data["fitness_vector"]["promotion_state"] == "public_artifact_ready"
+    assert data["council_verdict"]["gate_results"]["MIROFISH"] == "WARN"
+    assert data["object_chain"]["inquiry"] == [
+        SIGNAL_ID,
+        QUESTION_ID,
+        CLAIM_ID,
+        EVIDENCE_ID,
+        DOCTRINE_ID,
+    ]
+    assert registry.get_objects_by_type("Hypernode")[0].id == HYPERNODE_ID

--- a/tests/test_ontology_registry.py
+++ b/tests/test_ontology_registry.py
@@ -82,8 +82,9 @@ class TestRegistryFactory:
         # 16 base types (original metabolic chain + custodian + ExecutionLease)
         # + 6 spec-style additions (Claim, Doctrine, Capability, Cause, Movement, R_V_Measurement)
         # + 3 inquiry-chain (Signal, Question, Evidence)
-        # = 25 ObjectTypes
-        assert stats["registered_types"] == 25
+        # + 4 hypernode revenue-cell additions
+        # = 29 ObjectTypes
+        assert stats["registered_types"] == 29
         assert stats["registered_links"] >= 40  # original ~40 + inquiry-chain pairs
         assert stats["registered_actions"] >= 16
 
@@ -91,11 +92,11 @@ class TestRegistryFactory:
         names = registry.type_names()
         expected = [
             "ActionProposal", "AgentIdentity", "Capability", "Cause",
-            "Claim", "Contribution", "CustodianRole", "Doctrine",
+            "Claim", "Contribution", "CouncilVerdict", "CustodianRole", "Doctrine",
             "Evidence", "EvolutionEntry", "ExecutionLease", "Experiment",
-            "GateDecisionRecord", "KnowledgeArtifact", "Movement",
+            "FitnessVector", "GateDecisionRecord", "Hypernode", "KnowledgeArtifact", "Movement",
             "Outcome", "Paper", "Question", "R_V_Measurement",
-            "ResearchThread", "Signal", "TypedTask", "ValueEvent",
+            "ResearchThread", "RevenueCell", "Signal", "TypedTask", "ValueEvent",
             "VentureCell", "WitnessLog",
         ]
         assert names == expected


### PR DESCRIPTION
Splits the local dirty Empty Quadrant hypernode work into a clean PR against `chore/phase2-governance-isolation`.

Why this targets the phase2 branch instead of `main`:
- The hypernode seed depends on ontology prerequisites already present on `chore/phase2-governance-isolation`, especially `Signal`, `Question`, `Claim`, `Doctrine`, `Evidence`, and `ExecutionLease` schema additions.
- Current `main` does not yet have those ontology types, so a direct main PR would fail its own seed/test path.

Changed scope:
- Adds canonical `Hypernode`, `RevenueCell`, `CouncilVerdict`, and `FitnessVector` ontology types and links.
- Adds deterministic Empty Quadrant payload, council verdict, scoring, and ontology write-through seed.
- Adds `/api/hypernodes/empty-quadrant` router and `dharma_swarm.api` route.
- Adds dashboard page, hook, nav entry, and typed payload surface.
- Updates ontology registry expectations and ontology graph categorization.

Excluded from this split:
- Local vibegate files.
- Local `opportunity_dispatcher.py` edits.
- Local agni stage files.
- Local root reports/instructions.

Verification:
- `pytest -q tests/test_hypernode.py tests/test_ontology_registry.py`
- Result: 66 passed, 1 warning.
- Commit hooks passed with `DHARMA_UPLIFT_ACK=impact-checked`: contract tests, uplift guards, test hygiene, gitleaks, semgrep warn-only, whitespace/EOF, merge-conflict, large-file checks.
- Dashboard lint attempted earlier in the split but `eslint` was not installed in the worktree dependencies; no frontend lint result is claimed.