### PR TITLE
[codex] bind tcs heartbeat cron status

### DIFF
--- a/dharma_swarm/cron_runner.py
+++ b/dharma_swarm/cron_runner.py
@@ -91,6 +91,48 @@ def _run_system_map_populator(job: dict[str, Any]) -> CronJobExecutionResult:
     )
 
 
+def _run_tcs_heartbeat(job: dict[str, Any]) -> CronJobExecutionResult:
+    """Sample IdentityMonitor.measure() and append identity history locally."""
+
+    try:
+        from dharma_swarm.identity import IdentityMonitor
+
+        state_dir = Path(str(job.get("state_dir") or Path.home() / ".dharma"))
+        monitor = IdentityMonitor(state_dir=state_dir)
+        state = asyncio.run(
+            monitor.measure(threat_boost=bool(job.get("threat_boost", False)))
+        )
+        raw_history_path = str(job.get("history_path") or "").strip()
+        history_path = Path(raw_history_path).expanduser() if raw_history_path else None
+        monitor.save_history(history_path)
+        written_path = history_path or (state_dir / "meta" / "identity_history.jsonl")
+        output = (
+            "TCS heartbeat: "
+            f"tcs={state.tcs:.4f} regime={state.regime} "
+            f"gpr={state.gpr:.4f} bsi={state.bsi:.4f} rm={state.rm:.4f} "
+            f"history={written_path}"
+        )
+        return CronJobExecutionResult(
+            status=CronJobRunStatus.COMPLETED,
+            output=output,
+            metadata={
+                "tcs": state.tcs,
+                "gpr": state.gpr,
+                "bsi": state.bsi,
+                "rm": state.rm,
+                "regime": state.regime,
+                "history_path": str(written_path),
+            },
+        )
+    except Exception as exc:
+        error = f"TCS heartbeat failed: {exc}"
+        return CronJobExecutionResult(
+            status=CronJobRunStatus.FAILED,
+            output=error,
+            error=error,
+        )
+
+
 def _run_overnight_director(job: dict[str, Any]) -> CronJobExecutionResult:
     """Launch the overnight director as a long-running process."""
     import asyncio
@@ -485,6 +527,7 @@ def execute_cron_job(job: dict[str, Any]) -> CronJobExecutionResult:
         custodians       — custodian maintenance fleet (no quality re-scan)
         custodians_forge — custodian fleet + foreman quality re-scan
         system_map_populator — local system map refresh
+        tcs_heartbeat   — local IdentityMonitor time-series sample
     """
     handler = str(job.get("handler", "headless_prompt")).strip() or "headless_prompt"
 
@@ -516,6 +559,8 @@ def execute_cron_job(job: dict[str, Any]) -> CronJobExecutionResult:
         return _run_operator_brief(job)
     if handler == "system_map_populator":
         return _run_system_map_populator(job)
+    if handler == "tcs_heartbeat":
+        return _run_tcs_heartbeat(job)
 
     error = f"Unsupported cron handler: {handler}"
     return CronJobExecutionResult(

--- a/dharma_swarm/cron_scheduler.py
+++ b/dharma_swarm/cron_scheduler.py
@@ -345,13 +345,16 @@ def get_due_jobs(quiet_hours: set[int] | None = None) -> list[dict[str, Any]]:
 
     jobs = load_jobs()
     due: list[dict[str, Any]] = []
+    repaired = False
 
     for job in jobs:
         if not job.get("enabled", True):
             continue
         next_run = job.get("next_run_at")
         if not next_run:
-            continue
+            job["next_run_at"] = now.isoformat()
+            next_run = job["next_run_at"]
+            repaired = True
         next_dt = datetime.fromisoformat(next_run)
         if next_dt.tzinfo is None:
             next_dt = next_dt.replace(tzinfo=timezone.utc)
@@ -360,6 +363,9 @@ def get_due_jobs(quiet_hours: set[int] | None = None) -> list[dict[str, Any]]:
                 logger.debug("Job '%s' deferred (quiet hours)", job.get("name"))
                 continue
             due.append(job)
+
+    if repaired:
+        save_jobs(jobs)
 
     return due
 

--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -8,9 +8,9 @@ Do not hand-edit the generated block.
 |---|---:|
 | Dharma Python modules | 543 |
 | Top-level Dharma Python modules | 384 |
-| Dharma Python LOC | 246,116 |
+| Dharma Python LOC | 246,167 |
 | Test files | 548 |
-| Test function occurrences | 9,907 |
+| Test function occurrences | 9,909 |
 | Markdown files | 642 |
 | Markdown total lines | 164,968 |
 | Bridge files | 18 |

--- a/docs/governance/SOVEREIGN_MANIFEST.md
+++ b/docs/governance/SOVEREIGN_MANIFEST.md
@@ -66,7 +66,7 @@ These are the ground-truth metrics. All other documents citing different numbers
 | Top-level (flat) modules | **384 (70.8%)** | find dharma_swarm -maxdepth 1 -name "*.py" -type f |
 | Total Python LOC | **245,233** | wc -l across dharma_swarm Python modules |
 | Test files | **548** | find tests -name "*.py" -type f |
-| Test functions | **9,907 `def test_` occurrences under tests/** | rg "def test_" tests |
+| Test functions | **9,909 `def test_` occurrences under tests/** | rg "def test_" tests |
 | Tests collected (pytest) | **Needs write-permitted refresh** | not run during this DocOps count pass |
 | Collection errors | **Historical: 16 on 2026-04-04** | refresh before relying on this count |
 | Markdown files | **642** | find . -name "*.md" -type f |

--- a/tests/test_cron_runner.py
+++ b/tests/test_cron_runner.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from dharma_swarm.cron_job_runtime import CronJobRunStatus
@@ -369,8 +370,6 @@ def test_run_cron_job_dispatches_doctor_assurance():
 
 
 def test_run_cron_job_dispatches_system_map_populator(tmp_path):
-    from types import SimpleNamespace
-
     script = tmp_path / "scripts" / "system_map_populator.py"
     script.parent.mkdir()
     script.write_text("print('ok')\n", encoding="utf-8")
@@ -396,6 +395,45 @@ def test_run_cron_job_dispatches_system_map_populator(tmp_path):
     assert ["--audit-dir", "/tmp/audit"] == args[2:4]
     assert ["--output", "/tmp/latest.json"] == args[4:6]
     assert mock_run.call_args.kwargs["timeout"] == 12
+
+
+def test_run_cron_job_dispatches_tcs_heartbeat(tmp_path):
+    class FakeIdentityMonitor:
+        def __init__(self, state_dir):
+            self.state_dir = state_dir
+            self.saved_path = None
+
+        async def measure(self, *, threat_boost=False):
+            assert threat_boost is True
+            return SimpleNamespace(
+                tcs=0.8123,
+                gpr=0.7,
+                bsi=0.8,
+                rm=0.9,
+                regime="stable",
+            )
+
+        def save_history(self, path=None):
+            self.saved_path = path
+            target = path or (self.state_dir / "meta" / "identity_history.jsonl")
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text('{"tcs":0.8123}\n', encoding="utf-8")
+
+    history_path = tmp_path / "history" / "identity_history.jsonl"
+    with patch("dharma_swarm.identity.IdentityMonitor", FakeIdentityMonitor):
+        success, output, error = run_cron_job(
+            {
+                "handler": "tcs_heartbeat",
+                "state_dir": str(tmp_path),
+                "history_path": str(history_path),
+                "threat_boost": True,
+            }
+        )
+
+    assert success is True
+    assert error is None
+    assert "TCS heartbeat: tcs=0.8123 regime=stable" in output
+    assert history_path.exists()
 
 
 def test_run_cron_job_rejects_unknown_handler():

--- a/tests/test_cron_scheduler.py
+++ b/tests/test_cron_scheduler.py
@@ -163,6 +163,31 @@ class TestGetDueJobs:
         due = cron_scheduler.get_due_jobs(quiet_hours=set())
         assert len(due) == 0
 
+    def test_enabled_job_without_next_run_is_repaired_and_due(self):
+        cron_scheduler.save_jobs(
+            [
+                {
+                    "id": "legacy-heartbeat",
+                    "name": "Legacy heartbeat",
+                    "handler": "tcs_heartbeat",
+                    "schedule": {
+                        "kind": "interval",
+                        "minutes": 30,
+                        "display": "every 30m",
+                    },
+                    "enabled": True,
+                }
+            ]
+        )
+
+        due = cron_scheduler.get_due_jobs(quiet_hours=set())
+        repaired = cron_scheduler.get_job("legacy-heartbeat")
+
+        assert len(due) == 1
+        assert due[0]["id"] == "legacy-heartbeat"
+        assert repaired is not None
+        assert repaired["next_run_at"]
+
 
 class TestSaveJobOutput:
     """Tests for save_job_output()."""


### PR DESCRIPTION
## Why

Close the first Phase 0/1 backlog item under the new Coherence Delta rule: `tcs_heartbeat` was enabled in `~/.dharma/cron/jobs.json` but had UNKNOWN/null status because the imported record had no `next_run_at`, and this branch had no local handler for `handler=tcs_heartbeat`.

## Surface area touched

- [x] `dharma_swarm/...`
- [x] `tests/...`
- [x] `docs/...`

### Worktree mirrors checked

This PR is stacked on #155 because #155 already touches `cron_runner.py`. The live machine previously had an operational handler mirror in `dharma_swarm_lf5`; this PR formalizes the source-side scheduler and handler behavior.

## Interface mismatch impact

- [x] Existing mismatch resolved — enabled legacy cron jobs without `next_run_at` now become due once instead of being skipped forever.

## Coherence Delta

- Organ touched: metabolic clock / TCS identity heartbeat.
- Declared-vs-actual gap closed: `tcs_heartbeat` was declared as an enabled cron organ, but actual scheduler state had no `next_run_at` and no runnable handler in this branch.
- Proof that re-reads the map: `pytest -q tests/test_cron_scheduler.py tests/test_cron_runner.py -q`; `python scripts/docops/check_docops_integrity.py --changed-from origin/codex/organstate-system-map`; GitNexus impact checked `get_due_jobs`, `execute_cron_job`, and `run_cron_job`.
- New drift introduced: enabled legacy jobs missing `next_run_at` now run on the next scheduler scan; this is intended for imported jobs, but it changes first-run behavior from skip-forever to run-once-now.

## Verification

- [x] Pre-commit hooks pass on commit
- [x] Manual smoke

```
pytest -q tests/test_cron_scheduler.py tests/test_cron_runner.py -q
python scripts/docops/check_docops_integrity.py --changed-from origin/codex/organstate-system-map
```

Impact check:

```
gitnexus impact cron_scheduler.get_due_jobs: LOW, direct caller tick
gitnexus impact cron_runner.execute_cron_job: MEDIUM, direct callers include launchd_job_runner and run_cron_job
gitnexus impact cron_runner.run_cron_job: HIGH, direct callers mostly tests in indexed view
```

## Plan reference

- Plan: `/Users/dhyana/.dharma/audit/phase_0_1_backlog_2026-05-07.md`

## Risk + rollback

- Blast radius: medium; cron scheduling semantics change for enabled jobs missing `next_run_at`.
- Rollback: single revert; affected imported jobs return to skipped/null behavior.

## Checklist

- [x] No unintended changes reviewed
- [x] No new files at repo root
- [x] Tests added / updated for behavior change
