### PR TITLE
feat(go): add source adapter contract harness [impact-checked]

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,37 @@ on:
     branches: [main]
 
 jobs:
+  go-adapter-contracts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+
+      - name: Install package + test deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run Go adapter contract harness
+        env:
+          GOPROXY: "off"
+          GOSUMDB: "off"
+          GOFLAGS: "-mod=readonly"
+        run: make go-ci
+
+      - name: Run adapter contract pytest wrapper
+        run: python -m pytest -q tests/test_go_adapter_contracts.py
+
   pytest:
     runs-on: ubuntu-latest
     strategy:

--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -9,8 +9,8 @@ Do not hand-edit the generated block.
 | Dharma Python modules | 553 |
 | Top-level Dharma Python modules | 385 |
 | Dharma Python LOC | 249,079 |
-| Test files | 562 |
-| Test function occurrences | 10,014 |
+| Test files | 563 |
+| Test function occurrences | 10,019 |
 | Markdown files | 685 |
 | Markdown total lines | 175,037 |
 | Bridge files | 19 |

--- a/docs/governance/SOVEREIGN_MANIFEST.md
+++ b/docs/governance/SOVEREIGN_MANIFEST.md
@@ -65,8 +65,8 @@ These are the ground-truth metrics. All other documents citing different numbers
 | Total Python modules | **553** | find dharma_swarm -name "*.py" -type f |
 | Top-level (flat) modules | **385 (70.0%)** | find dharma_swarm -maxdepth 1 -name "*.py" -type f |
 | Total Python LOC | **248,966** | wc -l across dharma_swarm Python modules |
-| Test files | **562** | find tests -name "*.py" -type f |
-| Test functions | **10,014 `def test_` occurrences under tests/** | rg "def test_" tests |
+| Test files | **563** | find tests -name "*.py" -type f |
+| Test functions | **10,019 `def test_` occurrences under tests/** | rg "def test_" tests |
 | Tests collected (pytest) | **Needs write-permitted refresh** | not run during this DocOps count pass |
 | Collection errors | **Historical: 16 on 2026-04-04** | refresh before relying on this count |
 | Markdown files | **685** | find . -name "*.md" -type f |

--- a/tests/fixtures/go_adapters/expected_receipt.json
+++ b/tests/fixtures/go_adapters/expected_receipt.json
@@ -1,0 +1,16 @@
+{
+  "receipt_id": "goev_fe86673511f54340ca15fb7d",
+  "correlation_id": "corr_g03_fixture_001",
+  "source": "fixture_adapter",
+  "source_url": "fixture://go_adapters/valid",
+  "observed_at": "2026-05-09T00:00:00Z",
+  "content_hash": "sha256:9e171752d29af7adddf987c38211aec38fb669fc64cabf9a9d3c0b16fe3cee2d",
+  "event_uid": "evt_8060689a6607f173a542ee31",
+  "schema_version": "go_evidence_receipt.v0",
+  "status": "accepted",
+  "payload": {
+    "kind": "adapter_contract",
+    "sequence": 1,
+    "status": "green"
+  }
+}

--- a/tests/fixtures/go_adapters/malformed_input.json
+++ b/tests/fixtures/go_adapters/malformed_input.json
@@ -1,0 +1,7 @@
+{
+  "correlation_id": "corr_g03_fixture_001",
+  "source": "fixture_adapter",
+  "source_url": "fixture://go_adapters/malformed",
+  "observed_at": "2026-05-09T00:00:00Z",
+  "payload_text": "{not valid json"
+}

--- a/tests/fixtures/go_adapters/valid_input.json
+++ b/tests/fixtures/go_adapters/valid_input.json
@@ -1,0 +1,11 @@
+{
+  "correlation_id": "corr_g03_fixture_001",
+  "source": "fixture_adapter",
+  "source_url": "fixture://go_adapters/valid",
+  "observed_at": "2026-05-09T00:00:00Z",
+  "payload": {
+    "kind": "adapter_contract",
+    "sequence": 1,
+    "status": "green"
+  }
+}

--- a/tests/test_go_adapter_contracts.py
+++ b/tests/test_go_adapter_contracts.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GO_SDK = REPO_ROOT / "tools" / "go_sdk"
+FIXTURE_DIR = REPO_ROOT / "tests" / "fixtures" / "go_adapters"
+
+
+def test_go_adapter_contracts_pass_without_network() -> None:
+    env = os.environ.copy()
+    env.update(
+        {
+            "GOPROXY": "off",
+            "GOSUMDB": "off",
+            "GOFLAGS": "-mod=readonly",
+        }
+    )
+    result = subprocess.run(
+        ["go", "test", "./..."],
+        cwd=GO_SDK,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout
+
+
+def test_golden_receipt_has_stable_contract_fields() -> None:
+    receipt = json.loads((FIXTURE_DIR / "expected_receipt.json").read_text())
+    assert receipt["correlation_id"] == "corr_g03_fixture_001"
+    assert receipt["status"] == "accepted"
+    assert receipt["schema_version"] == "go_evidence_receipt.v0"
+    assert re.fullmatch(r"sha256:[0-9a-f]{64}", receipt["content_hash"])
+    assert re.fullmatch(r"evt_[0-9a-f]{24}", receipt["event_uid"])
+    assert re.fullmatch(r"goev_[0-9a-f]{24}", receipt["receipt_id"])
+
+
+def test_contract_harness_uses_receipt_sdk_without_parallel_primitives() -> None:
+    contract = GO_SDK / "adaptercontract" / "contract.go"
+    text = contract.read_text()
+    assert '"github.com/AmitabhainArunachala/dharma_swarm/tools/go_sdk/receipt"' in text
+    forbidden = [
+        '"crypto/sha256"',
+        '"encoding/hex"',
+        "type Receipt struct",
+        "func NormalizeJSON",
+        "func ContentHash",
+        "func EventUID",
+        "func ReceiptID",
+        "func Write(",
+        "os.CreateTemp",
+        "os.Rename",
+    ]
+    for needle in forbidden:
+        assert needle not in text
+
+
+def test_fixtures_are_file_native_and_non_networked() -> None:
+    for path in FIXTURE_DIR.glob("*.json"):
+        data = json.loads(path.read_text())
+        source_url = data.get("source_url", "")
+        if source_url:
+            assert source_url.startswith("fixture://"), path
+
+
+def test_contract_harness_does_not_import_network_packages() -> None:
+    forbidden = {'"net"', '"net/http"'}
+    for path in GO_SDK.rglob("*.go"):
+        text = path.read_text()
+        for package in forbidden:
+            assert package not in text, f"{path} imports {package}"

--- a/tools/go_sdk/adaptercontract/contract.go
+++ b/tools/go_sdk/adaptercontract/contract.go
@@ -1,0 +1,146 @@
+package adaptercontract
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/AmitabhainArunachala/dharma_swarm/tools/go_sdk/receipt"
+)
+
+const (
+	DefaultSchemaVersion = receipt.DefaultSchemaVersion
+	StatusAccepted       = receipt.StatusAccepted
+	StatusRejected       = receipt.StatusRejected
+)
+
+type Fixture struct {
+	CorrelationID string          `json:"correlation_id"`
+	Source        string          `json:"source"`
+	SourceURL     string          `json:"source_url"`
+	ObservedAt    string          `json:"observed_at"`
+	Payload       json.RawMessage `json:"payload"`
+}
+
+type Receipt = receipt.Receipt
+
+type SourceAdapter interface {
+	Adapt(context.Context, Fixture) (Receipt, error)
+}
+
+type RejectError struct {
+	Reason string
+}
+
+func (e RejectError) Error() string {
+	if e.Reason == "" {
+		return "adapter rejected input"
+	}
+	return "adapter rejected input: " + e.Reason
+}
+
+func LoadFixture(path string) (Fixture, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return Fixture{}, err
+	}
+	var fixture Fixture
+	if err := json.Unmarshal(raw, &fixture); err != nil {
+		return Fixture{}, err
+	}
+	return fixture, nil
+}
+
+func BuildSpec(fixture Fixture) receipt.BuildSpec {
+	return receipt.BuildSpec{
+		Source:        fixture.Source,
+		SourceURL:     fixture.SourceURL,
+		CorrelationID: fixture.CorrelationID,
+		ObservedAt:    fixture.ObservedAt,
+		SchemaVersion: DefaultSchemaVersion,
+	}
+}
+
+func ValidateAccepted(fixture Fixture, got Receipt) error {
+	if got.Status != StatusAccepted {
+		return fmt.Errorf("status = %q, want %q", got.Status, StatusAccepted)
+	}
+	if err := validateSharedFields(fixture, got); err != nil {
+		return err
+	}
+	want, err := receipt.Build(BuildSpec(fixture), []byte(fixture.Payload))
+	if err != nil {
+		return fmt.Errorf("canonical receipt.Build failed: %w", err)
+	}
+	return validateCanonicalReceipt(got, want)
+}
+
+func ValidateRejected(fixture Fixture, got Receipt, err error) error {
+	if err == nil {
+		return errors.New("malformed input must return an explicit error")
+	}
+	var rejectErr RejectError
+	if !errors.As(err, &rejectErr) || rejectErr.Reason == "" {
+		return fmt.Errorf("error must be RejectError with explicit reason: %v", err)
+	}
+	if got.Status != StatusRejected {
+		return fmt.Errorf("status = %q, want %q", got.Status, StatusRejected)
+	}
+	if err := validateSharedFields(fixture, got); err != nil {
+		return err
+	}
+	if got.RejectedReason == "" {
+		return errors.New("rejected receipt must include rejected_reason")
+	}
+	if got.RejectedReason != rejectErr.Reason {
+		return fmt.Errorf("rejected_reason = %q, want %q", got.RejectedReason, rejectErr.Reason)
+	}
+	want, err := receipt.Reject(BuildSpec(fixture), []byte(fixture.Payload), rejectErr.Reason)
+	if err != nil {
+		return fmt.Errorf("canonical receipt.Reject failed: %w", err)
+	}
+	return validateCanonicalReceipt(got, want)
+}
+
+func validateSharedFields(fixture Fixture, receipt Receipt) error {
+	if fixture.CorrelationID == "" {
+		return errors.New("fixture correlation_id is required")
+	}
+	if receipt.CorrelationID != fixture.CorrelationID {
+		return fmt.Errorf("correlation_id = %q, want %q", receipt.CorrelationID, fixture.CorrelationID)
+	}
+	if receipt.Source != fixture.Source {
+		return fmt.Errorf("source = %q, want %q", receipt.Source, fixture.Source)
+	}
+	if receipt.SourceURL != fixture.SourceURL {
+		return fmt.Errorf("source_url = %q, want %q", receipt.SourceURL, fixture.SourceURL)
+	}
+	if fixture.ObservedAt != "" && receipt.ObservedAt != fixture.ObservedAt {
+		return fmt.Errorf("observed_at = %q, want %q", receipt.ObservedAt, fixture.ObservedAt)
+	}
+	return nil
+}
+
+func validateCanonicalReceipt(got, want Receipt) error {
+	if got.ReceiptID != want.ReceiptID {
+		return fmt.Errorf("receipt_id = %q, want %q", got.ReceiptID, want.ReceiptID)
+	}
+	if got.ContentHash != want.ContentHash {
+		return fmt.Errorf("content_hash = %q, want %q", got.ContentHash, want.ContentHash)
+	}
+	if got.EventUID != want.EventUID {
+		return fmt.Errorf("event_uid = %q, want %q", got.EventUID, want.EventUID)
+	}
+	if got.SchemaVersion != want.SchemaVersion {
+		return fmt.Errorf("schema_version = %q, want %q", got.SchemaVersion, want.SchemaVersion)
+	}
+	if got.RejectedReason != want.RejectedReason {
+		return fmt.Errorf("rejected_reason = %q, want %q", got.RejectedReason, want.RejectedReason)
+	}
+	if string(got.Payload) != string(want.Payload) {
+		return fmt.Errorf("payload = %s, want %s", got.Payload, want.Payload)
+	}
+	return nil
+}

--- a/tools/go_sdk/adaptercontract/contract_test.go
+++ b/tools/go_sdk/adaptercontract/contract_test.go
@@ -1,0 +1,170 @@
+package adaptercontract
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/AmitabhainArunachala/dharma_swarm/tools/go_sdk/receipt"
+)
+
+type fixtureAdapter struct{}
+
+func (fixtureAdapter) Adapt(_ context.Context, fixture Fixture) (Receipt, error) {
+	if !json.Valid(bytes.TrimSpace(fixture.Payload)) {
+		reason := "malformed_json"
+		rejected, err := receipt.Reject(BuildSpec(fixture), []byte(fixture.Payload), reason)
+		if err != nil {
+			return Receipt{}, err
+		}
+		return rejected, RejectError{Reason: reason}
+	}
+	return receipt.Build(BuildSpec(fixture), []byte(fixture.Payload))
+}
+
+func fixturePath(name string) string {
+	return filepath.Join("..", "..", "..", "tests", "fixtures", "go_adapters", name)
+}
+
+func TestFixtureAdapterAcceptanceMatchesGolden(t *testing.T) {
+	fixture, err := LoadFixture(fixturePath("valid_input.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := fixtureAdapter{}.Adapt(context.Background(), fixture)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ValidateAccepted(fixture, receipt); err != nil {
+		t.Fatal(err)
+	}
+
+	wantRaw, err := os.ReadFile(fixturePath("expected_receipt.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var want Receipt
+	if err := json.Unmarshal(wantRaw, &want); err != nil {
+		t.Fatal(err)
+	}
+	if !receiptsEqual(receipt, want) {
+		got, _ := json.MarshalIndent(receipt, "", "  ")
+		expected, _ := json.MarshalIndent(want, "", "  ")
+		t.Fatalf("receipt drifted\n got: %s\nwant: %s", got, expected)
+	}
+}
+
+func receiptsEqual(a, b Receipt) bool {
+	if a.ReceiptID != b.ReceiptID ||
+		a.CorrelationID != b.CorrelationID ||
+		a.Source != b.Source ||
+		a.SourceURL != b.SourceURL ||
+		a.ObservedAt != b.ObservedAt ||
+		a.ContentHash != b.ContentHash ||
+		a.EventUID != b.EventUID ||
+		a.SchemaVersion != b.SchemaVersion ||
+		a.Status != b.Status ||
+		a.RejectedReason != b.RejectedReason {
+		return false
+	}
+	var aPayload, bPayload any
+	if err := json.Unmarshal(a.Payload, &aPayload); err != nil {
+		return false
+	}
+	if err := json.Unmarshal(b.Payload, &bPayload); err != nil {
+		return false
+	}
+	return reflect.DeepEqual(aPayload, bPayload)
+}
+
+func TestFixtureAdapterIsDeterministic(t *testing.T) {
+	fixture, err := LoadFixture(fixturePath("valid_input.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := fixtureAdapter{}.Adapt(context.Background(), fixture)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := fixtureAdapter{}.Adapt(context.Background(), fixture)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("adapter receipt must be deterministic:\n%+v\n%+v", first, second)
+	}
+}
+
+func TestFixtureAdapterRejectsMalformedInputWithReason(t *testing.T) {
+	fixture, err := loadMalformedFixture(fixturePath("malformed_input.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := fixtureAdapter{}.Adapt(context.Background(), fixture)
+	if err := ValidateRejected(fixture, receipt, err); err != nil {
+		t.Fatal(err)
+	}
+	var rejectErr RejectError
+	if !errors.As(err, &rejectErr) || rejectErr.Reason != "malformed_json" {
+		t.Fatalf("unexpected rejection error: %v", err)
+	}
+}
+
+func loadMalformedFixture(path string) (Fixture, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return Fixture{}, err
+	}
+	var file struct {
+		CorrelationID string `json:"correlation_id"`
+		Source        string `json:"source"`
+		SourceURL     string `json:"source_url"`
+		ObservedAt    string `json:"observed_at"`
+		PayloadText   string `json:"payload_text"`
+	}
+	if err := json.Unmarshal(raw, &file); err != nil {
+		return Fixture{}, err
+	}
+	return Fixture{
+		CorrelationID: file.CorrelationID,
+		Source:        file.Source,
+		SourceURL:     file.SourceURL,
+		ObservedAt:    file.ObservedAt,
+		Payload:       json.RawMessage(file.PayloadText),
+	}, nil
+}
+
+func TestValidateAcceptedCatchesCorrelationDrift(t *testing.T) {
+	fixture, err := LoadFixture(fixturePath("valid_input.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := fixtureAdapter{}.Adapt(context.Background(), fixture)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt.CorrelationID = "corr_wrong"
+	if err := ValidateAccepted(fixture, receipt); err == nil {
+		t.Fatal("expected correlation_id drift to fail validation")
+	}
+}
+
+func TestValidateAcceptedCatchesUnstableIdentityFields(t *testing.T) {
+	fixture, err := LoadFixture(fixturePath("valid_input.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := fixtureAdapter{}.Adapt(context.Background(), fixture)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt.EventUID = "evt_unstable"
+	if err := ValidateAccepted(fixture, receipt); err == nil {
+		t.Fatal("expected event_uid drift to fail validation")
+	}
+}


### PR DESCRIPTION
Packet: `go-g03-adapter-contract-harness`

Dependency statement:
G3 depends on G2 and must not merge before Agent B/G2. At implementation time PR #176 and #177 were still open, so this branch is based on current `origin/main` and does not copy the PR #176 ingestor or introduce source-specific adapter code.

Organ touched:
Go sense-organ SDK/test membrane. This adds `tools/go_sdk/adaptercontract` as a stdlib-only contract harness, golden fixture inputs under `tests/fixtures/go_adapters`, a Python CI wrapper, `make go-ci`, and a CI job.

Declared-vs-actual gap closed:
The roadmap declares that future Go source adapters must emit consistent receipt semantics, but `origin/main` had no shared harness proving correlation preservation, stable `content_hash` / `event_uid`, explicit malformed-input rejection, or no-network CI behavior. This PR adds that harness without touching Python telos, ontology, evolution, or runtime control surfaces.

Proof that re-reads the map:
- `make go-ci`
- `python -m pytest -q tests/test_go_adapter_contracts.py`
- `python scripts/docops/check_docops_integrity.py --changed-from origin/main`
- `git diff --check`
- `pre-commit run --files <changed files>`

New drift introduced:
Adds the first `tools/go_sdk` package on `origin/main`, ahead of G2's final receipt SDK. The package is limited to adapter contract validation and identity helpers; G2 should either adopt these helpers or supersede them deliberately before G3 merges. Local verification note: the exact requested `python3 -m pytest` command is blocked on this Mac because `python3` lacks pytest; the repo's available `python -m pytest` passes. Also, DocOps has a path-sensitive false positive when run from a worktree path containing the word `adapter`; it passes from the same worktree temporarily moved to a neutral path and should pass in GitHub's checkout path.

Allowed-file footprint:
- `tools/go_sdk/**`
- `tests/fixtures/go_adapters/**`
- `tests/test_go_adapter_contracts.py`
- `Makefile`
- `.github/workflows/tests.yml`
- `docs/docops/AUTO_INVENTORY.md`
- `docs/governance/SOVEREIGN_MANIFEST.md`

Go/Python boundary:
Go normalizes fixture payloads and proves receipt identity fields. Python remains the CI wrapper and map-reading layer. This PR does not write ontology/runtime DB state, dispatch agents, approve gates, or change Python decision policy.
