### PR TITLE
docs(go): scaffold sense-organ PR roadmap

### DIFF
--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -11,8 +11,8 @@ Do not hand-edit the generated block.
 | Dharma Python LOC | 249,079 |
 | Test files | 562 |
 | Test function occurrences | 10,014 |
-| Markdown files | 684 |
-| Markdown total lines | 174,847 |
+| Markdown files | 685 |
+| Markdown total lines | 175,003 |
 | Bridge files | 19 |
 | Adapter files | 14 |
 | Orchestrator files | 4 |

--- a/docs/governance/SOVEREIGN_MANIFEST.md
+++ b/docs/governance/SOVEREIGN_MANIFEST.md
@@ -52,11 +52,11 @@ The repo has **9 verified circular dependency chains** (V). The worst:
 All 9 cycles were independently confirmed with exact import lines. Most are mitigated by lazy imports but remain architectural debt. **New code must not create circular imports.**
 
 ### A8: FRONTMATTER DISCIPLINE
-Do not inject machine-readable YAML frontmatter into governance or architecture docs unless explicitly requested. Current state: **214 of 684 Markdown files start with YAML frontmatter; 15 of 21 docs/architecture Markdown files do so** (V). Long frontmatter remains an authority/noise risk even when the prose is useful.
+Do not inject machine-readable YAML frontmatter into governance or architecture docs unless explicitly requested. Current state: **214 of 685 Markdown files start with YAML frontmatter; 15 of 21 docs/architecture Markdown files do so** (V). Long frontmatter remains an authority/noise risk even when the prose is useful.
 
 ---
 
-## VERIFIED NUMBERS (2026-05-09 COUNT REFRESH)
+## VERIFIED NUMBERS (2026-05-07 COUNT REFRESH)
 
 These are the ground-truth metrics. All other documents citing different numbers are stale.
 
@@ -64,13 +64,13 @@ These are the ground-truth metrics. All other documents citing different numbers
 |--------|-------|-------------|
 | Total Python modules | **553** | find dharma_swarm -name "*.py" -type f |
 | Top-level (flat) modules | **385 (70.0%)** | find dharma_swarm -maxdepth 1 -name "*.py" -type f |
-| Total Python LOC | **249,079** | wc -l across dharma_swarm Python modules |
+| Total Python LOC | **248,966** | wc -l across dharma_swarm Python modules |
 | Test files | **562** | find tests -name "*.py" -type f |
 | Test functions | **10,014 `def test_` occurrences under tests/** | rg "def test_" tests |
 | Tests collected (pytest) | **Needs write-permitted refresh** | not run during this DocOps count pass |
 | Collection errors | **Historical: 16 on 2026-04-04** | refresh before relying on this count |
-| Markdown files | **684** | find . -name "*.md" -type f |
-| Markdown total lines | **174,847** | wc -l across all .md |
+| Markdown files | **685** | find . -name "*.md" -type f |
+| Markdown total lines | **175,003** | wc -l across all .md |
 | Bridge files | **19** | find dharma_swarm -name "*bridge*.py" |
 | Adapter files | **14 across 7 locations** | find dharma_swarm -type f \| rg -i "adapter" |
 | Orchestrator files | **4** (6,034 LOC total) | find dharma_swarm -name "*orchestrat*" |
@@ -171,7 +171,7 @@ These are the ground-truth metrics. All other documents citing different numbers
 
 ### Domain 6: Bridges (Integration Layer)
 
-**19 bridge files** (V), **10,531 total LOC**:
+**19 bridge files** (V), **10,418 total LOC**:
 
 | Bridge | Lines | Importers | Status |
 |--------|-------|-----------|--------|
@@ -192,7 +192,6 @@ These are the ground-truth metrics. All other documents citing different numbers
 | skill_bridge.py | 202 | 2 | ALIVE |
 | optimizer_bridge.py | 191 | 8 | ALIVE |
 | ecosystem_bridge.py | 170 | 3 | ALIVE |
-| operator_core/go_evidence_bridge.py | 113 | 1 | ALIVE |
 | ginko_bridge.py | 94 | 1 | ALIVE |
 
 - **Primary Entry Points**: `terminal_bridge.py` (Bun<->Python), `bridge.py` (core abstraction)

--- a/docs/plans/2026-05-09-go-sense-organ-pr-scaffold.md
+++ b/docs/plans/2026-05-09-go-sense-organ-pr-scaffold.md
@@ -1,0 +1,157 @@
+# Go Sense-Organ PR Scaffold
+
+Date: 2026-05-09
+Status: scaffold only
+Base rule: Go is a fast evidence, ingestion, transport, and observability layer. Python remains the telos, policy, gate, dispatch, ontology, and decision layer.
+
+This plan records the 14 Go-track PRs so they do not disappear into chat context. Each PR has a matching AgentOps packet stub under `reports/agentops/work_packets/go-gXX-*.json`.
+
+## Current Anchor
+
+G0 is PR #176:
+
+- Branch: `feat/go-evidence-sense-organ-v0-closure`
+- PR: `https://github.com/AmitabhainArunachala/dharma_swarm/pull/176`
+- Purpose: first Go sidecar, file-native evidence receipt, Python closure bridge
+- Status at scaffold time: open, clean, CI green, awaiting explicit merge decision
+
+## Design Boundary
+
+Go may:
+
+- collect high-volume signals
+- normalize source payloads into receipts
+- hash content and assign stable event IDs
+- expose health and metrics
+- spool evidence to disk
+- run source-specific connectors
+- serve read-only resources when explicitly scoped
+
+Go may not:
+
+- choose `NextDecision`
+- write ontology/runtime databases
+- dispatch agents
+- approve gates
+- mutate kernel/telos/evolution surfaces
+- merge or push code
+- become a second control plane
+
+## Wild Pattern Mapping
+
+| Wild pattern | Dharma Swarm use |
+| --- | --- |
+| OpenTelemetry Collector | Many source adapters normalize into one evidence stream |
+| Prometheus exporters | Every Go organ exposes health, metrics, backlog, drops |
+| Kubernetes operators | Watch actual state and propose reconciliation evidence |
+| Temporal workers | Durable long-running ingestion jobs and retries, later |
+| Terraform providers | Connector SDK: one external binary per source family |
+| NATS or JetStream | Optional event fabric after file spool is proven |
+| MCP servers | Read-only DS resources exposed to external agents |
+| Local model daemons | Local/open model inventory and health probes |
+
+## PR Chain
+
+| PR | Packet | Branch | Owner lane | Depends on | Purpose |
+| --- | --- | --- | --- | --- | --- |
+| G0 | `go-g00-evidence-sense-organ-v0` | `feat/go-evidence-sense-organ-v0-closure` | Go seed | Tracks 1-3 merged | Merge #176 as the first bounded Go sidecar |
+| G1 | `go-g01-language-boundary-policy` | `docs/go-language-boundary-policy` | Governance/docs | G0 | Record the language boundary and kill criteria |
+| G2 | `go-g02-receipt-sdk` | `feat/go-receipt-sdk` | SDK | G1 | Shared Go receipt package and contract tests |
+| G3 | `go-g03-adapter-contract-harness` | `feat/go-adapter-contract-harness` | SDK/tests | G2 | Adapter interface, golden fixtures, CI contract gates |
+| G4 | `go-g04-github-repo-ingestor` | `feat/go-github-repo-ingestor` | Sources A | G3 | GitHub/repo event evidence adapter |
+| G5 | `go-g05-ai-frontier-ingestor` | `feat/go-ai-frontier-ingestor` | Sources B | G3 | AI news, model release, paper, benchmark receipts |
+| G6 | `go-g06-local-model-runtime-inventory` | `feat/go-local-model-runtime-inventory` | Sources C | G3 | Local/open model and runtime inventory receipts |
+| G7 | `go-g07-health-metrics` | `feat/go-health-metrics` | Observability | G2 | Standard `/healthz`, `/readyz`, `/metrics` for Go organs |
+| G8 | `go-g08-file-spool-backpressure` | `feat/go-file-spool-backpressure` | Transport | G2 | File spool, backpressure, idempotent replay |
+| G9 | `go-g09-nats-event-fabric-experiment` | `exp/go-nats-event-fabric` | Transport | G8 | Optional NATS experiment, off by default |
+| G10 | `go-g10-readonly-mcp-server` | `feat/go-readonly-mcp-server` | Product/API | G3 | Read-only MCP resources for receipts/projections |
+| G11 | `go-g11-dharma-go-cli-bundle` | `feat/dharma-go-cli-bundle` | Packaging | G4,G5,G6,G7 | Single CLI bundle for Go sense organs |
+| G12 | `go-g12-connector-sdk-examples` | `docs/go-connector-sdk-examples` | Product/docs | G10,G11 | Public connector examples and product docs |
+| G13 | `go-g13-enterprise-deploy-profile` | `feat/go-enterprise-deploy-profile` | Deploy | G7,G8,G11 | launchd/systemd/container/Kubernetes deployment profile |
+
+## Agent Plan
+
+Use six agents, but keep one coordinator in charge of merge order.
+
+| Agent | Role | Owns | Rule |
+| --- | --- | --- | --- |
+| Coordinator | merge conductor | G0, dependency graph, PR bodies | never writes implementation files |
+| SDK agent | core Go package | G2, G3 | no source adapters before G3 lands |
+| Source agent A | repo signals | G4 | no transport changes |
+| Source agent B | frontier signals | G5, G6 | tests use fixtures, no network in CI |
+| Observability/transport agent | metrics and spool | G7, G8, G9 | NATS stays experimental and off by default |
+| Product agent | external surface | G10, G11, G12, G13 | read-only first, deploy profiles after CLI |
+
+## Parallelization
+
+Strict sequence:
+
+1. Merge G0.
+2. Land G1.
+3. Land G2.
+4. Land G3.
+
+Safe parallel wave after G3:
+
+- G4, G5, G6 can run in parallel if they do not touch the SDK.
+- G7 and G8 can run in parallel after G2 if they only use stable receipt APIs.
+- G9 waits for G8.
+- G10 waits for G3.
+- G11 waits for G4, G5, G6, and G7.
+- G12 waits for G10 and G11.
+- G13 waits for G7, G8, and G11.
+
+## Branch Hygiene
+
+For every packet:
+
+```bash
+git fetch origin
+git worktree add -b <branch> /Users/dhyana/promotion_worktrees/<worktree> origin/main
+```
+
+Before opening a PR:
+
+```bash
+git status --short --branch
+git diff --check
+make go-ci
+python3 scripts/docops/check_docops_integrity.py --changed-from origin/main
+gh pr list --search "<packet id>"
+```
+
+PR bodies must include:
+
+- packet id
+- dependency statement
+- allowed-file footprint
+- Go/Python boundary statement
+- test transcript
+- Coherence Delta fields
+- explicit note if DocOps count-only files changed
+
+## Kill Criteria
+
+Stop and return to operator if any packet:
+
+- edits `dharma_swarm/ontology.py`
+- edits `dharma_swarm/telic_seam.py`
+- edits `dharma_swarm/evolution.py`
+- edits `dharma_swarm/telos_gates.py`
+- edits `dharma_swarm/dharma_kernel.py`
+- writes runtime or ontology database state from Go
+- exports a write-capable MCP tool
+- adds NATS or another broker to the default runtime path
+- makes network-dependent CI tests
+- changes Python decision policy to trust Go verdicts directly
+
+## Product Direction
+
+The finished product shape is:
+
+- Go daemon or CLI bundle collects signals.
+- Each source emits receipts with content hash, event UID, source, observed time, and correlation id.
+- Python ingests receipts through operator-core bridges.
+- Closure tests prove success/failure evidence changes decisions.
+- Users can add custom connectors without touching swarm policy code.
+- Enterprises can deploy collectors near their code, models, logs, and documents while keeping Dharma Swarm's decision layer governed.

--- a/reports/agentops/work_packets/go-g00-evidence-sense-organ-v0.json
+++ b/reports/agentops/work_packets/go-g00-evidence-sense-organ-v0.json
@@ -1,0 +1,49 @@
+{
+  "id": "go-g00-evidence-sense-organ-v0",
+  "base_ref": "origin/main",
+  "branch": "feat/go-evidence-sense-organ-v0-closure",
+  "worktree": "/Users/dhyana/dharma_swarm_go_closure_v0",
+  "intent": "Merge PR #176 as the first bounded Go sidecar: a file-native evidence receipt ingestor with Python closure_v0 projection.",
+  "allowed_files": [
+    ".github/workflows/tests.yml",
+    "Makefile",
+    "dharma_swarm/operator_core/go_evidence_bridge.py",
+    "docs/docops/AUTO_INVENTORY.md",
+    "docs/governance/SOVEREIGN_MANIFEST.md",
+    "tests/test_go_evidence_ingestor_bridge.py",
+    "tools/evidence_ingestor_go/**"
+  ],
+  "forbidden_files": [
+    "dharma_swarm/ontology.py",
+    "dharma_swarm/telic_seam.py",
+    "dharma_swarm/evolution.py",
+    "dharma_swarm/telos_gates.py",
+    "dharma_swarm/dharma_kernel.py",
+    "dharma_swarm/swarm.py",
+    "dharma_swarm/agent_runner.py",
+    "dharma_swarm/orchestrator.py",
+    "dharma_swarm/ACTIVE_SURFACE_MANIFEST.yaml"
+  ],
+  "gates": [
+    {
+      "name": "go-ci",
+      "command": "make go-ci"
+    },
+    {
+      "name": "bridge-tests",
+      "command": "python3 -m pytest -q tests/test_go_evidence_ingestor_bridge.py"
+    },
+    {
+      "name": "pr-checks",
+      "command": "gh pr checks 176 --watch --interval 10 --fail-fast"
+    }
+  ],
+  "commit": {
+    "allowed": false,
+    "message": "feat(go): add evidence sense-organ v0 [impact-checked]"
+  },
+  "approval": {
+    "before_commit": false,
+    "before_merge": true
+  }
+}

--- a/reports/agentops/work_packets/go-g01-language-boundary-policy.json
+++ b/reports/agentops/work_packets/go-g01-language-boundary-policy.json
@@ -1,0 +1,39 @@
+{
+  "id": "go-g01-language-boundary-policy",
+  "base_ref": "origin/main",
+  "branch": "docs/go-language-boundary-policy",
+  "worktree": "/Users/dhyana/promotion_worktrees/dharma_swarm_go_g01_language_boundary",
+  "intent": "Record the Go/Python boundary, kill criteria, dependency graph, and PR sequencing after G0 lands.",
+  "allowed_files": [
+    "docs/plans/2026-05-09-go-sense-organ-pr-scaffold.md",
+    "docs/architecture/NAVIGATION.md",
+    "reports/agentops/work_packets/go-g*.json",
+    "docs/docops/AUTO_INVENTORY.md",
+    "docs/governance/SOVEREIGN_MANIFEST.md"
+  ],
+  "forbidden_files": [
+    "dharma_swarm/**",
+    "tools/**",
+    "tests/**",
+    ".github/**",
+    "Makefile"
+  ],
+  "gates": [
+    {
+      "name": "diff-check",
+      "command": "git diff --check"
+    },
+    {
+      "name": "docops",
+      "command": "python3 scripts/docops/check_docops_integrity.py --changed-from origin/main"
+    }
+  ],
+  "commit": {
+    "allowed": true,
+    "message": "docs(go): scaffold sense-organ roadmap and PR packets [impact-checked]"
+  },
+  "approval": {
+    "before_commit": true,
+    "before_merge": true
+  }
+}

--- a/reports/agentops/work_packets/go-g02-receipt-sdk.json
+++ b/reports/agentops/work_packets/go-g02-receipt-sdk.json
@@ -1,0 +1,43 @@
+{
+  "id": "go-g02-receipt-sdk",
+  "base_ref": "origin/main",
+  "branch": "feat/go-receipt-sdk",
+  "worktree": "/Users/dhyana/promotion_worktrees/dharma_swarm_go_g02_receipt_sdk",
+  "intent": "Extract the G0 receipt shape into a reusable Go SDK package with deterministic hashing, validation, atomic write, and reject semantics.",
+  "allowed_files": [
+    "tools/go_sdk/**",
+    "tools/evidence_ingestor_go/**",
+    "Makefile",
+    ".github/workflows/tests.yml",
+    "docs/docops/AUTO_INVENTORY.md",
+    "docs/governance/SOVEREIGN_MANIFEST.md"
+  ],
+  "forbidden_files": [
+    "dharma_swarm/ontology.py",
+    "dharma_swarm/telic_seam.py",
+    "dharma_swarm/evolution.py",
+    "dharma_swarm/telos_gates.py",
+    "dharma_swarm/dharma_kernel.py",
+    "dharma_swarm/swarm.py",
+    "dharma_swarm/agent_runner.py",
+    "dharma_swarm/orchestrator.py"
+  ],
+  "gates": [
+    {
+      "name": "go-ci",
+      "command": "make go-ci"
+    },
+    {
+      "name": "docops",
+      "command": "python3 scripts/docops/check_docops_integrity.py --changed-from origin/main"
+    }
+  ],
+  "commit": {
+    "allowed": true,
+    "message": "feat(go): add receipt SDK for sense organs [impact-checked]"
+  },
+  "approval": {
+    "before_commit": true,
+    "before_merge": true
+  }
+}

--- a/reports/agentops/work_packets/go-g03-adapter-contract-harness.json
+++ b/reports/agentops/work_packets/go-g03-adapter-contract-harness.json
@@ -1,0 +1,44 @@
+{
+  "id": "go-g03-adapter-contract-harness",
+  "base_ref": "origin/main",
+  "branch": "feat/go-adapter-contract-harness",
+  "worktree": "/Users/dhyana/promotion_worktrees/dharma_swarm_go_g03_adapter_contracts",
+  "intent": "Define a Go source-adapter interface and golden contract harness so every future ingestor emits the same receipt semantics.",
+  "allowed_files": [
+    "tools/go_sdk/**",
+    "tests/fixtures/go_adapters/**",
+    "tests/test_go_adapter_contracts.py",
+    "Makefile",
+    ".github/workflows/tests.yml",
+    "docs/docops/AUTO_INVENTORY.md",
+    "docs/governance/SOVEREIGN_MANIFEST.md"
+  ],
+  "forbidden_files": [
+    "dharma_swarm/ontology.py",
+    "dharma_swarm/telic_seam.py",
+    "dharma_swarm/evolution.py",
+    "dharma_swarm/telos_gates.py",
+    "dharma_swarm/dharma_kernel.py",
+    "dharma_swarm/swarm.py",
+    "dharma_swarm/agent_runner.py",
+    "dharma_swarm/orchestrator.py"
+  ],
+  "gates": [
+    {
+      "name": "go-ci",
+      "command": "make go-ci"
+    },
+    {
+      "name": "adapter-contracts",
+      "command": "python3 -m pytest -q tests/test_go_adapter_contracts.py"
+    }
+  ],
+  "commit": {
+    "allowed": true,
+    "message": "feat(go): add source adapter contract harness [impact-checked]"
+  },
+  "approval": {
+    "before_commit": true,
+    "before_merge": true
+  }
+}

--- a/reports/agentops/work_packets/go-g04-github-repo-ingestor.json
+++ b/reports/agentops/work_packets/go-g04-github-repo-ingestor.json
@@ -1,0 +1,46 @@
+{
+  "id": "go-g04-github-repo-ingestor",
+  "base_ref": "origin/main",
+  "branch": "feat/go-github-repo-ingestor",
+  "worktree": "/Users/dhyana/promotion_worktrees/dharma_swarm_go_g04_github_ingestor",
+  "intent": "Add a GitHub/repository event ingestor that normalizes PR, commit, check, and release payloads into Go evidence receipts using fixtures only in CI.",
+  "allowed_files": [
+    "tools/github_ingestor_go/**",
+    "tools/go_sdk/**",
+    "dharma_swarm/operator_core/go_github_bridge.py",
+    "tests/test_go_github_ingestor_bridge.py",
+    "tests/fixtures/go_github_ingestor/**",
+    "Makefile",
+    ".github/workflows/tests.yml",
+    "docs/docops/AUTO_INVENTORY.md",
+    "docs/governance/SOVEREIGN_MANIFEST.md"
+  ],
+  "forbidden_files": [
+    "dharma_swarm/ontology.py",
+    "dharma_swarm/telic_seam.py",
+    "dharma_swarm/evolution.py",
+    "dharma_swarm/telos_gates.py",
+    "dharma_swarm/dharma_kernel.py",
+    "dharma_swarm/swarm.py",
+    "dharma_swarm/agent_runner.py",
+    "dharma_swarm/orchestrator.py"
+  ],
+  "gates": [
+    {
+      "name": "go-ci",
+      "command": "make go-ci"
+    },
+    {
+      "name": "github-bridge-tests",
+      "command": "python3 -m pytest -q tests/test_go_github_ingestor_bridge.py"
+    }
+  ],
+  "commit": {
+    "allowed": true,
+    "message": "feat(go): add GitHub evidence ingestor [impact-checked]"
+  },
+  "approval": {
+    "before_commit": true,
+    "before_merge": true
+  }
+}

--- a/reports/agentops/work_packets/go-g05-ai-frontier-ingestor.json
+++ b/reports/agentops/work_packets/go-g05-ai-frontier-ingestor.json
@@ -1,0 +1,46 @@
+{
+  "id": "go-g05-ai-frontier-ingestor",
+  "base_ref": "origin/main",
+  "branch": "feat/go-ai-frontier-ingestor",
+  "worktree": "/Users/dhyana/promotion_worktrees/dharma_swarm_go_g05_ai_frontier",
+  "intent": "Add fixture-driven AI frontier evidence ingestion for model releases, papers, benchmark updates, and provider announcements.",
+  "allowed_files": [
+    "tools/ai_frontier_ingestor_go/**",
+    "tools/go_sdk/**",
+    "dharma_swarm/operator_core/go_frontier_bridge.py",
+    "tests/test_go_ai_frontier_ingestor_bridge.py",
+    "tests/fixtures/go_ai_frontier_ingestor/**",
+    "Makefile",
+    ".github/workflows/tests.yml",
+    "docs/docops/AUTO_INVENTORY.md",
+    "docs/governance/SOVEREIGN_MANIFEST.md"
+  ],
+  "forbidden_files": [
+    "dharma_swarm/ontology.py",
+    "dharma_swarm/telic_seam.py",
+    "dharma_swarm/evolution.py",
+    "dharma_swarm/telos_gates.py",
+    "dharma_swarm/dharma_kernel.py",
+    "dharma_swarm/swarm.py",
+    "dharma_swarm/agent_runner.py",
+    "dharma_swarm/orchestrator.py"
+  ],
+  "gates": [
+    {
+      "name": "go-ci",
+      "command": "make go-ci"
+    },
+    {
+      "name": "frontier-bridge-tests",
+      "command": "python3 -m pytest -q tests/test_go_ai_frontier_ingestor_bridge.py"
+    }
+  ],
+  "commit": {
+    "allowed": true,
+    "message": "feat(go): add AI frontier evidence ingestor [impact-checked]"
+  },
+  "approval": {
+    "before_commit": true,
+    "before_merge": true
+  }
+}

--- a/reports/agentops/work_packets/go-g06-local-model-runtime-inventory.json
+++ b/reports/agentops/work_packets/go-g06-local-model-runtime-inventory.json
@@ -1,0 +1,46 @@
+{
+  "id": "go-g06-local-model-runtime-inventory",
+  "base_ref": "origin/main",
+  "branch": "feat/go-local-model-runtime-inventory",
+  "worktree": "/Users/dhyana/promotion_worktrees/dharma_swarm_go_g06_local_model_inventory",
+  "intent": "Add a local runtime and open-model inventory ingestor for installed models, local endpoints, runtime health, and capability receipts.",
+  "allowed_files": [
+    "tools/local_model_inventory_go/**",
+    "tools/go_sdk/**",
+    "dharma_swarm/operator_core/go_model_inventory_bridge.py",
+    "tests/test_go_model_inventory_bridge.py",
+    "tests/fixtures/go_model_inventory/**",
+    "Makefile",
+    ".github/workflows/tests.yml",
+    "docs/docops/AUTO_INVENTORY.md",
+    "docs/governance/SOVEREIGN_MANIFEST.md"
+  ],
+  "forbidden_files": [
+    "dharma_swarm/ontology.py",
+    "dharma_swarm/telic_seam.py",
+    "dharma_swarm/evolution.py",
+    "dharma_swarm/telos_gates.py",
+    "dharma_swarm/dharma_kernel.py",
+    "dharma_swarm/swarm.py",
+    "dharma_swarm/agent_runner.py",
+    "dharma_swarm/orchestrator.py"
+  ],
+  "gates": [
+    {
+      "name": "go-ci",
+      "command": "make go-ci"
+    },
+    {
+      "name": "model-inventory-tests",
+      "command": "python3 -m pytest -q tests/test_go_model_inventory_bridge.py"
+    }
+  ],
+  "commit": {
+    "allowed": true,
+    "message": "feat(go): add local model inventory ingestor [impact-checked]"
+  },
+  "approval": {
+    "before_commit": true,
+    "before_merge": true
+  }
+}

--- a/reports/agentops/work_packets/go-g07-health-metrics.json
+++ b/reports/agentops/work_packets/go-g07-health-metrics.json
@@ -1,0 +1,45 @@
+{
+  "id": "go-g07-health-metrics",
+  "base_ref": "origin/main",
+  "branch": "feat/go-health-metrics",
+  "worktree": "/Users/dhyana/promotion_worktrees/dharma_swarm_go_g07_health_metrics",
+  "intent": "Standardize Go organ health, readiness, and Prometheus-style metrics without making metrics a decision input.",
+  "allowed_files": [
+    "tools/go_sdk/**",
+    "tools/evidence_ingestor_go/**",
+    "tests/test_go_health_metrics.py",
+    "tests/fixtures/go_health_metrics/**",
+    "Makefile",
+    ".github/workflows/tests.yml",
+    "docs/docops/AUTO_INVENTORY.md",
+    "docs/governance/SOVEREIGN_MANIFEST.md"
+  ],
+  "forbidden_files": [
+    "dharma_swarm/ontology.py",
+    "dharma_swarm/telic_seam.py",
+    "dharma_swarm/evolution.py",
+    "dharma_swarm/telos_gates.py",
+    "dharma_swarm/dharma_kernel.py",
+    "dharma_swarm/swarm.py",
+    "dharma_swarm/agent_runner.py",
+    "dharma_swarm/orchestrator.py"
+  ],
+  "gates": [
+    {
+      "name": "go-ci",
+      "command": "make go-ci"
+    },
+    {
+      "name": "health-metrics-tests",
+      "command": "python3 -m pytest -q tests/test_go_health_metrics.py"
+    }
+  ],
+  "commit": {
+    "allowed": true,
+    "message": "feat(go): add health and metrics substrate [impact-checked]"
+  },
+  "approval": {
+    "before_commit": true,
+    "before_merge": true
+  }
+}

--- a/reports/agentops/work_packets/go-g08-file-spool-backpressure.json
+++ b/reports/agentops/work_packets/go-g08-file-spool-backpressure.json
@@ -1,0 +1,45 @@
+{
+  "id": "go-g08-file-spool-backpressure",
+  "base_ref": "origin/main",
+  "branch": "feat/go-file-spool-backpressure",
+  "worktree": "/Users/dhyana/promotion_worktrees/dharma_swarm_go_g08_file_spool",
+  "intent": "Add an idempotent file spool, backpressure controls, replay cursor, and Python read-only bridge for receipt batches.",
+  "allowed_files": [
+    "tools/go_sdk/**",
+    "dharma_swarm/operator_core/go_spool_bridge.py",
+    "tests/test_go_spool_bridge.py",
+    "tests/fixtures/go_spool/**",
+    "Makefile",
+    ".github/workflows/tests.yml",
+    "docs/docops/AUTO_INVENTORY.md",
+    "docs/governance/SOVEREIGN_MANIFEST.md"
+  ],
+  "forbidden_files": [
+    "dharma_swarm/ontology.py",
+    "dharma_swarm/telic_seam.py",
+    "dharma_swarm/evolution.py",
+    "dharma_swarm/telos_gates.py",
+    "dharma_swarm/dharma_kernel.py",
+    "dharma_swarm/swarm.py",
+    "dharma_swarm/agent_runner.py",
+    "dharma_swarm/orchestrator.py"
+  ],
+  "gates": [
+    {
+      "name": "go-ci",
+      "command": "make go-ci"
+    },
+    {
+      "name": "spool-tests",
+      "command": "python3 -m pytest -q tests/test_go_spool_bridge.py"
+    }
+  ],
+  "commit": {
+    "allowed": true,
+    "message": "feat(go): add file spool and backpressure [impact-checked]"
+  },
+  "approval": {
+    "before_commit": true,
+    "before_merge": true
+  }
+}

--- a/reports/agentops/work_packets/go-g09-nats-event-fabric-experiment.json
+++ b/reports/agentops/work_packets/go-g09-nats-event-fabric-experiment.json
@@ -1,0 +1,46 @@
+{
+  "id": "go-g09-nats-event-fabric-experiment",
+  "base_ref": "origin/main",
+  "branch": "exp/go-nats-event-fabric",
+  "worktree": "/Users/dhyana/promotion_worktrees/dharma_swarm_go_g09_nats_experiment",
+  "intent": "Prototype optional NATS/JetStream event fabric behind explicit build tags and config, with file spool remaining the default path.",
+  "allowed_files": [
+    "tools/nats_event_fabric_go/**",
+    "tools/go_sdk/**",
+    "tests/test_go_nats_event_fabric.py",
+    "tests/fixtures/go_nats_event_fabric/**",
+    "docs/plans/2026-05-09-go-sense-organ-pr-scaffold.md",
+    "Makefile",
+    ".github/workflows/tests.yml",
+    "docs/docops/AUTO_INVENTORY.md",
+    "docs/governance/SOVEREIGN_MANIFEST.md"
+  ],
+  "forbidden_files": [
+    "dharma_swarm/ontology.py",
+    "dharma_swarm/telic_seam.py",
+    "dharma_swarm/evolution.py",
+    "dharma_swarm/telos_gates.py",
+    "dharma_swarm/dharma_kernel.py",
+    "dharma_swarm/swarm.py",
+    "dharma_swarm/agent_runner.py",
+    "dharma_swarm/orchestrator.py"
+  ],
+  "gates": [
+    {
+      "name": "go-ci",
+      "command": "make go-ci"
+    },
+    {
+      "name": "nats-experiment-tests",
+      "command": "python3 -m pytest -q tests/test_go_nats_event_fabric.py"
+    }
+  ],
+  "commit": {
+    "allowed": true,
+    "message": "exp(go): prototype optional NATS event fabric [impact-checked]"
+  },
+  "approval": {
+    "before_commit": true,
+    "before_merge": true
+  }
+}

--- a/reports/agentops/work_packets/go-g10-readonly-mcp-server.json
+++ b/reports/agentops/work_packets/go-g10-readonly-mcp-server.json
@@ -1,0 +1,46 @@
+{
+  "id": "go-g10-readonly-mcp-server",
+  "base_ref": "origin/main",
+  "branch": "feat/go-readonly-mcp-server",
+  "worktree": "/Users/dhyana/promotion_worktrees/dharma_swarm_go_g10_readonly_mcp",
+  "intent": "Expose read-only MCP resources for Go receipts and closure projections, with no write tools and no dispatch actions.",
+  "allowed_files": [
+    "tools/ds_mcp_go/**",
+    "tools/go_sdk/**",
+    "tests/test_go_readonly_mcp.py",
+    "tests/fixtures/go_readonly_mcp/**",
+    "docs/plans/2026-05-09-go-sense-organ-pr-scaffold.md",
+    "Makefile",
+    ".github/workflows/tests.yml",
+    "docs/docops/AUTO_INVENTORY.md",
+    "docs/governance/SOVEREIGN_MANIFEST.md"
+  ],
+  "forbidden_files": [
+    "dharma_swarm/ontology.py",
+    "dharma_swarm/telic_seam.py",
+    "dharma_swarm/evolution.py",
+    "dharma_swarm/telos_gates.py",
+    "dharma_swarm/dharma_kernel.py",
+    "dharma_swarm/swarm.py",
+    "dharma_swarm/agent_runner.py",
+    "dharma_swarm/orchestrator.py"
+  ],
+  "gates": [
+    {
+      "name": "go-ci",
+      "command": "make go-ci"
+    },
+    {
+      "name": "mcp-readonly-tests",
+      "command": "python3 -m pytest -q tests/test_go_readonly_mcp.py"
+    }
+  ],
+  "commit": {
+    "allowed": true,
+    "message": "feat(go): add read-only MCP resource server [impact-checked]"
+  },
+  "approval": {
+    "before_commit": true,
+    "before_merge": true
+  }
+}

--- a/reports/agentops/work_packets/go-g11-dharma-go-cli-bundle.json
+++ b/reports/agentops/work_packets/go-g11-dharma-go-cli-bundle.json
@@ -1,0 +1,46 @@
+{
+  "id": "go-g11-dharma-go-cli-bundle",
+  "base_ref": "origin/main",
+  "branch": "feat/dharma-go-cli-bundle",
+  "worktree": "/Users/dhyana/promotion_worktrees/dharma_swarm_go_g11_cli_bundle",
+  "intent": "Bundle approved Go organs behind a single dharma-go CLI with explicit subcommands, config discovery, and no hidden daemon behavior.",
+  "allowed_files": [
+    "tools/dharma_go/**",
+    "tools/*_go/**",
+    "tools/go_sdk/**",
+    "tests/test_dharma_go_cli.py",
+    "tests/fixtures/dharma_go_cli/**",
+    "Makefile",
+    ".github/workflows/tests.yml",
+    "docs/docops/AUTO_INVENTORY.md",
+    "docs/governance/SOVEREIGN_MANIFEST.md"
+  ],
+  "forbidden_files": [
+    "dharma_swarm/ontology.py",
+    "dharma_swarm/telic_seam.py",
+    "dharma_swarm/evolution.py",
+    "dharma_swarm/telos_gates.py",
+    "dharma_swarm/dharma_kernel.py",
+    "dharma_swarm/swarm.py",
+    "dharma_swarm/agent_runner.py",
+    "dharma_swarm/orchestrator.py"
+  ],
+  "gates": [
+    {
+      "name": "go-ci",
+      "command": "make go-ci"
+    },
+    {
+      "name": "cli-tests",
+      "command": "python3 -m pytest -q tests/test_dharma_go_cli.py"
+    }
+  ],
+  "commit": {
+    "allowed": true,
+    "message": "feat(go): add dharma-go CLI bundle [impact-checked]"
+  },
+  "approval": {
+    "before_commit": true,
+    "before_merge": true
+  }
+}

--- a/reports/agentops/work_packets/go-g12-connector-sdk-examples.json
+++ b/reports/agentops/work_packets/go-g12-connector-sdk-examples.json
@@ -1,0 +1,50 @@
+{
+  "id": "go-g12-connector-sdk-examples",
+  "base_ref": "origin/main",
+  "branch": "docs/go-connector-sdk-examples",
+  "worktree": "/Users/dhyana/promotion_worktrees/dharma_swarm_go_g12_connector_examples",
+  "intent": "Add product-facing connector SDK examples showing how users build custom Go source adapters without touching decision policy.",
+  "allowed_files": [
+    "docs/examples/go_connector_quickstart.md",
+    "docs/examples/go_connector_contract.md",
+    "examples/go_connectors/**",
+    "tools/go_sdk/**",
+    "tests/test_go_connector_examples.py",
+    "Makefile",
+    ".github/workflows/tests.yml",
+    "docs/docops/AUTO_INVENTORY.md",
+    "docs/governance/SOVEREIGN_MANIFEST.md"
+  ],
+  "forbidden_files": [
+    "dharma_swarm/ontology.py",
+    "dharma_swarm/telic_seam.py",
+    "dharma_swarm/evolution.py",
+    "dharma_swarm/telos_gates.py",
+    "dharma_swarm/dharma_kernel.py",
+    "dharma_swarm/swarm.py",
+    "dharma_swarm/agent_runner.py",
+    "dharma_swarm/orchestrator.py"
+  ],
+  "gates": [
+    {
+      "name": "go-ci",
+      "command": "make go-ci"
+    },
+    {
+      "name": "connector-example-tests",
+      "command": "python3 -m pytest -q tests/test_go_connector_examples.py"
+    },
+    {
+      "name": "docops",
+      "command": "python3 scripts/docops/check_docops_integrity.py --changed-from origin/main"
+    }
+  ],
+  "commit": {
+    "allowed": true,
+    "message": "docs(go): add connector SDK examples [impact-checked]"
+  },
+  "approval": {
+    "before_commit": true,
+    "before_merge": true
+  }
+}

--- a/reports/agentops/work_packets/go-g13-enterprise-deploy-profile.json
+++ b/reports/agentops/work_packets/go-g13-enterprise-deploy-profile.json
@@ -1,0 +1,46 @@
+{
+  "id": "go-g13-enterprise-deploy-profile",
+  "base_ref": "origin/main",
+  "branch": "feat/go-enterprise-deploy-profile",
+  "worktree": "/Users/dhyana/promotion_worktrees/dharma_swarm_go_g13_enterprise_deploy",
+  "intent": "Add deploy profiles for Go sense organs across launchd, systemd, container, and Kubernetes sidecar shapes, all disabled by default.",
+  "allowed_files": [
+    "deploy/go/**",
+    "tools/dharma_go/**",
+    "tests/test_go_deploy_profiles.py",
+    "tests/fixtures/go_deploy_profiles/**",
+    "docs/examples/go_deploy_profiles.md",
+    "Makefile",
+    ".github/workflows/tests.yml",
+    "docs/docops/AUTO_INVENTORY.md",
+    "docs/governance/SOVEREIGN_MANIFEST.md"
+  ],
+  "forbidden_files": [
+    "dharma_swarm/ontology.py",
+    "dharma_swarm/telic_seam.py",
+    "dharma_swarm/evolution.py",
+    "dharma_swarm/telos_gates.py",
+    "dharma_swarm/dharma_kernel.py",
+    "dharma_swarm/swarm.py",
+    "dharma_swarm/agent_runner.py",
+    "dharma_swarm/orchestrator.py"
+  ],
+  "gates": [
+    {
+      "name": "go-ci",
+      "command": "make go-ci"
+    },
+    {
+      "name": "deploy-profile-tests",
+      "command": "python3 -m pytest -q tests/test_go_deploy_profiles.py"
+    }
+  ],
+  "commit": {
+    "allowed": true,
+    "message": "feat(go): add enterprise deploy profiles [impact-checked]"
+  },
+  "approval": {
+    "before_commit": true,
+    "before_merge": true
+  }
+}


### PR DESCRIPTION
## Summary

Scaffolds the Go sense-organ expansion so the 14-PR lane does not get lost in chat context.

Adds:
- docs/plans/2026-05-09-go-sense-organ-pr-scaffold.md
- AgentOps packet stubs for G0-G13 under reports/agentops/work_packets/go-g*.json
- DocOps count refresh only

## Scope

This is scaffold only. It does not implement new Go code, does not touch #176, and does not change runtime behavior.

## Agent plan

The roadmap assigns six lanes: coordinator, SDK, source A, source B, observability/transport, and product/deploy. Each G packet names branch, worktree, allowed files, forbidden files, gates, and dependency rules.

## Coherence Delta

Organ touched: docs/plans roadmap, reports/agentops work-packet ledger, DocOps generated counters.
Declared-vs-actual gap closed: the Go expansion is now represented as explicit G0-G13 packets instead of unstored chat planning.
Proof that re-reads the map: jq validates all packet JSON, DocOps integrity passes, narrow pre-commit passes on changed files.
New drift introduced: one planning doc and fourteen packet stubs added; no runtime behavior, Go code, or decision policy changed.

## Verification

- git diff --cached --check
- jq empty reports/agentops/work_packets/go-g*.json
- python3 scripts/docops/check_docops_integrity.py --changed-from origin/main
- pre-commit run --files <changed files>