### PR TITLE
Human YDS Ledger v0

### DIFF
--- a/dharma_swarm/human_yds_ledger.py
+++ b/dharma_swarm/human_yds_ledger.py
@@ -1,0 +1,171 @@
+"""Append-only human YDS rating ledger.
+
+The ledger is intentionally small and path-injected. It records human/operator
+quality ratings in the JSONL shape already consumed by the Daily Operating
+Brief, without becoming a self-grader, dashboard, runtime authority, ontology
+writer, or memory consolidation path.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+
+HUMAN_SOURCE_MARKERS = ("human", "operator", "dhyana")
+DEFAULT_HUMAN_SOURCE = "human_operator"
+
+
+@dataclass(frozen=True)
+class HumanYDSRating:
+    """One authoritative human quality rating for one artifact."""
+
+    timestamp: str
+    rating: str
+    artifact: str
+    human_comment: str = ""
+    source: str = DEFAULT_HUMAN_SOURCE
+    operator_id: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_record(self) -> dict[str, Any]:
+        """Return the JSONL record shape consumed by Daily Operating Brief."""
+
+        record: dict[str, Any] = {
+            "timestamp": self.timestamp,
+            "rating": self.rating,
+            "artifact": self.artifact,
+            "source": self.source,
+        }
+        if self.human_comment:
+            record["human_comment"] = self.human_comment
+        if self.operator_id:
+            record["operator_id"] = self.operator_id
+        if self.metadata:
+            record["metadata"] = self.metadata
+        return record
+
+
+def append_human_yds_rating(
+    ledger_path: Path,
+    *,
+    artifact: str,
+    rating: str,
+    human_comment: str = "",
+    source: str = DEFAULT_HUMAN_SOURCE,
+    operator_id: str = "",
+    timestamp: datetime | str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> HumanYDSRating:
+    """Append one human-authoritative YDS rating to an explicit JSONL path."""
+
+    normalized = HumanYDSRating(
+        timestamp=_timestamp(timestamp),
+        rating=_required("rating", rating),
+        artifact=_required("artifact", artifact),
+        human_comment=str(human_comment).strip(),
+        source=_human_source(source),
+        operator_id=str(operator_id).strip(),
+        metadata=dict(metadata or {}),
+    )
+    ledger_path.parent.mkdir(parents=True, exist_ok=True)
+    with ledger_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(normalized.to_record(), sort_keys=True) + "\n")
+    return normalized
+
+
+def load_human_yds_ratings(
+    ledger_path: Path,
+    *,
+    include_advisory: bool = False,
+) -> list[HumanYDSRating]:
+    """Load human ratings from JSONL, ignoring malformed or incomplete rows."""
+
+    if not ledger_path.exists():
+        return []
+    ratings: list[HumanYDSRating] = []
+    for record in _iter_jsonl_records(ledger_path):
+        source = str(record.get("source") or "").strip()
+        if not include_advisory and not is_human_source(source):
+            continue
+        rating = str(record.get("rating") or record.get("yds") or "").strip()
+        artifact = str(record.get("artifact") or "").strip()
+        timestamp = str(record.get("timestamp") or "").strip()
+        if not rating or not artifact or not timestamp:
+            continue
+        ratings.append(
+            HumanYDSRating(
+                timestamp=timestamp,
+                rating=rating,
+                artifact=artifact,
+                human_comment=str(
+                    record.get("human_comment") or record.get("comment") or ""
+                ).strip(),
+                source=source,
+                operator_id=str(record.get("operator_id") or "").strip(),
+                metadata=record.get("metadata")
+                if isinstance(record.get("metadata"), dict)
+                else {},
+            )
+        )
+    return ratings
+
+
+def is_human_source(source: str) -> bool:
+    """Return whether a source string names a human/operator authority."""
+
+    lowered = source.lower()
+    return any(marker in lowered for marker in HUMAN_SOURCE_MARKERS)
+
+
+def _human_source(source: str) -> str:
+    normalized = _required("source", source)
+    if not is_human_source(normalized):
+        raise ValueError("source must identify a human/operator authority")
+    return normalized
+
+
+def _required(field_name: str, value: str) -> str:
+    normalized = str(value).strip()
+    if not normalized:
+        raise ValueError(f"{field_name} is required")
+    return normalized
+
+
+def _timestamp(value: datetime | str | None) -> str:
+    if value is None:
+        value = datetime.now(timezone.utc)
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+    normalized = str(value).strip()
+    if not normalized:
+        raise ValueError("timestamp is required")
+    return normalized
+
+
+def _iter_jsonl_records(path: Path) -> Iterable[dict[str, Any]]:
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(record, dict):
+            yield record
+
+
+__all__ = [
+    "DEFAULT_HUMAN_SOURCE",
+    "HUMAN_SOURCE_MARKERS",
+    "HumanYDSRating",
+    "append_human_yds_rating",
+    "is_human_source",
+    "load_human_yds_ratings",
+]

--- a/docs/governance/HUMAN_YDS_LEDGER.md
+++ b/docs/governance/HUMAN_YDS_LEDGER.md
@@ -1,0 +1,94 @@
+# Human YDS Ledger v0
+
+The Human YDS Ledger is the first small authority surface for operator quality
+ratings. It records what the human explicitly judged as good, bad, difficult,
+or worth trusting.
+
+It is not a self-grader, dashboard, API, ontology migration, memory writer, or
+automated reward model.
+
+## Purpose
+
+Daily Operating Brief v0 already reads a `yds_ratings_path`. This ledger provides
+the append-only JSONL writer for that path so human ratings can become regular
+operating evidence instead of scattered chat comments.
+
+## Record Shape
+
+Each line is one JSON object:
+
+```json
+{
+  "timestamp": "2026-05-06T01:02:00Z",
+  "rating": "5.10a",
+  "artifact": "daily-brief-v0",
+  "source": "human_operator",
+  "human_comment": "clear enough to operate from",
+  "operator_id": "dhyana",
+  "metadata": {
+    "branch": "chore/daily-operating-brief-v0"
+  }
+}
+```
+
+Required fields:
+
+- `timestamp`
+- `rating`
+- `artifact`
+- `source`
+
+Optional fields:
+
+- `human_comment`
+- `operator_id`
+- `metadata`
+
+## Authority Rule
+
+Only sources that clearly identify a human/operator are authoritative. The v0
+writer rejects sources like `ai_self_grader`. Advisory AI scores may exist in
+other files, but they are not written through this ledger.
+
+## Use From Python
+
+```python
+from pathlib import Path
+
+from dharma_swarm.human_yds_ledger import append_human_yds_rating
+
+append_human_yds_rating(
+    Path("reports/yds/human_ratings.jsonl"),
+    artifact="docops-integrity-v0",
+    rating="5.10b",
+    human_comment="useful enough to merge after review",
+    source="operator_dhyana",
+)
+```
+
+Then pass the same path to Daily Operating Brief:
+
+```python
+from dharma_swarm.daily_operating_brief import DailyOperatingBriefInputs
+
+inputs = DailyOperatingBriefInputs(
+    yds_ratings_path=Path("reports/yds/human_ratings.jsonl")
+)
+```
+
+## Boundaries
+
+- No default write to `~/.dharma`
+- No live runtime/autonomy call
+- No dashboard/API surface
+- No YDS auto-assignment
+- No memory consolidation
+- No ontology schema change
+
+## Still Missing
+
+- Operator CLI command
+- Canonical rating vocabulary beyond preserving the human's string
+- Artifact identity registry
+- Daily Brief output path convention
+- Contribution to Memory tail

--- a/tests/test_human_yds_ledger.py
+++ b/tests/test_human_yds_ledger.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from dharma_swarm.daily_operating_brief import (
+    DailyOperatingBriefInputs,
+    build_daily_operating_brief,
+    render_markdown,
+)
+from dharma_swarm.human_yds_ledger import (
+    append_human_yds_rating,
+    is_human_source,
+    load_human_yds_ratings,
+)
+
+
+def test_appends_human_rating_to_explicit_jsonl_path(tmp_path: Path) -> None:
+    ledger_path = tmp_path / "ratings" / "yds.jsonl"
+    timestamp = datetime(2026, 5, 6, 1, 2, tzinfo=timezone.utc)
+
+    rating = append_human_yds_rating(
+        ledger_path,
+        artifact="daily-brief-v0",
+        rating="5.10a",
+        human_comment="clear enough to operate from",
+        operator_id="dhyana",
+        timestamp=timestamp,
+        metadata={"branch": "chore/daily-operating-brief-v0"},
+    )
+
+    assert rating.timestamp == "2026-05-06T01:02:00Z"
+    records = ledger_path.read_text(encoding="utf-8").splitlines()
+    assert len(records) == 1
+    payload = json.loads(records[0])
+    assert payload["artifact"] == "daily-brief-v0"
+    assert payload["rating"] == "5.10a"
+    assert payload["source"] == "human_operator"
+    assert payload["human_comment"] == "clear enough to operate from"
+    assert payload["operator_id"] == "dhyana"
+    assert payload["metadata"]["branch"] == "chore/daily-operating-brief-v0"
+
+
+def test_append_is_append_only(tmp_path: Path) -> None:
+    ledger_path = tmp_path / "yds.jsonl"
+
+    append_human_yds_rating(ledger_path, artifact="a", rating="5.8")
+    append_human_yds_rating(ledger_path, artifact="b", rating="5.9")
+
+    assert len(ledger_path.read_text(encoding="utf-8").splitlines()) == 2
+    loaded = load_human_yds_ratings(ledger_path)
+    assert [rating.artifact for rating in loaded] == ["a", "b"]
+
+
+def test_rejects_non_human_authoritative_source(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="human/operator"):
+        append_human_yds_rating(
+            tmp_path / "yds.jsonl",
+            artifact="self-score",
+            rating="5.13d",
+            source="ai_self_grader",
+        )
+
+
+def test_load_filters_advisory_non_human_rows(tmp_path: Path) -> None:
+    ledger_path = tmp_path / "yds.jsonl"
+    ledger_path.write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-05-06T01:00:00Z",
+                "artifact": "human-artifact",
+                "rating": "5.9",
+                "source": "human_operator",
+            }
+        )
+        + "\n"
+        + json.dumps(
+            {
+                "timestamp": "2026-05-06T02:00:00Z",
+                "artifact": "ai-artifact",
+                "rating": "5.12",
+                "source": "ai_self_grader",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    authoritative = load_human_yds_ratings(ledger_path)
+    advisory_included = load_human_yds_ratings(ledger_path, include_advisory=True)
+
+    assert [rating.artifact for rating in authoritative] == ["human-artifact"]
+    assert [rating.artifact for rating in advisory_included] == [
+        "human-artifact",
+        "ai-artifact",
+    ]
+
+
+def test_ledger_records_feed_daily_operating_brief(tmp_path: Path) -> None:
+    ledger_path = tmp_path / "yds.jsonl"
+    append_human_yds_rating(
+        ledger_path,
+        artifact="docops-integrity-v0",
+        rating="5.10b",
+        human_comment="useful enough to merge after review",
+        source="operator_dhyana",
+        timestamp="2026-05-06T03:00:00Z",
+    )
+
+    brief = build_daily_operating_brief(
+        DailyOperatingBriefInputs(yds_ratings_path=ledger_path)
+    )
+
+    rendered = render_markdown(brief)
+    assert "`docops-integrity-v0` rated `5.10b`" in rendered
+    assert "useful enough to merge after review" in rendered
+
+
+def test_missing_ledger_loads_empty_and_does_not_touch_home(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    fake_home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(fake_home))
+
+    assert load_human_yds_ratings(tmp_path / "missing.jsonl") == []
+    assert not (fake_home / ".dharma").exists()
+
+
+def test_human_source_detection_is_explicit() -> None:
+    assert is_human_source("human_operator") is True
+    assert is_human_source("operator_dhyana") is True
+    assert is_human_source("ai_self_grader") is False


### PR DESCRIPTION
## Summary

Adds the append-only Human YDS JSONL ledger writer/reader plus Daily Brief compatibility coverage.

#135 and #138 are merged, so this PR is rebased onto `main`. Current diff remains narrow: 1 commit, 3 files.

## Validation

- `pytest -q tests/test_human_yds_ledger.py tests/test_daily_operating_brief.py tests/test_llm_burn.py`: 25 passed
- `python3 -m compileall dharma_swarm/human_yds_ledger.py tests/test_human_yds_ledger.py`: passed
- `git diff --check origin/main...HEAD`: passed

## Merge Order

1. This PR
2. #136 DocOps Integrity v0, refreshed last against final main counts