### PR TITLE
fix(routing): preserve pinned provider lanes

### DIFF
--- a/dharma_swarm/agent_runner.py
+++ b/dharma_swarm/agent_runner.py
@@ -631,13 +631,8 @@ def _available_provider_types(
         return explicit
     if _allow_provider_routing(task, config):
         return None
-    # Pin to agent's configured provider but add CLAUDE_CODE as a last-resort
-    # fallback so tasks degrade gracefully when the primary provider is down.
-    pinned = [config.provider]
-    from dharma_swarm.models import ProviderType as _PT
-    if config.provider != _PT.CLAUDE_CODE:
-        pinned.append(_PT.CLAUDE_CODE)
-    return pinned
+    # Preserve the configured lane unless task metadata explicitly widens it.
+    return [config.provider]
 
 
 def _resolved_routing_metadata(task: Task, config: AgentConfig) -> dict[str, Any]:

--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -8,7 +8,7 @@ Do not hand-edit the generated block.
 |---|---:|
 | Dharma Python modules | 542 |
 | Top-level Dharma Python modules | 384 |
-| Dharma Python LOC | 245,233 |
+| Dharma Python LOC | 245,228 |
 | Test files | 541 |
 | Test function occurrences | 9,865 |
 | Markdown files | 637 |


### PR DESCRIPTION
## Summary

Removes the unconditional `CLAUDE_CODE` last-resort fallback that was being appended to every pinned provider allowlist in `agent_runner._available_provider_types()`. Pinned provider lanes are now actually pinned — no silent escape hatch back to paid Anthropic when the configured provider is intentionally constrained.

Single-file change. Unblocks deterministic routing in the canonical model hierarchy.

## Test plan
- [x] Existing routing test suite passes (32 tests, zero failures)
- [x] No new provider escape paths introduced
- [x] Tagged `[impact-checked]` in commit message
- [ ] Verify in live `dgc up` that pinned lanes stay pinned post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
