### PR TITLE
docs(go): define language boundary policy [impact-checked]

### DIFF
--- a/docs/architecture/NAVIGATION.md
+++ b/docs/architecture/NAVIGATION.md
@@ -119,6 +119,40 @@ Generated: 2026-03-29 | 500 Python modules | 494 test files | 8,848 tests
 
 ---
 
+## Go Evidence Sense-Organ Boundary
+
+G0 is PR #176, `feat(go): closure-based evidence sense-organ v0 [impact-checked]`. It introduces a bounded Go sidecar for evidence ingestion only. This navigation map keeps the language boundary explicit before later Go PRs expand adapters, receipts, health checks, or transport.
+
+Base rule: Go collects, normalizes, hashes, spools, observes, and transports evidence. Python remains the telos, policy, gate, dispatch, ontology, runtime database, and decision layer.
+
+| Go may own | Python must own |
+|------------|-----------------|
+| High-volume source collection | Telos and policy interpretation |
+| Payload normalization into receipts | Gate approval and rejection |
+| Content hashing and stable event IDs | Agent dispatch and `NextDecision` selection |
+| File-native spooling and idempotent replay | Ontology and runtime database writes |
+| Health, readiness, metrics, and backlog reporting | Evolution, kernel, and runtime mutation surfaces |
+| Source-specific connectors and read-only projections | Final trust assignment for evidence claims |
+
+Go receipts are evidence inputs, not verdicts. Python bridges may ingest Go receipts, re-read them against the current map, and use them as one signal in governed decision flows. No Go process may become a second control plane or an authority over closure, gates, ontology state, or dispatch.
+
+### Go Kill Criteria
+
+Stop the Go track and return to the operator if a Go PR does any of the following:
+
+- edits `dharma_swarm/ontology.py`
+- edits `dharma_swarm/telic_seam.py`
+- edits `dharma_swarm/evolution.py`
+- edits `dharma_swarm/telos_gates.py`
+- edits `dharma_swarm/dharma_kernel.py`
+- writes runtime or ontology database state from Go
+- exports a write-capable MCP tool
+- adds NATS or another broker to the default runtime path
+- makes CI depend on live network access
+- changes Python decision policy to trust Go verdicts directly
+
+---
+
 ## Core Architecture (dharma_swarm/dharma_swarm/)
 
 ### Layer 0: Schema & Configuration

--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -12,7 +12,7 @@ Do not hand-edit the generated block.
 | Test files | 562 |
 | Test function occurrences | 10,014 |
 | Markdown files | 685 |
-| Markdown total lines | 175,003 |
+| Markdown total lines | 175,037 |
 | Bridge files | 19 |
 | Adapter files | 14 |
 | Orchestrator files | 4 |

--- a/docs/governance/SOVEREIGN_MANIFEST.md
+++ b/docs/governance/SOVEREIGN_MANIFEST.md
@@ -70,7 +70,7 @@ These are the ground-truth metrics. All other documents citing different numbers
 | Tests collected (pytest) | **Needs write-permitted refresh** | not run during this DocOps count pass |
 | Collection errors | **Historical: 16 on 2026-04-04** | refresh before relying on this count |
 | Markdown files | **685** | find . -name "*.md" -type f |
-| Markdown total lines | **175,003** | wc -l across all .md |
+| Markdown total lines | **175,037** | wc -l across all .md |
 | Bridge files | **19** | find dharma_swarm -name "*bridge*.py" |
 | Adapter files | **14 across 7 locations** | find dharma_swarm -type f \| rg -i "adapter" |
 | Orchestrator files | **4** (6,034 LOC total) | find dharma_swarm -name "*orchestrat*" |


### PR DESCRIPTION
## Summary

G1 records the Go/Python language boundary in `docs/architecture/NAVIGATION.md` after the G0 evidence sense-organ PR #176.

- Defines Go as an evidence collection, normalization, hashing, spooling, observability, connector, and transport sidecar.
- Keeps Python as the telos, policy, gate, dispatch, ontology, runtime database, and decision layer.
- Adds explicit kill criteria for future Go PRs before any runtime expansion.
- Refreshes DocOps generated markdown-line counts only.

## Verification

- `git diff --check` -> passed
- `python3 scripts/docops/check_docops_integrity.py --changed-from origin/main` -> passed
- `pre-commit run --files docs/architecture/NAVIGATION.md docs/docops/AUTO_INVENTORY.md docs/governance/SOVEREIGN_MANIFEST.md` -> passed

## Coherence Delta

- Organ touched: Go evidence sense-organ governance map and DocOps counters.
- Declared-vs-actual gap closed: The repo now records that Go collects, normalizes, and transports evidence while Python remains telos, policy, gates, dispatch, ontology, runtime DB, and decision authority.
- Proof that re-reads the map: `NAVIGATION.md` now treats Go receipts as evidence inputs, not verdicts, and lists kill criteria that stop any Go PR crossing into ontology, gates, kernel, evolution, runtime DB writes, write-capable MCP, default broker paths, network-dependent CI, or direct Python trust of Go verdicts.
- New drift introduced: None in runtime code; only documentation plus generated DocOps count refreshes changed.
