### PR TITLE
cleanup: backfill docstrings on event_log.EventLog public methods

### DIFF
--- a/dharma_swarm/event_log.py
+++ b/dharma_swarm/event_log.py
@@ -21,10 +21,12 @@ class EventLog:
     """Manage append-only runtime envelope and snapshot streams."""
 
     def __init__(self, base_dir: Path | str | None = None) -> None:
+        """Initialize the log under ``base_dir`` (defaults to ~/.dharma/events), creating it if missing."""
         self.base_dir = Path(base_dir or DEFAULT_EVENT_LOG_DIR)
         self.base_dir.mkdir(parents=True, exist_ok=True)
 
     def stream_path(self, stream: str) -> Path:
+        """Return the JSONL file path for ``stream``; falls back to ``runtime`` if the name is empty."""
         safe_name = str(stream).strip() or "runtime"
         return self.base_dir / f"{safe_name}.jsonl"
 
@@ -34,6 +36,7 @@ class EventLog:
         *,
         stream: str = "runtime",
     ) -> dict[str, Any]:
+        """Validate ``envelope`` against the runtime contract and append it as a JSON line to ``stream``; returns the stored dict. Raises ``ValueError`` on invalid input."""
         data = envelope.as_dict() if isinstance(envelope, RuntimeEnvelope) else dict(envelope)
         ok, errors = validate_envelope(data)
         if not ok:
@@ -49,6 +52,7 @@ class EventLog:
         *,
         stream: str = "snapshots",
     ) -> SnapshotRecord:
+        """Append a state snapshot to ``stream`` via continuity_harness; returns the resulting SnapshotRecord."""
         return append_snapshot(self.stream_path(stream), state)
 
     def read_envelopes(
@@ -61,6 +65,7 @@ class EventLog:
         limit: int | None = None,
         newest_first: bool = False,
     ) -> list[dict[str, Any]]:
+        """Load envelopes from ``stream``, optionally filtered by ``session_id`` / ``trace_id`` / ``event_type``, sorted by emitted_at, then truncated to ``limit``."""
         path = self.stream_path(stream)
         if not path.exists():
             return []
@@ -98,6 +103,7 @@ class EventLog:
         return rows
 
     def tail(self, *, stream: str = "runtime", limit: int = 20) -> list[dict[str, Any]]:
+        """Return the most recent ``limit`` envelopes from ``stream``, newest first."""
         return self.read_envelopes(stream=stream, limit=limit, newest_first=True)
 
     def read_snapshots(
@@ -106,12 +112,14 @@ class EventLog:
         stream: str = "snapshots",
         limit: int | None = None,
     ) -> list[SnapshotRecord]:
+        """Load all SnapshotRecord rows from ``stream``; if ``limit`` is set, return only the last ``limit`` rows."""
         rows = load_snapshots(self.stream_path(stream))
         if limit is not None and limit > 0:
             return rows[-limit:]
         return rows
 
     def verify_stream(self, *, stream: str = "runtime") -> tuple[bool, list[str]]:
+        """Validate every line of ``stream`` against the runtime envelope contract; return ``(ok, errors)``."""
         path = self.stream_path(stream)
         if not path.exists():
             return (False, ["runtime stream missing"])
@@ -133,6 +141,7 @@ class EventLog:
         return (len(errors) == 0, errors)
 
     def verify_snapshot_stream(self, *, stream: str = "snapshots") -> tuple[bool, list[str]]:
+        """Validate every line of the snapshot ``stream`` via continuity_harness; return ``(ok, errors)``."""
         path = self.stream_path(stream)
         if not path.exists():
             return (False, ["snapshot stream missing"])

--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -8,11 +8,11 @@ Do not hand-edit the generated block.
 |---|---:|
 | Dharma Python modules | 542 |
 | Top-level Dharma Python modules | 384 |
-| Dharma Python LOC | 245,228 |
-| Test files | 541 |
-| Test function occurrences | 9,865 |
-| Markdown files | 637 |
-| Markdown total lines | 164,612 |
+| Dharma Python LOC | 244,997 |
+| Test files | 545 |
+| Test function occurrences | 9,894 |
+| Markdown files | 640 |
+| Markdown total lines | 164,792 |
 | Bridge files | 18 |
 | Adapter files | 14 |
 | Orchestrator files | 4 |

--- a/docs/governance/SOVEREIGN_MANIFEST.md
+++ b/docs/governance/SOVEREIGN_MANIFEST.md
@@ -65,8 +65,8 @@ These are the ground-truth metrics. All other documents citing different numbers
 | Total Python modules | **542** | find dharma_swarm -name "*.py" -type f |
 | Top-level (flat) modules | **384 (70.8%)** | find dharma_swarm -maxdepth 1 -name "*.py" -type f |
 | Total Python LOC | **245,233** | wc -l across dharma_swarm Python modules |
-| Test files | **543** | find tests -name "*.py" -type f |
-| Test functions | **9,882 `def test_` occurrences under tests/** | rg "def test_" tests |
+| Test files | **545** | find tests -name "*.py" -type f |
+| Test functions | **9,894 `def test_` occurrences under tests/** | rg "def test_" tests |
 | Tests collected (pytest) | **Needs write-permitted refresh** | not run during this DocOps count pass |
 | Collection errors | **Historical: 16 on 2026-04-04** | refresh before relying on this count |
 | Markdown files | **640** | find . -name "*.md" -type f |


### PR DESCRIPTION
## Summary

Auto-generated by the dharma_swarm cleanup loop (run #2, priority-7 docstring backfill task).

Adds one short docstring to every public method on `EventLog` in `dharma_swarm/event_log.py` — 9 methods (`__init__`, `stream_path`, `append_envelope`, `append_snapshot`, `read_envelopes`, `tail`, `read_snapshots`, `verify_stream`, `verify_snapshot_stream`). The class itself already carried a docstring. No behavior change, no signature change, no comments.

Also refreshes two metric surfaces so the docops-integrity gate stays green:
- `docs/docops/AUTO_INVENTORY.md` (auto-section regenerated)
- `docs/governance/SOVEREIGN_MANIFEST.md` (Test files 543→545, Test functions 9,882→9,894 — these were **already failing the assertion gate on `origin/main`** before this branch was cut; intervening commits between run #1 (4a1cc14) and current main (fb9d415) added 2 test files and 12 test functions without bumping the manifest)

## Evidence

Pre-change scan: `ast.get_docstring(node)` returned `None` for all 9 public methods.
Post-change scan: 9/9 carry a docstring; the class docstring is preserved unchanged.

## Files changed (3)

- `dharma_swarm/event_log.py` — +9 lines (one docstring per public method)
- `docs/docops/AUTO_INVENTORY.md` — +5/-5 lines (counter refresh)
- `docs/governance/SOVEREIGN_MANIFEST.md` — +2/-2 lines (test-files/test-functions counts)

Net diff: 16 insertions, 7 deletions, 108 diff lines including context.

## Verification

- `python3 -m pytest tests/test_event_log.py -q` → **1 passed**
- `python3 -c "from dharma_swarm import event_log"` → ok; 9/9 method docstrings present
- `shasum -a 256 dharma_swarm/dharma_kernel.py` → unchanged from `origin/main` (`fd4a588…b2bb071`)
- `pre-commit run --files dharma_swarm/event_log.py docs/docops/AUTO_INVENTORY.md docs/governance/SOVEREIGN_MANIFEST.md` → all 12 hooks **Passed**
- Branched off `origin/main` @ `fb9d415`

## Risk

**Low** — pure documentation + assertion-counter refresh.

Hard rules respected:
- ≤300 lines diff (108)
- ≤5 files changed (3)
- `dharma_kernel.py` untouched
- `.pre-commit-config.yaml` / `.github/workflows/*` / telos-gate registry untouched
- No god classes structurally edited
- No reformatting, no renames, no version bumps

Reversible: `git revert <merge-sha>`.

## Cleanup loop bookkeeping

Pops `event_log.py` from the `docstring_targets_remaining` queue. Remaining queue: `continuity_harness.py`, `session_event_bridge.py`, `runtime_bridge.py`. (Note: `runtime_bridge.py` does not exist in the repo — that entry should be removed at the next state-file refresh.)

The SOVEREIGN_MANIFEST.md fix in this PR is the same pattern as the prior session's "DocOps Integrity Restored: SOVEREIGN_MANIFEST.md Test Function Count Manually Fixed to 9,882" — when test counts drift on main without manifest updates, the docops-integrity assertion gate fails for everyone. Worth filing a separate issue to either (a) auto-write these manifest values via `--write-auto-sections`, (b) loosen the assertion to a tolerance band, or (c) add a CI step that fails the offending PR rather than letting drift accumulate on main.
