### PR TITLE
feat(trace-attractor): add projection contracts

### DIFF
--- a/dharma_swarm/trace_attractor/__init__.py
+++ b/dharma_swarm/trace_attractor/__init__.py
@@ -1,0 +1,37 @@
+"""Trace Attractor Ledger projection contracts.
+
+This package is intentionally read-model only.  It defines normalized event
+and packet types plus deterministic in-memory projection helpers; store readers,
+SignalBus subscribers, CLI commands, and dashboard surfaces belong in later
+implementation PRs.
+"""
+
+from dharma_swarm.trace_attractor.models import (
+    ATTRACTOR_PACKET_SCHEMA_VERSION,
+    AttractorEvent,
+    AttractorPacket,
+    FindingSeverity,
+    FourfoldWarrantSummary,
+    LifecycleFinding,
+    ProvenanceEdge,
+    ProvenanceGraph,
+    ProvenanceNode,
+    ValueSummary,
+    WarrantStatus,
+)
+from dharma_swarm.trace_attractor.projector import TraceAttractorProjector
+
+__all__ = [
+    "ATTRACTOR_PACKET_SCHEMA_VERSION",
+    "AttractorEvent",
+    "AttractorPacket",
+    "FindingSeverity",
+    "FourfoldWarrantSummary",
+    "LifecycleFinding",
+    "ProvenanceEdge",
+    "ProvenanceGraph",
+    "ProvenanceNode",
+    "TraceAttractorProjector",
+    "ValueSummary",
+    "WarrantStatus",
+]

--- a/dharma_swarm/trace_attractor/models.py
+++ b/dharma_swarm/trace_attractor/models.py
@@ -1,0 +1,227 @@
+"""Typed read-model contracts for the Trace Attractor Ledger.
+
+These models do not read or write runtime state.  They define the stable JSON
+shape that later store readers, SignalBus capture, CLI commands, and dashboard
+routes must target.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+ATTRACTOR_PACKET_SCHEMA_VERSION = 1
+DHARMA_JSONLD_CONTEXT = {
+    "prov": "http://www.w3.org/ns/prov#",
+    "dharma": "https://dharma.local/ns#",
+    "trace_id": "dharma:traceId",
+    "value_summary": "dharma:valueSummary",
+}
+
+
+def utc_now_iso() -> str:
+    """Return a compact UTC timestamp for packet generation."""
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _canonical_json(data: dict[str, Any]) -> str:
+    return json.dumps(
+        data,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        default=str,
+    )
+
+
+class _TraceAttractorModel(BaseModel):
+    model_config = ConfigDict(use_enum_values=True)
+
+
+class FindingSeverity(str, Enum):
+    """Severity for lifecycle findings in an AttractorPacket."""
+
+    INFO = "INFO"
+    DEGRADED = "DEGRADED"
+    BLOCKER = "BLOCKER"
+
+
+class WarrantStatus(str, Enum):
+    """Evidence status for a Fourfold Action Warrant dimension."""
+
+    PASS = "pass"
+    HOLD = "hold"
+    BLOCK = "block"
+    UNKNOWN = "unknown"
+
+
+class FourfoldWarrantSummary(_TraceAttractorModel):
+    """Fourfold Action Warrant evidence summary attached to a trace."""
+
+    status: WarrantStatus = WarrantStatus.UNKNOWN
+    maheshwari: WarrantStatus = WarrantStatus.UNKNOWN
+    mahakali: WarrantStatus = WarrantStatus.UNKNOWN
+    mahalakshmi: WarrantStatus = WarrantStatus.UNKNOWN
+    mahasaraswati: WarrantStatus = WarrantStatus.UNKNOWN
+    evidence_refs: list[str] = Field(default_factory=list)
+
+    @property
+    def has_evidence(self) -> bool:
+        return bool(self.evidence_refs) or any(
+            value != WarrantStatus.UNKNOWN.value
+            for value in (
+                self.status,
+                self.maheshwari,
+                self.mahakali,
+                self.mahalakshmi,
+                self.mahasaraswati,
+            )
+        )
+
+
+class ValueSummary(_TraceAttractorModel):
+    """Compact value accounting summary for a projected trace."""
+
+    composite_value: float = 0.0
+    economic_amount: float = 0.0
+    currency: str = "USD"
+    agent_count: int = 0
+    artifact_count: int = 0
+    task_count: int = 0
+
+
+class LifecycleFinding(_TraceAttractorModel):
+    """A deterministic lifecycle or evidence-quality finding."""
+
+    code: str
+    severity: FindingSeverity
+    message: str
+    source_event_id: str = ""
+    source_object_id: str = ""
+    evidence_refs: list[str] = Field(default_factory=list)
+
+
+class ProvenanceNode(_TraceAttractorModel):
+    """A PROV-compatible node in the projected packet graph."""
+
+    id: str
+    label: str = ""
+    kind: str = "prov:Entity"
+    source_event_id: str = ""
+    attributes: dict[str, Any] = Field(default_factory=dict)
+
+
+class ProvenanceEdge(_TraceAttractorModel):
+    """A PROV-compatible edge in the projected packet graph."""
+
+    source: str
+    target: str
+    relation: str
+    source_event_id: str = ""
+    attributes: dict[str, Any] = Field(default_factory=dict)
+
+
+class ProvenanceGraph(_TraceAttractorModel):
+    """Small graph projection embedded inside an AttractorPacket."""
+
+    nodes: list[ProvenanceNode] = Field(default_factory=list)
+    edges: list[ProvenanceEdge] = Field(default_factory=list)
+
+
+class AttractorEvent(_TraceAttractorModel):
+    """Normalized event row used as input to the projection.
+
+    The event shape borrows CloudEvents fields while keeping Dharma-specific
+    correlation fields explicit.  Later PRs can derive this object from ontology,
+    runtime, telemetry, or SignalBus records.
+    """
+
+    event_id: str
+    trace_id: str = ""
+    proposal_id: str = ""
+    session_id: str = ""
+    source_store: str
+    source_table_or_type: str
+    source_object_id: str
+    event_type: str
+    subject: str = ""
+    occurred_at: str
+    attributes: dict[str, Any] = Field(default_factory=dict)
+
+    @property
+    def primary_object_id(self) -> str:
+        return self.source_object_id or self.subject
+
+    def attribute_text(self, key: str) -> str:
+        value = self.attributes.get(key)
+        if value is None:
+            return ""
+        return str(value)
+
+    def to_cloudevent(self) -> dict[str, Any]:
+        """Render a CloudEvents-inspired envelope for this normalized event."""
+        data = dict(self.attributes)
+        if self.trace_id:
+            data.setdefault("trace_id", self.trace_id)
+        if self.proposal_id:
+            data.setdefault("proposal_id", self.proposal_id)
+        if self.session_id:
+            data.setdefault("session_id", self.session_id)
+        return {
+            "specversion": "1.0",
+            "id": self.event_id,
+            "source": f"dharma://{self.source_store}/{self.source_table_or_type}",
+            "type": f"dev.dharma.{self.event_type}",
+            "time": self.occurred_at,
+            "subject": self.subject or self.primary_object_id,
+            "data": data,
+        }
+
+
+class AttractorPacket(_TraceAttractorModel):
+    """Rebuildable trace-level read model assembled from normalized events."""
+
+    schema_version: int = ATTRACTOR_PACKET_SCHEMA_VERSION
+    trace_id: str
+    generated_at: str = Field(default_factory=utc_now_iso)
+    session_ids: list[str] = Field(default_factory=list)
+    proposal_ids: list[str] = Field(default_factory=list)
+    gate_decision_ids: list[str] = Field(default_factory=list)
+    task_ids: list[str] = Field(default_factory=list)
+    claim_ids: list[str] = Field(default_factory=list)
+    delegation_run_ids: list[str] = Field(default_factory=list)
+    artifact_ids: list[str] = Field(default_factory=list)
+    outcome_ids: list[str] = Field(default_factory=list)
+    value_event_ids: list[str] = Field(default_factory=list)
+    contribution_ids: list[str] = Field(default_factory=list)
+    economic_event_ids: list[str] = Field(default_factory=list)
+    signal_event_ids: list[str] = Field(default_factory=list)
+    witness_log_ids: list[str] = Field(default_factory=list)
+    lineage_edge_ids: list[str] = Field(default_factory=list)
+    fourfold_warrant: FourfoldWarrantSummary = Field(
+        default_factory=FourfoldWarrantSummary
+    )
+    value_summary: ValueSummary = Field(default_factory=ValueSummary)
+    lifecycle_findings: list[LifecycleFinding] = Field(default_factory=list)
+    provenance_graph: ProvenanceGraph = Field(default_factory=ProvenanceGraph)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return JSON-serializable packet data."""
+        return self.model_dump(mode="json")
+
+    def to_stable_json(self) -> str:
+        """Return deterministic compact JSON suitable for CLI golden tests."""
+        return _canonical_json(self.to_dict())
+
+    def to_jsonld_stub(self) -> dict[str, Any]:
+        """Return the minimal JSON-LD wrapper promised by the master spec."""
+        data = self.to_dict()
+        data["@context"] = dict(DHARMA_JSONLD_CONTEXT)
+        data["@id"] = f"dharma:trace/{self.trace_id}"
+        data["@type"] = "dharma:AttractorPacket"
+        return data

--- a/dharma_swarm/trace_attractor/projector.py
+++ b/dharma_swarm/trace_attractor/projector.py
@@ -1,0 +1,502 @@
+"""Deterministic in-memory projection for Trace Attractor Ledger packets."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from dharma_swarm.trace_attractor.models import (
+    AttractorEvent,
+    AttractorPacket,
+    FindingSeverity,
+    FourfoldWarrantSummary,
+    LifecycleFinding,
+    ProvenanceEdge,
+    ProvenanceGraph,
+    ProvenanceNode,
+    ValueSummary,
+    utc_now_iso,
+)
+
+
+_ACTION_PROPOSAL_TYPES = {"actionproposal", "action_proposals"}
+_GATE_DECISION_TYPES = {"gatedecisionrecord", "gate_decision_records"}
+_TASK_TYPES = {"task", "tasks"}
+_CLAIM_TYPES = {"taskclaim", "task_claims"}
+_DELEGATION_TYPES = {"delegationrun", "delegation_runs"}
+_ARTIFACT_TYPES = {"artifactrecord", "artifact_records", "knowledgeartifact"}
+_OUTCOME_TYPES = {"outcome", "outcomes"}
+_VALUE_EVENT_TYPES = {"valueevent", "value_events"}
+_CONTRIBUTION_TYPES = {"contribution", "contributions"}
+_ECONOMIC_TYPES = {"economic_event", "economic_events", "economiceventrecord"}
+_SIGNAL_STORES = {"signal_bus", "signalbus"}
+_WITNESS_TYPES = {"witnesslog", "witness_logs"}
+_LINEAGE_TYPES = {"lineageedge", "lineage_edges"}
+
+
+def _norm(value: str) -> str:
+    return value.replace("-", "_").replace(".", "_").replace(" ", "_").lower()
+
+
+def _text(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value)
+
+
+def _attr(event: AttractorEvent, key: str) -> str:
+    return _text(event.attributes.get(key)).strip()
+
+
+def _first_text(event: AttractorEvent, *keys: str) -> str:
+    for key in keys:
+        value = _attr(event, key)
+        if value:
+            return value
+    return ""
+
+
+def _add(target: set[str], value: Any) -> None:
+    text = _text(value).strip()
+    if text:
+        target.add(text)
+
+
+def _float_attr(event: AttractorEvent, key: str) -> float:
+    raw = event.attributes.get(key)
+    if raw is None or raw == "":
+        return 0.0
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _sorted(values: set[str]) -> list[str]:
+    return sorted(values)
+
+
+def _node_kind(source_type: str) -> str:
+    normalized = _norm(source_type)
+    if normalized in _ACTION_PROPOSAL_TYPES | _GATE_DECISION_TYPES:
+        return "prov:Activity"
+    if normalized in _TASK_TYPES | _DELEGATION_TYPES:
+        return "prov:Activity"
+    if normalized in _CONTRIBUTION_TYPES:
+        return "prov:Entity"
+    if normalized in _SIGNAL_STORES:
+        return "prov:Activity"
+    return "prov:Entity"
+
+
+class TraceAttractorProjector:
+    """Build deterministic trace packets from normalized events.
+
+    This projector is intentionally pure: callers provide already-normalized
+    events, and no database, SignalBus, filesystem, or ontology registry is
+    touched here.
+    """
+
+    def build_packet(
+        self,
+        trace_id: str,
+        events: Iterable[AttractorEvent | dict[str, Any]],
+        *,
+        generated_at: str | None = None,
+    ) -> AttractorPacket:
+        normalized = [
+            event
+            if isinstance(event, AttractorEvent)
+            else AttractorEvent.model_validate(event)
+            for event in events
+        ]
+        trace_events = sorted(
+            (event for event in normalized if event.trace_id == trace_id),
+            key=lambda event: (event.occurred_at, event.event_id),
+        )
+
+        session_ids: set[str] = set()
+        proposal_ids: set[str] = set()
+        gate_decision_ids: set[str] = set()
+        task_ids: set[str] = set()
+        claim_ids: set[str] = set()
+        delegation_run_ids: set[str] = set()
+        artifact_ids: set[str] = set()
+        outcome_ids: set[str] = set()
+        value_event_ids: set[str] = set()
+        contribution_ids: set[str] = set()
+        economic_event_ids: set[str] = set()
+        signal_event_ids: set[str] = set()
+        witness_log_ids: set[str] = set()
+        lineage_edge_ids: set[str] = set()
+        agent_ids: set[str] = set()
+        currencies: set[str] = set()
+        findings: list[LifecycleFinding] = []
+        nodes: dict[str, ProvenanceNode] = {}
+        edges: dict[tuple[str, str, str, str], ProvenanceEdge] = {}
+        warrant = FourfoldWarrantSummary()
+
+        composite_value = 0.0
+        economic_amount = 0.0
+        counted_value_events: set[str] = set()
+        counted_economic_events: set[str] = set()
+
+        for event in trace_events:
+            source_type = _norm(event.source_table_or_type)
+            event_type = _norm(event.event_type)
+            primary_id = event.primary_object_id
+
+            _add(session_ids, event.session_id)
+            _add(session_ids, _attr(event, "session_id"))
+            _add(proposal_ids, event.proposal_id)
+            _add(proposal_ids, _attr(event, "proposal_id"))
+            _add(
+                agent_ids,
+                _first_text(event, "agent_id", "created_by", "attributed_to"),
+            )
+
+            if event.source_store and _norm(event.source_store) in _SIGNAL_STORES:
+                _add(signal_event_ids, event.event_id)
+
+            if source_type in _ACTION_PROPOSAL_TYPES:
+                _add(proposal_ids, primary_id)
+            if source_type in _GATE_DECISION_TYPES:
+                _add(
+                    gate_decision_ids,
+                    _first_text(event, "gate_decision_id", "decision_id")
+                    or primary_id,
+                )
+            if source_type in _TASK_TYPES:
+                _add(task_ids, _first_text(event, "task_id") or primary_id)
+            if source_type in _CLAIM_TYPES:
+                _add(claim_ids, _first_text(event, "claim_id") or primary_id)
+            if source_type in _DELEGATION_TYPES:
+                _add(
+                    delegation_run_ids,
+                    _first_text(event, "run_id", "delegation_run_id")
+                    or primary_id,
+                )
+            if source_type in _ARTIFACT_TYPES:
+                _add(
+                    artifact_ids,
+                    _first_text(event, "artifact_id", "knowledge_artifact_id")
+                    or primary_id,
+                )
+            if source_type in _OUTCOME_TYPES or "outcome_recorded" in event_type:
+                _add(outcome_ids, _first_text(event, "outcome_id") or primary_id)
+            if source_type in _VALUE_EVENT_TYPES or "value_event_recorded" in event_type:
+                _add(value_event_ids, _first_text(event, "value_event_id") or primary_id)
+            if source_type in _CONTRIBUTION_TYPES:
+                _add(contribution_ids, _first_text(event, "contribution_id") or primary_id)
+            if source_type in _ECONOMIC_TYPES:
+                _add(
+                    economic_event_ids,
+                    _first_text(event, "economic_event_id", "event_id")
+                    or primary_id,
+                )
+            if source_type in _WITNESS_TYPES:
+                _add(witness_log_ids, _first_text(event, "witness_log_id") or primary_id)
+            if source_type in _LINEAGE_TYPES:
+                _add(
+                    lineage_edge_ids,
+                    _first_text(event, "lineage_edge_id", "edge_id")
+                    or primary_id,
+                )
+
+            self._collect_attribute_ids(
+                event,
+                task_ids=task_ids,
+                claim_ids=claim_ids,
+                delegation_run_ids=delegation_run_ids,
+                artifact_ids=artifact_ids,
+                outcome_ids=outcome_ids,
+                value_event_ids=value_event_ids,
+                contribution_ids=contribution_ids,
+                economic_event_ids=economic_event_ids,
+                witness_log_ids=witness_log_ids,
+                lineage_edge_ids=lineage_edge_ids,
+            )
+
+            is_value_event_source = (
+                source_type in _VALUE_EVENT_TYPES
+                or "value_event_recorded" in event_type
+            )
+            value_event_id = (
+                _first_text(event, "value_event_id")
+                or (primary_id if is_value_event_source else "")
+            )
+            if is_value_event_source and value_event_id not in counted_value_events:
+                composite_value += _float_attr(event, "composite_value")
+                if value_event_id:
+                    counted_value_events.add(value_event_id)
+
+            if source_type in _ECONOMIC_TYPES and primary_id not in counted_economic_events:
+                economic_amount += _float_attr(event, "amount")
+                counted_economic_events.add(primary_id)
+                currency = _first_text(event, "currency")
+                if currency:
+                    currencies.add(currency)
+
+            warrant = self._merge_warrant(warrant, event)
+            self._add_graph_nodes_and_edges(event, nodes, edges)
+            findings.extend(self._find_event_issues(event))
+
+        if not warrant.has_evidence:
+            findings.append(LifecycleFinding(
+                code="warrant_unknown",
+                severity=FindingSeverity.INFO,
+                message="No Fourfold Action Warrant evidence was present in projected events.",
+            ))
+
+        packet = AttractorPacket(
+            trace_id=trace_id,
+            generated_at=generated_at or utc_now_iso(),
+            session_ids=_sorted(session_ids),
+            proposal_ids=_sorted(proposal_ids),
+            gate_decision_ids=_sorted(gate_decision_ids),
+            task_ids=_sorted(task_ids),
+            claim_ids=_sorted(claim_ids),
+            delegation_run_ids=_sorted(delegation_run_ids),
+            artifact_ids=_sorted(artifact_ids),
+            outcome_ids=_sorted(outcome_ids),
+            value_event_ids=_sorted(value_event_ids),
+            contribution_ids=_sorted(contribution_ids),
+            economic_event_ids=_sorted(economic_event_ids),
+            signal_event_ids=_sorted(signal_event_ids),
+            witness_log_ids=_sorted(witness_log_ids),
+            lineage_edge_ids=_sorted(lineage_edge_ids),
+            fourfold_warrant=warrant,
+            value_summary=ValueSummary(
+                composite_value=round(composite_value, 6),
+                economic_amount=round(economic_amount, 6),
+                currency=self._currency(currencies),
+                agent_count=len(agent_ids),
+                artifact_count=len(artifact_ids),
+                task_count=len(task_ids),
+            ),
+            lifecycle_findings=sorted(
+                findings,
+                key=lambda finding: (
+                    finding.severity,
+                    finding.code,
+                    finding.source_event_id,
+                    finding.source_object_id,
+                ),
+            ),
+            provenance_graph=ProvenanceGraph(
+                nodes=sorted(nodes.values(), key=lambda node: node.id),
+                edges=sorted(
+                    edges.values(),
+                    key=lambda edge: (
+                        edge.source,
+                        edge.target,
+                        edge.relation,
+                        edge.source_event_id,
+                    ),
+                ),
+            ),
+        )
+        return packet
+
+    def _collect_attribute_ids(
+        self,
+        event: AttractorEvent,
+        *,
+        task_ids: set[str],
+        claim_ids: set[str],
+        delegation_run_ids: set[str],
+        artifact_ids: set[str],
+        outcome_ids: set[str],
+        value_event_ids: set[str],
+        contribution_ids: set[str],
+        economic_event_ids: set[str],
+        witness_log_ids: set[str],
+        lineage_edge_ids: set[str],
+    ) -> None:
+        _add(task_ids, _attr(event, "task_id"))
+        _add(claim_ids, _attr(event, "claim_id"))
+        _add(delegation_run_ids, _first_text(event, "run_id", "delegation_run_id"))
+        _add(artifact_ids, _first_text(event, "artifact_id", "knowledge_artifact_id"))
+        _add(outcome_ids, _attr(event, "outcome_id"))
+        _add(value_event_ids, _attr(event, "value_event_id"))
+        _add(contribution_ids, _attr(event, "contribution_id"))
+        _add(economic_event_ids, _first_text(event, "economic_event_id"))
+        _add(witness_log_ids, _first_text(event, "witness_log_id"))
+        _add(lineage_edge_ids, _first_text(event, "lineage_edge_id", "edge_id"))
+
+    def _merge_warrant(
+        self,
+        current: FourfoldWarrantSummary,
+        event: AttractorEvent,
+    ) -> FourfoldWarrantSummary:
+        raw = event.attributes.get("fourfold_warrant")
+        data: dict[str, Any] = dict(raw) if isinstance(raw, dict) else {}
+        for key in (
+            "status",
+            "maheshwari",
+            "mahakali",
+            "mahalakshmi",
+            "mahasaraswati",
+        ):
+            if key in event.attributes:
+                data[key] = event.attributes[key]
+        if not data:
+            return current
+
+        payload = current.model_dump(mode="json")
+        evidence_refs = set(payload.get("evidence_refs", []))
+        evidence_refs.add(event.event_id)
+        for key, value in data.items():
+            if key == "evidence_refs" and isinstance(value, list):
+                evidence_refs.update(
+                    _text(item) for item in value if _text(item).strip()
+                )
+            elif key in payload and _text(value).strip():
+                payload[key] = _text(value).strip()
+        payload["evidence_refs"] = sorted(evidence_refs)
+        try:
+            return FourfoldWarrantSummary.model_validate(payload)
+        except Exception:
+            return current
+
+    def _add_graph_nodes_and_edges(
+        self,
+        event: AttractorEvent,
+        nodes: dict[str, ProvenanceNode],
+        edges: dict[tuple[str, str, str, str], ProvenanceEdge],
+    ) -> None:
+        primary_id = event.primary_object_id
+        if primary_id:
+            nodes.setdefault(
+                primary_id,
+                ProvenanceNode(
+                    id=primary_id,
+                    label=event.source_table_or_type,
+                    kind=_node_kind(event.source_table_or_type),
+                    source_event_id=event.event_id,
+                    attributes={
+                        "source_store": event.source_store,
+                        "source_table_or_type": event.source_table_or_type,
+                    },
+                ),
+            )
+
+        self._edge_from_attr(event, nodes, edges, primary_id, "proposal_id", "prov:used")
+        self._edge_from_attr(
+            event, nodes, edges, primary_id, "task_id", "prov:wasGeneratedBy"
+        )
+        self._edge_from_attr(
+            event, nodes, edges, primary_id, "outcome_id", "prov:wasDerivedFrom"
+        )
+        self._edge_from_attr(
+            event, nodes, edges, primary_id, "value_event_id", "prov:wasDerivedFrom"
+        )
+        self._edge_from_attr(
+            event,
+            nodes,
+            edges,
+            primary_id,
+            "parent_artifact_id",
+            "prov:wasDerivedFrom",
+        )
+        self._edge_from_attr(
+            event, nodes, edges, primary_id, "agent_id", "prov:wasAttributedTo"
+        )
+
+    def _edge_from_attr(
+        self,
+        event: AttractorEvent,
+        nodes: dict[str, ProvenanceNode],
+        edges: dict[tuple[str, str, str, str], ProvenanceEdge],
+        source: str,
+        attr_name: str,
+        relation: str,
+    ) -> None:
+        target = _attr(event, attr_name)
+        if not source or not target or source == target:
+            return
+        nodes.setdefault(
+            target,
+            ProvenanceNode(id=target, label=attr_name, kind="prov:Entity"),
+        )
+        key = (source, target, relation, event.event_id)
+        edges.setdefault(
+            key,
+            ProvenanceEdge(
+                source=source,
+                target=target,
+                relation=relation,
+                source_event_id=event.event_id,
+            ),
+        )
+
+    def _find_event_issues(self, event: AttractorEvent) -> list[LifecycleFinding]:
+        findings: list[LifecycleFinding] = []
+        source_type = _norm(event.source_table_or_type)
+        event_type = _norm(event.event_type)
+        primary_id = event.primary_object_id
+
+        if not event.trace_id:
+            findings.append(LifecycleFinding(
+                code="missing_trace_id",
+                severity=FindingSeverity.DEGRADED,
+                message="Projected event does not carry trace_id.",
+                source_event_id=event.event_id,
+                source_object_id=primary_id,
+            ))
+
+        if source_type in _OUTCOME_TYPES or "outcome_recorded" in event_type:
+            if not (event.proposal_id or _attr(event, "proposal_id")):
+                findings.append(LifecycleFinding(
+                    code="orphan_outcome",
+                    severity=FindingSeverity.DEGRADED,
+                    message="Outcome event lacks a proposal link.",
+                    source_event_id=event.event_id,
+                    source_object_id=primary_id,
+                ))
+
+        if source_type in _VALUE_EVENT_TYPES or "value_event_recorded" in event_type:
+            if not _attr(event, "outcome_id"):
+                findings.append(LifecycleFinding(
+                    code="orphan_value_event",
+                    severity=FindingSeverity.DEGRADED,
+                    message="ValueEvent event lacks an outcome link.",
+                    source_event_id=event.event_id,
+                    source_object_id=primary_id,
+                ))
+
+        if source_type in {"artifactrecord", "artifact_records"}:
+            has_manifest = any(
+                _attr(event, key)
+                for key in ("manifest_path", "payload_path", "checksum")
+            )
+            if not has_manifest:
+                findings.append(LifecycleFinding(
+                    code="artifact_without_manifest",
+                    severity=FindingSeverity.DEGRADED,
+                    message=(
+                        "Artifact record lacks manifest, payload path, "
+                        "and checksum evidence."
+                    ),
+                    source_event_id=event.event_id,
+                    source_object_id=primary_id,
+                ))
+
+        if source_type in _ECONOMIC_TYPES:
+            if not (_attr(event, "value_event_id") or _attr(event, "outcome_id")):
+                findings.append(LifecycleFinding(
+                    code="economic_without_value_event",
+                    severity=FindingSeverity.BLOCKER,
+                    message="Economic event cannot be tied to a value event or outcome.",
+                    source_event_id=event.event_id,
+                    source_object_id=primary_id,
+                ))
+
+        return findings
+
+    def _currency(self, currencies: set[str]) -> str:
+        if not currencies:
+            return "USD"
+        if len(currencies) == 1:
+            return next(iter(currencies))
+        return "MIXED"

--- a/tests/test_trace_attractor_projection.py
+++ b/tests/test_trace_attractor_projection.py
@@ -1,0 +1,298 @@
+"""Tests for pure Trace Attractor Ledger projection contracts."""
+
+from __future__ import annotations
+
+from dharma_swarm.trace_attractor import (
+    AttractorEvent,
+    FindingSeverity,
+    TraceAttractorProjector,
+)
+
+
+FIXED_AT = "2026-05-05T00:00:00Z"
+
+
+def _event(
+    event_id: str,
+    *,
+    source_store: str,
+    source_type: str,
+    source_object_id: str,
+    event_type: str,
+    trace_id: str = "trc-main",
+    proposal_id: str = "",
+    session_id: str = "sess-main",
+    occurred_at: str = FIXED_AT,
+    **attributes: object,
+) -> AttractorEvent:
+    return AttractorEvent(
+        event_id=event_id,
+        trace_id=trace_id,
+        proposal_id=proposal_id,
+        session_id=session_id,
+        source_store=source_store,
+        source_table_or_type=source_type,
+        source_object_id=source_object_id,
+        event_type=event_type,
+        subject=source_object_id,
+        occurred_at=occurred_at,
+        attributes=dict(attributes),
+    )
+
+
+def test_projector_builds_stable_packet_from_synthetic_cross_substrate_trace() -> None:
+    events = [
+        _event(
+            "evt-econ",
+            source_store="telemetry_plane",
+            source_type="economic_events",
+            source_object_id="econ-1",
+            event_type="economic_event_recorded",
+            task_id="task-1",
+            run_id="run-1",
+            value_event_id="ve-1",
+            amount=1200.0,
+            currency="USD",
+            agent_id="agent-a",
+        ),
+        _event(
+            "evt-value-signal",
+            source_store="signal_bus",
+            source_type="VALUE_EVENT_RECORDED",
+            source_object_id="sig-ve-1",
+            event_type="value_event_recorded",
+            outcome_id="outcome-1",
+            value_event_id="ve-1",
+            composite_value=0.82,
+            agent_id="agent-a",
+        ),
+        _event(
+            "evt-claim",
+            source_store="runtime_state",
+            source_type="task_claims",
+            source_object_id="claim-1",
+            event_type="task_claim_recorded",
+            task_id="task-1",
+            claim_id="claim-1",
+            agent_id="agent-a",
+        ),
+        _event(
+            "evt-run",
+            source_store="runtime_state",
+            source_type="delegation_runs",
+            source_object_id="run-1",
+            event_type="delegation_run_recorded",
+            task_id="task-1",
+            claim_id="claim-1",
+            run_id="run-1",
+            agent_id="agent-a",
+        ),
+        _event(
+            "evt-proposal",
+            source_store="ontology",
+            source_type="ActionProposal",
+            source_object_id="proposal-1",
+            event_type="action_proposal_recorded",
+            proposal_id="proposal-1",
+            task_id="task-1",
+        ),
+        _event(
+            "evt-gate",
+            source_store="ontology",
+            source_type="GateDecisionRecord",
+            source_object_id="gate-1",
+            event_type="gate_decision_recorded",
+            proposal_id="proposal-1",
+            gate_decision_id="gate-1",
+        ),
+        _event(
+            "evt-artifact",
+            source_store="runtime_state",
+            source_type="artifact_records",
+            source_object_id="artifact-1",
+            event_type="artifact_recorded",
+            task_id="task-1",
+            run_id="run-1",
+            artifact_id="artifact-1",
+            manifest_path="reports/witness/trace.md",
+            checksum="sha256:abc",
+        ),
+        _event(
+            "evt-outcome",
+            source_store="ontology",
+            source_type="Outcome",
+            source_object_id="outcome-1",
+            event_type="outcome_recorded",
+            proposal_id="proposal-1",
+            task_id="task-1",
+            outcome_id="outcome-1",
+            agent_id="agent-a",
+        ),
+        _event(
+            "evt-contribution",
+            source_store="ontology",
+            source_type="Contribution",
+            source_object_id="contrib-1",
+            event_type="contribution_recorded",
+            value_event_id="ve-1",
+            contribution_id="contrib-1",
+            agent_id="agent-a",
+        ),
+        _event(
+            "evt-warrant",
+            source_store="governance",
+            source_type="FourfoldActionWarrant",
+            source_object_id="warrant-1",
+            event_type="fourfold_warrant_recorded",
+            status="pass",
+            maheshwari="pass",
+            mahakali="hold",
+            mahalakshmi="pass",
+            mahasaraswati="pass",
+        ),
+        _event(
+            "evt-other-trace",
+            source_store="ontology",
+            source_type="Outcome",
+            source_object_id="outcome-other",
+            event_type="outcome_recorded",
+            trace_id="trc-other",
+            outcome_id="outcome-other",
+        ),
+    ]
+
+    projector = TraceAttractorProjector()
+    packet = projector.build_packet("trc-main", reversed(events), generated_at=FIXED_AT)
+    again = projector.build_packet("trc-main", events, generated_at=FIXED_AT)
+
+    assert packet.to_stable_json() == again.to_stable_json()
+    assert packet.trace_id == "trc-main"
+    assert packet.proposal_ids == ["proposal-1"]
+    assert packet.gate_decision_ids == ["gate-1"]
+    assert packet.task_ids == ["task-1"]
+    assert packet.claim_ids == ["claim-1"]
+    assert packet.delegation_run_ids == ["run-1"]
+    assert packet.artifact_ids == ["artifact-1"]
+    assert packet.outcome_ids == ["outcome-1"]
+    assert packet.value_event_ids == ["ve-1"]
+    assert packet.contribution_ids == ["contrib-1"]
+    assert packet.economic_event_ids == ["econ-1"]
+    assert packet.signal_event_ids == ["evt-value-signal"]
+    assert packet.value_summary.composite_value == 0.82
+    assert packet.value_summary.economic_amount == 1200.0
+    assert packet.value_summary.agent_count == 1
+    assert packet.value_summary.artifact_count == 1
+    assert packet.value_summary.task_count == 1
+    assert packet.fourfold_warrant.status == "pass"
+    assert "outcome-other" not in packet.to_stable_json()
+
+
+def test_projector_emits_lifecycle_findings_from_normalized_events() -> None:
+    events = [
+        _event(
+            "evt-orphan-outcome",
+            source_store="ontology",
+            source_type="Outcome",
+            source_object_id="outcome-orphan",
+            event_type="outcome_recorded",
+            outcome_id="outcome-orphan",
+        ),
+        _event(
+            "evt-orphan-ve",
+            source_store="ontology",
+            source_type="ValueEvent",
+            source_object_id="ve-orphan",
+            event_type="value_event_recorded",
+            value_event_id="ve-orphan",
+            composite_value=0.2,
+        ),
+        _event(
+            "evt-bare-artifact",
+            source_store="runtime_state",
+            source_type="artifact_records",
+            source_object_id="artifact-bare",
+            event_type="artifact_recorded",
+            artifact_id="artifact-bare",
+        ),
+        _event(
+            "evt-econ-unlinked",
+            source_store="telemetry_plane",
+            source_type="economic_events",
+            source_object_id="econ-unlinked",
+            event_type="economic_event_recorded",
+            amount=50.0,
+            currency="USD",
+        ),
+    ]
+
+    packet = TraceAttractorProjector().build_packet(
+        "trc-main",
+        events,
+        generated_at=FIXED_AT,
+    )
+
+    findings = {finding.code: finding for finding in packet.lifecycle_findings}
+    assert findings["orphan_outcome"].severity == FindingSeverity.DEGRADED.value
+    assert findings["orphan_value_event"].severity == FindingSeverity.DEGRADED.value
+    assert findings["artifact_without_manifest"].severity == FindingSeverity.DEGRADED.value
+    assert findings["economic_without_value_event"].severity == FindingSeverity.BLOCKER.value
+    assert findings["warrant_unknown"].severity == FindingSeverity.INFO.value
+
+
+def test_attractor_event_maps_to_cloudevent_envelope() -> None:
+    event = _event(
+        "evt-signal",
+        source_store="signal_bus",
+        source_type="VALUE_EVENT_RECORDED",
+        source_object_id="sig-1",
+        event_type="value_event_recorded",
+        proposal_id="proposal-1",
+        value_event_id="ve-1",
+    )
+
+    envelope = event.to_cloudevent()
+
+    assert envelope["specversion"] == "1.0"
+    assert envelope["id"] == "evt-signal"
+    assert envelope["source"] == "dharma://signal_bus/VALUE_EVENT_RECORDED"
+    assert envelope["type"] == "dev.dharma.value_event_recorded"
+    assert envelope["subject"] == "sig-1"
+    assert envelope["data"]["trace_id"] == "trc-main"
+    assert envelope["data"]["proposal_id"] == "proposal-1"
+    assert envelope["data"]["value_event_id"] == "ve-1"
+
+
+def test_packet_jsonld_stub_keeps_projection_data() -> None:
+    packet = TraceAttractorProjector().build_packet(
+        "trc-main",
+        [_event(
+            "evt-proposal",
+            source_store="ontology",
+            source_type="ActionProposal",
+            source_object_id="proposal-1",
+            event_type="action_proposal_recorded",
+        )],
+        generated_at=FIXED_AT,
+    )
+
+    jsonld = packet.to_jsonld_stub()
+
+    assert jsonld["@id"] == "dharma:trace/trc-main"
+    assert jsonld["@type"] == "dharma:AttractorPacket"
+    assert jsonld["@context"]["prov"] == "http://www.w3.org/ns/prov#"
+    assert jsonld["proposal_ids"] == ["proposal-1"]
+
+
+def test_empty_trace_packet_is_stable_and_read_only() -> None:
+    packet = TraceAttractorProjector().build_packet(
+        "trc-empty",
+        [],
+        generated_at=FIXED_AT,
+    )
+
+    assert packet.to_dict()["trace_id"] == "trc-empty"
+    assert packet.to_dict()["generated_at"] == FIXED_AT
+    assert packet.value_summary.composite_value == 0.0
+    assert packet.provenance_graph.nodes == []
+    assert packet.provenance_graph.edges == []
+    assert [finding.code for finding in packet.lifecycle_findings] == ["warrant_unknown"]


### PR DESCRIPTION
## Summary

- Adds `dharma_swarm/trace_attractor/` with pure Trace Attractor Ledger read-model contracts: `AttractorEvent`, `AttractorPacket`, warrant/value/provenance/finding models, and deterministic JSON helpers.
- Adds an in-memory `TraceAttractorProjector` that consumes normalized events and builds stable trace packets without reading or writing any stores.
- Adds focused projection tests covering cross-substrate synthetic traces, deterministic rebuilds, lifecycle findings, CloudEvents mapping, JSON-LD stubs, and empty-trace behavior.

## Scope Guard

This is PR 2 from `docs/plans/TRACE_ATTRACTOR_LEDGER_MASTER_SPEC.md` only. No CLI, no SignalBus subscribers, no store readers, no DB writes, and no dashboard/API surface.

## Verification

- `pytest -q tests/test_trace_attractor_projection.py` -> 5 passed, 1 warning
- `pytest -q tests/test_authority_revenue_loop.py tests/test_value_events_cli.py tests/test_signal_bus.py tests/test_artifact_manifest.py tests/test_trace_attractor_projection.py` -> 62 passed, 1 skipped, 1 warning
- `python -m compileall -q dharma_swarm/trace_attractor`
- `git diff --cached --check`
- `rg -n "[^\\x00-\\x7F]" dharma_swarm/trace_attractor tests/test_trace_attractor_projection.py`
- Fourfold Shakti Warrant -> `ALLOW`, 4/4 dimensions
- Commit hooks passed: test hygiene, contract tests, uplift guards, gitleaks, semgrep, whitespace, EOF, merge-conflict, large-file checks.