### PR TITLE
fix(cron): document BR-004 — repo + live cron files as complementary roles [impact-checked]

### DIFF
--- a/cron_jobs.README.md
+++ b/cron_jobs.README.md
@@ -1,0 +1,69 @@
+# `cron_jobs.json` — declarative job specs
+
+This file is the **declarative source-of-truth** for jobs that should be running
+in the dharma_swarm cron substrate. It is the spec, not the live state.
+
+## Two files, two complementary roles
+
+| File | Role | Schema | Owner | Mutable by |
+|------|------|--------|-------|-----------|
+| `<repo>/cron_jobs.json` | **declarative spec** — what jobs SHOULD exist | JSON list of job specs | source-controlled | git commits |
+| `~/.dharma/cron/jobs.json` | **runtime state** — what the daemon is currently tracking | `{jobs: [...], updated_at: ...}` | `dharma_swarm/cron_scheduler.py` | the daemon (atomic write) |
+
+Both files are intentional. The split that BR-004 in
+`docs/state/BROKEN_REGISTER.md` flagged was not a split-brain — it was a
+documentation gap. This README closes that gap.
+
+## Read paths in code
+
+The repo file (this one) is read by:
+
+- `dharma_swarm/launchd_job_runner.py` — looks up a job spec by id for one-shot
+  invocation by launchd. The launchd plist names a job id; this runner finds
+  the spec and executes it.
+- `dharma_swarm/pulse.py:_check_and_run_cron_jobs` — pulse-driven cron loop
+  reading the same declarative specs. Updates its own last-run tracker at
+  `~/.dharma/cron_last_run.json`.
+- `api/module_truth.py` — module inventory display (read-only documentation
+  surface).
+- `tests/test_launchd_job_runner.py`, `tests/test_pulse.py` — coverage.
+
+The live runtime file (`~/.dharma/cron/jobs.json`) is read by:
+
+- `dharma_swarm/cron_scheduler.py` — the daemon's authoritative reader/writer.
+  It tracks `last_status`, `last_run_at`, `next_run_at`, and per-job metadata
+  on every tick.
+- `dharma_swarm/cron_daemon.py` — daemon loop that calls `cron_scheduler.tick()`.
+- `dharma_swarm/doctor.py` — health checks normalize/validate the live file.
+
+## Migration script
+
+`scripts/cron_unify.py` is the idempotent reconciler. It reads both files,
+proposes a unified live file (`~/.dharma/cron/jobs.unified.json`), and writes
+an audit row to `~/.dharma/audit/cron_split_brain_<ts>.json`. It does NOT
+mutate the live file. Operator review then atomic-swaps:
+
+```
+cp ~/.dharma/cron/jobs.json ~/.dharma/cron/jobs.json.bak
+mv ~/.dharma/cron/jobs.unified.json ~/.dharma/cron/jobs.json
+```
+
+As of 2026-05-07 the live file is already the canonical superset (all 17 repo
+job ids are id-collisions in live), so unification is a no-op.
+
+## When to edit which
+
+- **Adding a new job that should always run on every checkout:** add it to
+  `cron_jobs.json` (this file). The daemon will pick it up on next sync.
+- **Tweaking a running job's schedule or runtime state:** the live file is
+  the right surface only at operator time; for permanent changes, edit the
+  declarative spec here and let the daemon reconcile.
+- **Inspecting why a job last failed:** read the live file's `last_status` /
+  `last_error` fields, or check `~/.dharma/cron/logs/`.
+
+## Reference
+
+- `docs/governance/METABOLIC_CLOCK.md` — scheduler state snapshot
+- `docs/state/BROKEN_REGISTER.md` BR-004 — the gap this README closes
+- `dharma_swarm/cron_scheduler.py:JOBS_FILE` — live file canonical owner
+- `scripts/cron_unify.py` — reconciliation utility

--- a/dharma_swarm/pulse.py
+++ b/dharma_swarm/pulse.py
@@ -425,11 +425,22 @@ def pulse(config: DaemonConfig | None = None) -> str:
     return result
 
 
+CRON_JOBS_FILE = Path(__file__).resolve().parent.parent / "cron_jobs.json"
+"""Default path to the declarative cron-job spec file.
+
+Resolved relative to this module so the lookup works across any user's
+checkout. Runtime state (last_status / last_run_at) lives in
+`~/.dharma/cron/jobs.json` owned by `cron_scheduler.py`; this module only
+consumes declarative specs. Tests monkeypatch this constant; production code
+should not reassign it.
+"""
+
+
 def _check_and_run_cron_jobs(cfg: DaemonConfig | None = None) -> None:
-    """Check and run due cron jobs from `~/dharma_swarm/cron_jobs.json`."""
+    """Check and run due cron jobs declared in repo `cron_jobs.json`."""
     _ = cfg  # reserved for future per-job policy wiring
 
-    cron_file = Path.home() / "dharma_swarm" / "cron_jobs.json"
+    cron_file = CRON_JOBS_FILE
     if not cron_file.exists():
         return
 

--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -6,16 +6,16 @@ Do not hand-edit the generated block.
 <!-- DOCOPS:START metric=repo_inventory -->
 | Metric | Value |
 |---|---:|
-| Dharma Python modules | 543 |
+| Dharma Python modules | 544 |
 | Top-level Dharma Python modules | 384 |
-| Dharma Python LOC | 246,176 |
-| Test files | 548 |
-| Test function occurrences | 9,909 |
-| Markdown files | 642 |
-| Markdown total lines | 164,968 |
+| Dharma Python LOC | 246,579 |
+| Test files | 549 |
+| Test function occurrences | 9,928 |
+| Markdown files | 961 |
+| Markdown total lines | 264,026 |
 | Bridge files | 18 |
 | Adapter files | 14 |
 | Orchestrator files | 4 |
 | Router files | 13 |
-| Authority candidate docs | 264 |
+| Authority candidate docs | 276 |
 <!-- DOCOPS:END -->

--- a/docs/governance/SOVEREIGN_MANIFEST.md
+++ b/docs/governance/SOVEREIGN_MANIFEST.md
@@ -62,15 +62,15 @@ These are the ground-truth metrics. All other documents citing different numbers
 
 | Metric | Value | Verification |
 |--------|-------|-------------|
-| Total Python modules | **543** | find dharma_swarm -name "*.py" -type f |
-| Top-level (flat) modules | **384 (70.8%)** | find dharma_swarm -maxdepth 1 -name "*.py" -type f |
-| Total Python LOC | **245,233** | wc -l across dharma_swarm Python modules |
-| Test files | **548** | find tests -name "*.py" -type f |
-| Test functions | **9,909 `def test_` occurrences under tests/** | rg "def test_" tests |
+| Total Python modules | **544** | find dharma_swarm -name "*.py" -type f |
+| Top-level (flat) modules | **384 (70.6%)** | find dharma_swarm -maxdepth 1 -name "*.py" -type f |
+| Total Python LOC | **246,579** | wc -l across dharma_swarm Python modules |
+| Test files | **549** | find tests -name "*.py" -type f |
+| Test functions | **9,928 `def test_` occurrences under tests/** | rg "def test_" tests |
 | Tests collected (pytest) | **Needs write-permitted refresh** | not run during this DocOps count pass |
 | Collection errors | **Historical: 16 on 2026-04-04** | refresh before relying on this count |
-| Markdown files | **642** | find . -name "*.md" -type f |
-| Markdown total lines | **164,968** | wc -l across all .md |
+| Markdown files | **961** | find . -name "*.md" -type f |
+| Markdown total lines | **264,026** | wc -l across all .md |
 | Bridge files | **18** | find dharma_swarm -name "*bridge*.py" |
 | Adapter files | **14 across 7 locations** | find dharma_swarm -type f \| rg -i "adapter" |
 | Orchestrator files | **4** (6,034 LOC total) | find dharma_swarm -name "*orchestrat*" |

--- a/tests/test_pulse.py
+++ b/tests/test_pulse.py
@@ -199,7 +199,6 @@ def test_check_and_run_cron_jobs_runs_due_job_once_per_slot(tmp_path: Path, monk
             return fixed_now if tz is None else fixed_now.astimezone(tz)
 
     monkeypatch.setattr(pulse, "datetime", _FixedDateTime)
-    monkeypatch.setattr(pulse.Path, "home", lambda: tmp_path)
 
     state_dir = tmp_path / ".dharma"
     state_dir.mkdir(parents=True, exist_ok=True)
@@ -208,6 +207,7 @@ def test_check_and_run_cron_jobs_runs_due_job_once_per_slot(tmp_path: Path, monk
     cron_dir = tmp_path / "dharma_swarm"
     cron_dir.mkdir(parents=True, exist_ok=True)
     cron_file = cron_dir / "cron_jobs.json"
+    monkeypatch.setattr(pulse, "CRON_JOBS_FILE", cron_file)
     cron_file.write_text(
         json.dumps(
             [
@@ -243,12 +243,12 @@ def test_check_and_run_cron_jobs_runs_due_job_once_per_slot(tmp_path: Path, monk
 
 
 def test_check_and_run_cron_jobs_ignores_invalid_job_payload(tmp_path: Path, monkeypatch):
-    monkeypatch.setattr(pulse.Path, "home", lambda: tmp_path)
     monkeypatch.setattr(pulse, "STATE_DIR", tmp_path / ".dharma")
 
     cron_dir = tmp_path / "dharma_swarm"
     cron_dir.mkdir(parents=True, exist_ok=True)
     cron_file = cron_dir / "cron_jobs.json"
+    monkeypatch.setattr(pulse, "CRON_JOBS_FILE", cron_file)
     cron_file.write_text(
         json.dumps(
             [
@@ -280,7 +280,6 @@ def test_check_and_run_cron_jobs_runs_due_interval_job_once(tmp_path: Path, monk
             return fixed_now if tz is None else fixed_now.astimezone(tz)
 
     monkeypatch.setattr(pulse, "datetime", _FixedDateTime)
-    monkeypatch.setattr(pulse.Path, "home", lambda: tmp_path)
 
     state_dir = tmp_path / ".dharma"
     state_dir.mkdir(parents=True, exist_ok=True)
@@ -289,6 +288,7 @@ def test_check_and_run_cron_jobs_runs_due_interval_job_once(tmp_path: Path, monk
     cron_dir = tmp_path / "dharma_swarm"
     cron_dir.mkdir(parents=True, exist_ok=True)
     cron_file = cron_dir / "cron_jobs.json"
+    monkeypatch.setattr(pulse, "CRON_JOBS_FILE", cron_file)
     cron_file.write_text(
         json.dumps(
             [


### PR DESCRIPTION
## Why

BR-004 (cron split-brain) in the broken register flagged a "split-brain" between `cron_jobs.json` (repo root) and `~/.dharma/cron/jobs.json` (live). On investigation: not a split-brain — two complementary files with two complementary roles that were never documented. This PR closes the documentation gap and fixes one fragile path.

## Surface

- **NEW** `cron_jobs.README.md` (root) — declares the two-file architecture: repo file = declarative spec; live file = runtime state owned by `cron_scheduler.py`. Lists code consumers of each. Documents `scripts/cron_unify.py` as the reconciler (which on 2026-05-07 reports the live file is already the canonical superset — no orphans to import).
- `dharma_swarm/pulse.py` — replaces fragile `Path.home() / "dharma_swarm" / "cron_jobs.json"` (broke for any user not on Dhyana's M5) with module-level `CRON_JOBS_FILE = Path(__file__).resolve().parent.parent / "cron_jobs.json"`.
- `tests/test_pulse.py` — three cron tests now monkeypatch `pulse.CRON_JOBS_FILE` instead of `Path.home()`. Cleaner contract, same coverage. `pytest tests/test_pulse.py` → 10 passed.
- `docs/docops/AUTO_INVENTORY.md` — auto-regenerated by `--write-auto-sections`.
- `docs/governance/SOVEREIGN_MANIFEST.md` — drift refresh: 543→544 Python modules, 548→549 test files, 9,909→9,928 test functions, 642→961 markdown files, 164,968→264,026 markdown lines. Pre-existing drift this PR exposed via the docops integrity check.

## NOT changed

- `~/.dharma/cron/jobs.json` (live runtime file) — not mutated. `cron_unify.py` dry-run confirms live is the canonical superset.
- `dharma_swarm/launchd_job_runner.py` — already uses the correct `Path(__file__).parent.parent / "cron_jobs.json"` idiom; nothing to fix.
- `docs/state/BROKEN_REGISTER.md` — does not yet exist on `main`. PR #159 introduces it. Once #159 merges, a follow-up PR will move BR-004 to CLOSED with this PR's evidence.

## Verification

- [x] `python3 -m pytest tests/test_pulse.py -q` → 10 passed
- [x] `python3 scripts/docops/check_docops_integrity.py --write-auto-sections` → exits clean
- [x] All pre-commit hooks pass (kernel-integrity, secrets-scan, dharma-uplift-guards, docops integrity, gitleaks, semgrep, test hygiene)
- [ ] CI green on full suite
- [ ] Once PR #159 merges: open follow-up PR moving BR-004 to CLOSED in `docs/state/BROKEN_REGISTER.md`

## Coherence Delta

- **Organ touched:** `pulse.py` cron dispatch, governance docs (manifest counts), root-level documentation
- **Gap closed:** BR-004 documentation gap; fragile user-home path in pulse.py
- **Proof carried:** test suite green; manifest drift reconciled
- **Drift introduced:** none — purely informative + one robustness fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
