### PR TITLE
chore(roaming): document roaming_dispatch_daemon — wiring lane COMPLETE

### DIFF
--- a/dharma_swarm/roaming_dispatch_daemon.py
+++ b/dharma_swarm/roaming_dispatch_daemon.py
@@ -23,11 +23,15 @@ from dharma_swarm.roaming_operator_bridge import RoamingOperatorBridge, _build_b
 
 @dataclass(frozen=True)
 class DaemonCycleResult:
+    """One iteration's outcome: bridge task IDs collected and mailbox task IDs dispatched."""
+
     collected_bridge_task_ids: list[str] = field(default_factory=list)
     dispatched_mailbox_task_ids: list[str] = field(default_factory=list)
 
 
 class MailboxRepoSync:
+    """Git wrapper for fetching and pushing the roaming mailbox queue directories."""
+
     def __init__(self, repo_root: Path, branch: str) -> None:
         self.repo_root = repo_root
         self.branch = branch
@@ -41,11 +45,13 @@ class MailboxRepoSync:
         )
 
     def sync_inbound(self) -> None:
+        """Fetch the configured branch and fast-forward the local mailbox repo."""
         self._run("fetch", "origin", self.branch)
         self._run("checkout", self.branch)
         self._run("pull", "--ff-only", "origin", self.branch)
 
     def sync_outbound(self, *, note: str) -> None:
+        """Commit and push any changes inside the mailbox tasks/responses/receipts dirs."""
         status = self._run(
             "status",
             "--short",
@@ -67,6 +73,8 @@ class MailboxRepoSync:
 
 
 class RoamingDispatchDaemon:
+    """Local-side daemon that bridges OperatorBridge tasks to the roaming mailbox queue."""
+
     def __init__(
         self,
         *,
@@ -92,8 +100,11 @@ class RoamingDispatchDaemon:
         ).exists()
 
     async def collect_available(self) -> list[str]:
+        """Pull every responded mailbox task back into the bridge and return their bridge IDs."""
         collected: list[str] = []
-        responded = self.mailbox.list_tasks(recipient=self.recipient, status="responded")
+        responded = self.mailbox.list_tasks(
+            recipient=self.recipient, status="responded"
+        )
         for task in responded:
             if self._receipt_exists(task.task_id):
                 continue
@@ -105,6 +116,7 @@ class RoamingDispatchDaemon:
         return collected
 
     async def dispatch_available(self) -> list[str]:
+        """Push up to dispatch_limit pending bridge tasks into the mailbox; return mailbox IDs."""
         dispatched: list[str] = []
         for _ in range(self.dispatch_limit):
             task = await self.adapter.dispatch_next(recipient=self.recipient)
@@ -114,6 +126,7 @@ class RoamingDispatchDaemon:
         return dispatched
 
     async def cycle_once(self) -> DaemonCycleResult:
+        """Run one full sync-collect-dispatch-push cycle and return what moved."""
         if self.git_sync is not None:
             self.git_sync.sync_inbound()
 
@@ -126,7 +139,9 @@ class RoamingDispatchDaemon:
                 parts.append(f"collect {len(collected)}")
             if dispatched:
                 parts.append(f"dispatch {len(dispatched)}")
-            self.git_sync.sync_outbound(note=f"Roaming daemon {' + '.join(parts)} for {self.recipient}")
+            self.git_sync.sync_outbound(
+                note=f"Roaming daemon {' + '.join(parts)} for {self.recipient}"
+            )
 
         return DaemonCycleResult(
             collected_bridge_task_ids=collected,
@@ -134,6 +149,7 @@ class RoamingDispatchDaemon:
         )
 
     async def run_loop(self, *, interval_seconds: float = 10.0) -> None:
+        """Run cycle_once forever, sleeping interval_seconds between iterations."""
         while True:
             try:
                 await self.cycle_once()
@@ -143,7 +159,9 @@ class RoamingDispatchDaemon:
 
 
 def _parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Run the local roaming dispatch/collect daemon.")
+    parser = argparse.ArgumentParser(
+        description="Run the local roaming dispatch/collect daemon."
+    )
     parser.add_argument("--db-path", required=True)
     parser.add_argument("--mailbox-root", default="")
     parser.add_argument("--ledger-dir", default="")
@@ -170,7 +188,9 @@ async def _main_async(argv: list[str] | None = None) -> int:
     )
     git_sync = None
     if args.repo_root and args.git_branch:
-        git_sync = MailboxRepoSync(repo_root=Path(args.repo_root), branch=args.git_branch)
+        git_sync = MailboxRepoSync(
+            repo_root=Path(args.repo_root), branch=args.git_branch
+        )
     daemon = RoamingDispatchDaemon(
         adapter=adapter,
         recipient=args.recipient,
@@ -194,6 +214,7 @@ async def _main_async(argv: list[str] | None = None) -> int:
 
 
 def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint: parse argv and run the daemon in run-once or run-loop mode."""
     import asyncio
 
     return asyncio.run(_main_async(argv))

--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -8,7 +8,7 @@ Do not hand-edit the generated block.
 |---|---:|
 | Dharma Python modules | 542 |
 | Top-level Dharma Python modules | 384 |
-| Dharma Python LOC | 245,233 |
+| Dharma Python LOC | 245,254 |
 | Test files | 541 |
 | Test function occurrences | 9,865 |
 | Markdown files | 637 |


### PR DESCRIPTION
## Summary

Second wiring-lane PR. Marks `dharma_swarm/roaming_dispatch_daemon.py` **COMPLETE** by adding eight one-line docstrings on its public surface. The module is actively wired and tested; only docstrings were missing to satisfy the wiring-lane criterion.

## Triage findings

| Signal | Value |
|---|---|
| Module-level docstring | Already present (lines 1–9) |
| Integration test | `tests/test_roaming_dispatch_daemon.py::test_dispatch_daemon_cycles_dispatch_then_collect` — **passes** (verified) |
| Other test references | `tests/test_roaming_operator_bridge.py` imports it |
| Design docs | `docs/plans/2026-03-26-roaming-control-plane-spec.md`, `docs/plans/2026-03-27-recent-change-merge-map.md` |
| CLI entrypoint | `python -m dharma_swarm.roaming_dispatch_daemon run-once \| run-loop` (argparse, all required flags) |
| Cron-shaped? | No — long-running foreground daemon (`run_loop`), not a `conductors.CONDUCTOR_CONFIGS` wake-cycle |
| Last commit | 2026-03-26 |
| Public-surface docstrings (before) | 0 |
| Public-surface docstrings (after) | 8 |

## What this PR does

- Adds one-line docstrings on:
  - `DaemonCycleResult` (dataclass)
  - `MailboxRepoSync`, `.sync_inbound`, `.sync_outbound`
  - `RoamingDispatchDaemon`, `.collect_available`, `.dispatch_available`, `.cycle_once`, `.run_loop`
  - `main`
- Refreshes `docs/docops/AUTO_INVENTORY.md` (Python LOC bumped 245233 → 245254 from the inserted docstrings).

## What this PR does NOT do

- Does not modify behavior. Diff is +25/-4 docstring + ruff-format line-wrap noise.
- Does not register the daemon in `conductors.CONDUCTOR_CONFIGS` (correctly: it isn't wake-cycle-shaped).
- Does not add new tests (the existing integration test already covers the cycle).

## Known follow-ups (out of scope here, flagged for a future PR)

- `RoamingDispatchDaemon.run_loop` swallows exceptions silently (`except Exception: pass`). Should log via stdlib logging.
- `RoamingDispatchDaemon.run_loop` calls `time.sleep()` inside an async function, blocking the event loop. Should use `await asyncio.sleep()`.

These are real bugs but expanding scope mid-wiring violates the lane's "minimum-viable per session" rule. Filing as separate work.

## Test plan

- [x] `python3 -m pytest tests/test_roaming_dispatch_daemon.py -q` — 1 passed.
- [x] `ruff check dharma_swarm/roaming_dispatch_daemon.py` — clean.
- [x] All pre-commit hooks pass (test hygiene, contract tests, uplift guards, docops integrity, gitleaks, semgrep).

## Wiring lane progress

Two of seven graveyard items resolved:
1. `scripts/build_loop.sh` — **ARCHIVED** (PR #142, superseded by `loop_metabolic.sh` / `agent_loop.py`).
2. `dharma_swarm/roaming_dispatch_daemon.py` — **COMPLETE** (this PR).

Remaining queue: `cron_job_runtime.py`, `codex_overnight.py`, `agent_runner_quality.py`, `thinkodynamic_canary.py`, `allout_autopilot.py`.

---

## Incubation Triage

This PR was opened or updated by the 2026-05-07 triage harvest for an INCUBATE branch.

### What Was Attempted
chore(roaming): document roaming_dispatch_daemon — wiring lane COMPLETE

### Why This Is Parked
- Bucket: INCUBATE
- Reason: real work but conflicts need human/agent follow-up later
- Signal score: 2
- Conflicts against origin/main: yes
- Conflict files: docs/docops/AUTO_INVENTORY.md
- Tests counted in changed test files: 0
- Source branch: `wiring/triage-roaming-dispatch-2026-05-07`
- Source tip: `9133360edd9e5bb066281da5639be79402a47dfe`
- Central files: dharma_swarm/roaming_dispatch_daemon.py, docs/docops/AUTO_INVENTORY.md

### What Is Missing To Ship
- Re-review scope against current `origin/main`.
- Resolve conflicts if listed above.
- Run focused tests for the touched surface.
- Convert this draft to ready only after the above is complete.
