### PR TITLE
feat(shakti): main-based board feedback edge [impact-checked]

### DIFF
--- a/dharma_swarm/shakti_executive/feedback_writer.py
+++ b/dharma_swarm/shakti_executive/feedback_writer.py
@@ -1,0 +1,189 @@
+"""Write realized outcomes back into ``opportunity_board.json``.
+
+This module closes the next concrete step on BR-002 (central VentureCell loop
+is open). The shakti executive already READS Outcome / ValueEvent /
+Contribution rows from the TelicSeam (see ``inputs.read_telic_feedback``),
+but the WRITE side — feeding realized outcomes back into the board so future
+scoring sees what already happened — was the missing edge.
+
+What this module does:
+
+- ``update_opportunity_outcome(opp_id, outcome, *, board_path=None)``
+  appends an outcome record to the matching opportunity's
+  ``realized_outcomes`` list and recomputes a ``learned_score_delta``
+  derived from outcome success / fitness. Writes atomically (tmp + rename).
+
+What this module does NOT do:
+
+- It does NOT resolve ``proposal_id`` → ``opportunity_id``. That linkage lives
+  upstream — Outcomes carry ``proposal_id`` (see
+  ``dharma_swarm/telic_seam.py:record_outcome``), and the proposal is created
+  from a campaign manifest at ``~/.dharma/campaigns/<opp_id>/manifest.json``
+  by ``dharma_swarm/opportunity_dispatcher.py``. The caller is expected to
+  walk that chain and pass the fully-resolved ``opp_id``.
+- It does NOT register a caller. Wiring this writer into the existing telic
+  seam outcome dispatcher is the follow-up step; until that lands, this
+  module is a public-API library.
+
+Design contracts:
+
+- Idempotent on duplicate ``outcome_id``. If an outcome with the same id is
+  already present in ``realized_outcomes``, the write is a no-op and returns
+  ``False``.
+- Atomic write. Uses tmp + rename, the same pattern as
+  ``dharma_swarm/cron_scheduler.py:save_jobs`` (line 208).
+- Best-effort backup. Writes the prior file to
+  ``opportunity_board.json.bak.<ts>`` if it exists, matching the convention
+  in ``tests/test_shakti_executive.py:51``.
+- Silent on missing board. If the board file does not exist, this function
+  is a no-op returning ``False`` rather than raising — outcomes can arrive
+  before the board is initialized.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BOARD_PATH = Path.home() / ".dharma" / "meta" / "opportunity_board.json"
+
+
+@dataclass(frozen=True)
+class OutcomeRecord:
+    """Minimal projection of a TelicSeam Outcome for board feedback.
+
+    Constructed by the caller from an Outcome row read out of
+    ``ontology.db``. We project to a small frozen shape so the writer's
+    contract does not couple to the ontology schema.
+    """
+
+    outcome_id: str
+    """Stable id from the ontology layer (Outcome.id). Used for dedup."""
+
+    proposal_id: str
+    """The ActionProposal id the outcome closed. Audit trail only."""
+
+    success: bool
+    """Whether the agent completed the task successfully."""
+
+    fitness_score: float = 0.0
+    """0.0–1.0 (or higher), agent self-reported. Drives learned_score_delta."""
+
+    duration_ms: float = 0.0
+    """Wall time. Audit trail only."""
+
+    result_summary: str = ""
+    """Short human-readable summary. Truncated upstream to 500 chars."""
+
+    recorded_at: float = 0.0
+    """Unix timestamp when the outcome was recorded. 0.0 = use now()."""
+
+
+def _learned_score_delta(outcome: OutcomeRecord) -> float:
+    """Convert a single outcome into a board-score adjustment.
+
+    Conservative: success contributes +fitness, failure contributes
+    -0.5 * (1.0 - fitness). Capped to [-1.0, +1.0] per single outcome so a
+    single bad run cannot dominate the board score. The caller can sum
+    deltas across multiple outcomes; the cap is per-row.
+    """
+    if outcome.success:
+        delta = max(0.0, min(1.0, outcome.fitness_score))
+    else:
+        delta = -0.5 * (1.0 - max(0.0, min(1.0, outcome.fitness_score)))
+    return max(-1.0, min(1.0, delta))
+
+
+def _atomic_write_json(path: Path, payload: list[dict[str, Any]]) -> None:
+    """Tmp-then-rename atomic write. Same pattern as cron_scheduler.py:208."""
+    tmp = path.with_suffix(path.suffix + f".tmp.{int(time.time() * 1000)}")
+    tmp.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    tmp.replace(path)
+
+
+def update_opportunity_outcome(
+    opp_id: str,
+    outcome: OutcomeRecord,
+    *,
+    board_path: Path | None = None,
+    backup: bool = True,
+) -> bool:
+    """Append an outcome to the matching opportunity's realized_outcomes list.
+
+    Returns True on a successful append, False if the board does not exist,
+    no matching opportunity is found, or the outcome was already recorded
+    (idempotent). Writes atomically via tmp+rename.
+    """
+    path = (board_path or DEFAULT_BOARD_PATH).expanduser()
+    if not path.exists():
+        logger.debug("opportunity_board.json missing at %s; skipping", path)
+        return False
+
+    try:
+        rows = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("Could not read opportunity_board at %s: %s", path, exc)
+        return False
+
+    if not isinstance(rows, list):
+        logger.warning("opportunity_board at %s is not a list; refusing to write", path)
+        return False
+
+    matched = False
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        row_id = str(row.get("opportunity_id") or "")
+        if row_id != opp_id:
+            continue
+        matched = True
+
+        existing = row.setdefault("realized_outcomes", [])
+        if not isinstance(existing, list):
+            logger.warning(
+                "opportunity %s has non-list realized_outcomes; replacing", opp_id
+            )
+            existing = []
+            row["realized_outcomes"] = existing
+
+        if any(
+            isinstance(prev, dict) and prev.get("outcome_id") == outcome.outcome_id
+            for prev in existing
+        ):
+            return False  # idempotent: already recorded
+
+        existing.append(
+            {
+                "outcome_id": outcome.outcome_id,
+                "proposal_id": outcome.proposal_id,
+                "success": outcome.success,
+                "fitness_score": outcome.fitness_score,
+                "duration_ms": outcome.duration_ms,
+                "result_summary": outcome.result_summary,
+                "recorded_at": outcome.recorded_at or time.time(),
+            }
+        )
+        row["learned_score_delta"] = (
+            float(row.get("learned_score_delta", 0.0)) + _learned_score_delta(outcome)
+        )
+        break
+
+    if not matched:
+        logger.debug("no opportunity matched id=%s; outcome dropped", opp_id)
+        return False
+
+    if backup and path.exists():
+        backup_path = path.with_suffix(path.suffix + f".bak.{int(time.time())}")
+        try:
+            backup_path.write_bytes(path.read_bytes())
+        except OSError as exc:
+            logger.warning("backup write failed for %s: %s", path, exc)
+
+    _atomic_write_json(path, rows)
+    return True

--- a/dharma_swarm/telic_seam.py
+++ b/dharma_swarm/telic_seam.py
@@ -332,6 +332,36 @@ class TelicSeam:
                     "session_id": corr.session_id,
                 })
 
+            # BR-002 closure: feed realized outcomes back to opportunity_board.json
+            # so future Shakti scoring sees what already happened. Best-effort —
+            # failure here does NOT break the canonical Outcome write to ontology.db.
+            # Resolves opportunity_id from task.metadata, set by
+            # opportunity_dispatcher._create_task_board_row (line ~508).
+            opp_id = ""
+            try:
+                opp_id = str((task.metadata or {}).get("opportunity_id") or "")
+            except (AttributeError, TypeError):
+                opp_id = ""
+            if opp_id:
+                try:
+                    from dharma_swarm.shakti_executive.feedback_writer import (
+                        OutcomeRecord,
+                        update_opportunity_outcome,
+                    )
+                    update_opportunity_outcome(
+                        opp_id,
+                        OutcomeRecord(
+                            outcome_id=obj.id,
+                            proposal_id=proposal_id or "",
+                            success=success,
+                            fitness_score=fitness_score,
+                            duration_ms=duration_ms,
+                            result_summary=result_summary[:500] if result_summary else "",
+                        ),
+                    )
+                except Exception as exc:
+                    logger.debug("BR-002 board feedback failed: %s", exc)
+
             self._flush_registry()
             return obj.id
 

--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -6,13 +6,13 @@ Do not hand-edit the generated block.
 <!-- DOCOPS:START metric=repo_inventory -->
 | Metric | Value |
 |---|---:|
-| Dharma Python modules | 550 |
+| Dharma Python modules | 551 |
 | Top-level Dharma Python modules | 385 |
-| Dharma Python LOC | 248,451 |
-| Test files | 559 |
-| Test function occurrences | 9,984 |
+| Dharma Python LOC | 248,670 |
+| Test files | 560 |
+| Test function occurrences | 9,995 |
 | Markdown files | 664 |
-| Markdown total lines | 168,935 |
+| Markdown total lines | 168,937 |
 | Bridge files | 18 |
 | Adapter files | 14 |
 | Orchestrator files | 4 |

--- a/docs/governance/SOVEREIGN_MANIFEST.md
+++ b/docs/governance/SOVEREIGN_MANIFEST.md
@@ -17,7 +17,7 @@
 These are immutable engineering laws for this repository. Violation = architectural regression.
 
 ### A1: NO FLAT-PACKAGE GROWTH
-The `dharma_swarm/` package currently has **385 files at its top level (70.0% of 550 total Python modules)** (V). No new .py file may be added to the top level. New modules must go into an appropriate subdirectory. Existing top-level files will be organized over time.
+The `dharma_swarm/` package currently has **385 files at its top level (69.9% of 551 total Python modules)** (V). No new .py file may be added to the top level. New modules must go into an appropriate subdirectory. Existing top-level files will be organized over time.
 
 ### A2: NO DUPLICATE IMPLEMENTATIONS
 Before creating a new file for routing, bridging, adapting, or orchestrating, check if one already exists. The repo currently has **18 bridge files** (V), **3 model_routing copies** (2 are identical, 1 is different) (V), **4 orchestrators** (V), **14 adapter files across 7 locations** (V), and **13 router files** (V). Do not add more without deprecating an existing one.
@@ -62,15 +62,15 @@ These are the ground-truth metrics. All other documents citing different numbers
 
 | Metric | Value | Verification |
 |--------|-------|-------------|
-| Total Python modules | **550** | find dharma_swarm -name "*.py" -type f |
+| Total Python modules | **551** | find dharma_swarm -name "*.py" -type f |
 | Top-level (flat) modules | **385 (70.0%)** | find dharma_swarm -maxdepth 1 -name "*.py" -type f |
-| Total Python LOC | **248,451** | wc -l across dharma_swarm Python modules |
-| Test files | **559** | find tests -name "*.py" -type f |
-| Test functions | **9,984 `def test_` occurrences under tests/** | rg "def test_" tests |
+| Total Python LOC | **248,670** | wc -l across dharma_swarm Python modules |
+| Test files | **560** | find tests -name "*.py" -type f |
+| Test functions | **9,995 `def test_` occurrences under tests/** | rg "def test_" tests |
 | Tests collected (pytest) | **Needs write-permitted refresh** | not run during this DocOps count pass |
 | Collection errors | **Historical: 16 on 2026-04-04** | refresh before relying on this count |
 | Markdown files | **664** | find . -name "*.md" -type f |
-| Markdown total lines | **168,935** | wc -l across all .md |
+| Markdown total lines | **168,937** | wc -l across all .md |
 | Bridge files | **18** | find dharma_swarm -name "*bridge*.py" |
 | Adapter files | **14 across 7 locations** | find dharma_swarm -type f \| rg -i "adapter" |
 | Orchestrator files | **4** (6,034 LOC total) | find dharma_swarm -name "*orchestrat*" |

--- a/docs/state/BROKEN_REGISTER.md
+++ b/docs/state/BROKEN_REGISTER.md
@@ -36,7 +36,9 @@
 - **root_cause:** Board → VentureCell → gates → dispatch → outcome → witness/algedonic → board feedback path is not closed. Outcomes do not feed back into opportunity_board.json.
 - **blast_radius:** Shakti always re-derives from raw signals; opportunity loop is forward-only; "later VentureCells more powerful than earlier" is aspiration, not mechanism.
 - **evidence:** `~/.dharma/audit/central_loop_trace_2026-05-07.md`; vision_maps `06_outward_organs.md`; survey synthesis Finding 2.
-- **status:** WORKAROUND — 2026-05-07 partial closure: `dharma_swarm/shakti_executive/inputs.py` now reads TelicSeam `Outcome` / `ValueEvent` / `Contribution`, dispatcher health, campaign manifests, and Darwin sealed-packet archive rows as feedback signals. Full VentureCell polymorphism remains open.
+- **status:** PARTIAL — 2026-05-07 partial closure across two writes:
+  1. **Read side (this branch):** `dharma_swarm/shakti_executive/inputs.py` reads TelicSeam `Outcome` / `ValueEvent` / `Contribution`, dispatcher health, campaign manifests, and Darwin sealed-packet archive rows as feedback signals.
+  2. **Write side (this commit):** `dharma_swarm/shakti_executive/feedback_writer.py` exposes `update_opportunity_outcome(opp_id, outcome)` that appends realized outcomes to `opportunity_board.json` and updates `learned_score_delta`. Atomic write, idempotent on duplicate `outcome_id`, capped per-outcome score delta. 8/8 tests pass under `tests/test_feedback_writer.py`. **Caller wiring (proposal_id → campaign manifest → opportunity_id resolution) is NOT yet in place** — the writer is a public-API library; the resolver is a follow-up. Full VentureCell polymorphism (BR-008) and full loop closure remain open.
 
 ### BR-003 — Apply gate present but closed (self-evolution loop)
 - **first_observed:** 2026-05-07

--- a/tests/test_feedback_writer.py
+++ b/tests/test_feedback_writer.py
@@ -1,0 +1,137 @@
+"""Tests for ``dharma_swarm.shakti_executive.feedback_writer``.
+
+Covers the BR-002 next-step writer: outcome appended to opportunity's
+realized_outcomes, learned_score_delta updated, atomic write, idempotency,
+and the no-op paths (missing board, missing opportunity).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from dharma_swarm.shakti_executive.feedback_writer import (
+    OutcomeRecord,
+    update_opportunity_outcome,
+)
+
+
+def _board(tmp_path: Path, *opps: dict) -> Path:
+    path = tmp_path / "opportunity_board.json"
+    path.write_text(json.dumps(list(opps)), encoding="utf-8")
+    return path
+
+
+def _outcome(**kwargs) -> OutcomeRecord:
+    defaults = {
+        "outcome_id": "out-1",
+        "proposal_id": "prop-1",
+        "success": True,
+        "fitness_score": 0.8,
+        "duration_ms": 1500.0,
+        "result_summary": "ok",
+        "recorded_at": 1_700_000_000.0,
+    }
+    defaults.update(kwargs)
+    return OutcomeRecord(**defaults)
+
+
+def test_appends_outcome_to_matching_opportunity(tmp_path: Path):
+    board = _board(
+        tmp_path,
+        {"opportunity_id": "opp-A", "title": "Reforest"},
+        {"opportunity_id": "opp-B", "title": "Compost"},
+    )
+    out = _outcome(outcome_id="out-1", success=True, fitness_score=0.9)
+
+    ok = update_opportunity_outcome("opp-A", out, board_path=board)
+    assert ok is True
+
+    rows = json.loads(board.read_text())
+    a = next(r for r in rows if r["opportunity_id"] == "opp-A")
+    b = next(r for r in rows if r["opportunity_id"] == "opp-B")
+
+    assert len(a["realized_outcomes"]) == 1
+    assert a["realized_outcomes"][0]["outcome_id"] == "out-1"
+    assert a["realized_outcomes"][0]["success"] is True
+    assert a["learned_score_delta"] == 0.9
+    assert "realized_outcomes" not in b
+    assert "learned_score_delta" not in b
+
+
+def test_failure_outcome_decreases_score(tmp_path: Path):
+    board = _board(tmp_path, {"opportunity_id": "opp-A"})
+    out = _outcome(outcome_id="out-fail", success=False, fitness_score=0.0)
+
+    ok = update_opportunity_outcome("opp-A", out, board_path=board)
+    assert ok is True
+
+    rows = json.loads(board.read_text())
+    assert rows[0]["learned_score_delta"] == -0.5
+    assert rows[0]["realized_outcomes"][0]["success"] is False
+
+
+def test_idempotent_on_duplicate_outcome_id(tmp_path: Path):
+    board = _board(tmp_path, {"opportunity_id": "opp-A"})
+    out = _outcome(outcome_id="out-dup", success=True, fitness_score=0.5)
+
+    first = update_opportunity_outcome("opp-A", out, board_path=board)
+    second = update_opportunity_outcome("opp-A", out, board_path=board)
+
+    assert first is True
+    assert second is False  # idempotent
+
+    rows = json.loads(board.read_text())
+    assert len(rows[0]["realized_outcomes"]) == 1
+    # delta applied exactly once
+    assert rows[0]["learned_score_delta"] == 0.5
+
+
+def test_no_match_returns_false_and_does_not_write(tmp_path: Path):
+    board = _board(tmp_path, {"opportunity_id": "opp-A"})
+    before = board.read_text()
+
+    ok = update_opportunity_outcome("opp-MISSING", _outcome(), board_path=board)
+    assert ok is False
+    assert board.read_text() == before
+
+
+def test_missing_board_returns_false(tmp_path: Path):
+    missing = tmp_path / "does_not_exist.json"
+    ok = update_opportunity_outcome("opp-A", _outcome(), board_path=missing)
+    assert ok is False
+    assert not missing.exists()
+
+
+def test_atomic_write_preserves_other_rows(tmp_path: Path):
+    board = _board(
+        tmp_path,
+        {"opportunity_id": "opp-A", "title": "A", "score": 1.0},
+        {"opportunity_id": "opp-B", "title": "B", "score": 2.0},
+        {"opportunity_id": "opp-C", "title": "C", "score": 3.0},
+    )
+    update_opportunity_outcome("opp-B", _outcome(outcome_id="x"), board_path=board)
+
+    rows = json.loads(board.read_text())
+    assert len(rows) == 3
+    assert {r["opportunity_id"] for r in rows} == {"opp-A", "opp-B", "opp-C"}
+    a = next(r for r in rows if r["opportunity_id"] == "opp-A")
+    c = next(r for r in rows if r["opportunity_id"] == "opp-C")
+    assert a == {"opportunity_id": "opp-A", "title": "A", "score": 1.0}
+    assert c == {"opportunity_id": "opp-C", "title": "C", "score": 3.0}
+
+
+def test_backup_file_written_on_update(tmp_path: Path):
+    board = _board(tmp_path, {"opportunity_id": "opp-A"})
+    update_opportunity_outcome("opp-A", _outcome(), board_path=board)
+    backups = list(tmp_path.glob("opportunity_board.json.bak.*"))
+    assert len(backups) == 1
+
+
+def test_score_delta_capped_per_outcome(tmp_path: Path):
+    """A single oversized fitness_score does not blow past the cap."""
+    board = _board(tmp_path, {"opportunity_id": "opp-A"})
+    out = _outcome(outcome_id="big", success=True, fitness_score=999.0)
+    update_opportunity_outcome("opp-A", out, board_path=board)
+    rows = json.loads(board.read_text())
+    assert rows[0]["learned_score_delta"] == 1.0

--- a/tests/test_telic_seam.py
+++ b/tests/test_telic_seam.py
@@ -13,6 +13,8 @@ Verifies:
 9. Stats reflect the metabolic state
 """
 
+import json
+
 import pytest
 
 from dharma_swarm.lineage import LineageGraph
@@ -441,6 +443,85 @@ class TestRecordOutcome:
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # Full Metabolic Loop
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+
+class TestRecordOutcomeBoardFeedback:
+    """BR-002 closure: record_outcome must feed back to opportunity_board.json
+    when the task carries metadata.opportunity_id. Failure on the board side
+    must not break the canonical Outcome write."""
+
+    def _opp_task(self, opp_id: str) -> Task:
+        return Task(
+            title="opp-task",
+            metadata={"opportunity_id": opp_id, "source": "frontier_task"},
+        )
+
+    def _seed_board(self, board_path, *opp_ids: str) -> None:
+        rows = [{"opportunity_id": opp_id, "title": f"opp {opp_id}"} for opp_id in opp_ids]
+        board_path.write_text(json.dumps(rows), encoding="utf-8")
+
+    def test_writes_to_board_when_metadata_has_opp_id(self, seam, tmp_path, monkeypatch):
+        board = tmp_path / "opportunity_board.json"
+        self._seed_board(board, "opp-A")
+        monkeypatch.setattr(
+            "dharma_swarm.shakti_executive.feedback_writer.DEFAULT_BOARD_PATH",
+            board,
+        )
+        task = self._opp_task("opp-A")
+        seam.record_dispatch(task, "agent_alpha")
+
+        outcome_id = seam.record_outcome(
+            task, "agent_alpha", success=True, fitness_score=0.7
+        )
+        assert outcome_id is not None
+
+        rows = json.loads(board.read_text())
+        a = next(r for r in rows if r["opportunity_id"] == "opp-A")
+        assert "realized_outcomes" in a
+        assert len(a["realized_outcomes"]) == 1
+        assert a["realized_outcomes"][0]["outcome_id"] == outcome_id
+        assert a["realized_outcomes"][0]["success"] is True
+        assert a["learned_score_delta"] == pytest.approx(0.7)
+
+    def test_does_not_touch_board_when_no_opp_id(self, seam, sample_task, tmp_path, monkeypatch):
+        board = tmp_path / "opportunity_board.json"
+        self._seed_board(board, "opp-A")
+        monkeypatch.setattr(
+            "dharma_swarm.shakti_executive.feedback_writer.DEFAULT_BOARD_PATH",
+            board,
+        )
+        seam.record_dispatch(sample_task, "agent_alpha")
+
+        outcome_id = seam.record_outcome(sample_task, "agent_alpha", success=True)
+        assert outcome_id is not None
+
+        rows = json.loads(board.read_text())
+        a = next(r for r in rows if r["opportunity_id"] == "opp-A")
+        assert "realized_outcomes" not in a
+        assert "learned_score_delta" not in a
+
+    def test_board_write_failure_does_not_break_outcome_recording(
+        self, seam, tmp_path, monkeypatch
+    ):
+        # Point feedback_writer at a non-existent board to force the no-op path,
+        # then additionally make update_opportunity_outcome raise to simulate
+        # an unexpected error.
+        def _raise(*_args, **_kwargs):
+            raise RuntimeError("simulated board write failure")
+
+        monkeypatch.setattr(
+            "dharma_swarm.shakti_executive.feedback_writer.update_opportunity_outcome",
+            _raise,
+        )
+        task = self._opp_task("opp-X")
+        seam.record_dispatch(task, "agent_alpha")
+
+        outcome_id = seam.record_outcome(task, "agent_alpha", success=True)
+        # Canonical write still succeeds; board failure logged at debug level.
+        assert outcome_id is not None
+        obj = seam.registry.get_object(outcome_id)
+        assert obj is not None
+        assert obj.properties["success"] is True
 
 
 class TestFullLoop:


### PR DESCRIPTION
## Summary

Clean main-based successor for Track 1 / PR #166.

PR #166 was stacked on the now-superseded #159 branch. This branch starts from current `origin/main` after #172 merged and ports only the scoped Track 1 feedback edge:

- `dharma_swarm/shakti_executive/feedback_writer.py`
- `dharma_swarm/telic_seam.py`
- `docs/state/BROKEN_REGISTER.md`
- `tests/test_feedback_writer.py`
- `tests/test_telic_seam.py`
- mechanical DocOps count refresh in `docs/docops/AUTO_INVENTORY.md` and `docs/governance/SOVEREIGN_MANIFEST.md`

## What Changed

- Adds `OutcomeRecord` and `update_opportunity_outcome()` for append-only, idempotent opportunity-board outcome feedback.
- Wires `TelicSeam.record_outcome()` to write opportunity-board feedback when `task.metadata["opportunity_id"]` is present.
- Preserves the current main outcome signal fanout from #172 while adding the board-feedback edge.
- Keeps board writes failure-isolated; canonical ontology outcome recording remains authoritative.

## Coherence Delta

Organ touched: Shakti Executive write side, TelicSeam outcome edge, opportunity-board feedback substrate, DocOps counts.

Declared-vs-actual gap closed: BR-002 now has the write-through evidence edge from completed telic outcomes back into `opportunity_board.json` when an opportunity id is available.

Proof that re-reads the map: `pytest -q tests/test_telic_seam.py tests/test_feedback_writer.py` passed with 72 tests.

New drift introduced: opportunity rows may gain `realized_outcomes` and `learned_score_delta`; downstream readers can consume these in a later PR.

## Verification

- `pytest -q tests/test_telic_seam.py tests/test_feedback_writer.py` -> 72 passed
- `python3 scripts/docops/check_docops_integrity.py` -> passed
- `git diff --check origin/main...HEAD` -> passed

## Supersedes

Supersedes #166, which remains stacked on the old #159 branch lineage.
