### PR TITLE
feat(knowledge-ops): seed semantic metabolism organ

### DIFF
--- a/dharma_swarm/knowledge_ops/__init__.py
+++ b/dharma_swarm/knowledge_ops/__init__.py
@@ -1,0 +1,31 @@
+"""KnowledgeOps: read-only semantic lifecycle projections for Dharma Swarm.
+
+This package intentionally starts as a projection layer.  It reads existing
+docs, wiki atoms, runtime maps, and code surfaces, then emits nodes, edges, and
+context artifacts.  It does not mutate canonical docs, ontology rows, runtime
+state, cron jobs, or archive paths.
+"""
+
+from dharma_swarm.knowledge_ops.extractor import KnowledgeOpsExtractor
+from dharma_swarm.knowledge_ops.schema import (
+    EdgeKind,
+    KnowledgeEdge,
+    KnowledgeNode,
+    KnowledgeOpsSnapshot,
+    KnowledgeOpsMode,
+    LifecycleStatus,
+    NodeKind,
+    SourceRef,
+)
+
+__all__ = [
+    "EdgeKind",
+    "KnowledgeEdge",
+    "KnowledgeNode",
+    "KnowledgeOpsExtractor",
+    "KnowledgeOpsMode",
+    "KnowledgeOpsSnapshot",
+    "LifecycleStatus",
+    "NodeKind",
+    "SourceRef",
+]

--- a/dharma_swarm/knowledge_ops/cli.py
+++ b/dharma_swarm/knowledge_ops/cli.py
@@ -1,0 +1,77 @@
+"""CLI for read-only KnowledgeOps projections."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from dharma_swarm.knowledge_ops.extractor import ExtractorConfig, KnowledgeOpsExtractor
+from dharma_swarm.knowledge_ops.projections import (
+    default_mode_schedule,
+    render_agent_context_bundle,
+    render_concept_card,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path("."))
+    parser.add_argument("--wiki-root", type=Path)
+    parser.add_argument("--output-dir", type=Path, default=Path("reports/knowledge_ops"))
+    parser.add_argument("--wiki-limit", type=int, default=250)
+    parser.add_argument("--bundle-objective", default="Inventory KnowledgeOps substrate.")
+    parser.add_argument("--dry-run", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    config = ExtractorConfig(
+        repo_root=args.repo_root,
+        wiki_root=args.wiki_root,
+        wiki_limit=args.wiki_limit,
+    )
+    snapshot = KnowledgeOpsExtractor(config).extract()
+    summary = {
+        "node_count": len(snapshot.nodes),
+        "edge_count": len(snapshot.edges),
+        "node_count_by_kind": snapshot.node_count_by_kind(),
+        "edge_count_by_kind": snapshot.edge_count_by_kind(),
+    }
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    if args.dry_run:
+        return 0
+
+    output_dir = args.output_dir
+    if not output_dir.is_absolute():
+        output_dir = args.repo_root / output_dir
+    snapshot.write_jsonl(output_dir)
+    (output_dir / "mode_schedule.json").write_text(
+        json.dumps(default_mode_schedule(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    if snapshot.nodes:
+        first_concept = next(
+            (node for node in snapshot.nodes if node.kind.value == "concept"),
+            snapshot.nodes[0],
+        )
+        (output_dir / "sample_concept_card.md").write_text(
+            render_concept_card(first_concept, related_edges=snapshot.edges),
+            encoding="utf-8",
+        )
+    (output_dir / "sample_agent_context_bundle.md").write_text(
+        render_agent_context_bundle(
+            bundle_id="knowledgeops.v0.sample",
+            role="knowledge-ops-reviewer",
+            objective=args.bundle_objective,
+            nodes=snapshot.nodes,
+            edges=snapshot.edges,
+        ),
+        encoding="utf-8",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dharma_swarm/knowledge_ops/extractor.py
+++ b/dharma_swarm/knowledge_ops/extractor.py
@@ -1,0 +1,431 @@
+"""Read-only KnowledgeOps graph extractor.
+
+The extractor inventories existing authority docs, state docs, code surfaces,
+runtime projections, and wiki atoms.  It emits a projection graph that can be
+reviewed by humans or downstream agents.  It does not promote, archive, move,
+or mutate any source surface.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+from dharma_swarm.knowledge_ops.schema import (
+    EdgeKind,
+    KnowledgeEdge,
+    KnowledgeNode,
+    KnowledgeOpsSnapshot,
+    LifecycleStatus,
+    NodeKind,
+    SourceRef,
+)
+
+
+AUTHORITY_TERMS = ("canonical", "source of truth", "authoritative", "ground truth")
+CODE_REF_RE = re.compile(
+    r"`([A-Za-z0-9_./-]+\.(?:py|md|yaml|yml|json|toml|sh|ts|tsx|js|jsx)(?::\d+)?)`"
+)
+BROKEN_ID_RE = re.compile(r"\b(BR-\d{3})\b")
+HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$")
+SLOT_RE = re.compile(r"^###\s+Slot\s+(\d+)\s+[-—]\s+(.+?)\s*$")
+WIKI_LINK_RE = re.compile(r"\[\[([^\]|#]+)(?:#[^\]|]+)?(?:\|[^\]]+)?\]\]")
+
+
+DEFAULT_DOC_PATHS = (
+    "CLAUDE.md",
+    "docs/MEGAFILE_INDEX.md",
+    "docs/governance/BUILD_SESSION_ENTRYPOINT.md",
+    "docs/governance/CANONICAL_DOC_STACK.md",
+    "docs/governance/SOVEREIGN_MANIFEST.md",
+    "docs/governance/REPO_GOVERNANCE_AUDIT.md",
+    "docs/architecture/NAVIGATION.md",
+    "docs/architecture/WIRING_AND_LOOPS.md",
+    "docs/architecture/MEMORY_SYSTEM_FUSION_MAP_2026-05-01.md",
+    "docs/state/BROKEN_REGISTER.md",
+    "docs/state/LIVE_OPS_DASHBOARD.md",
+    "reports/system_map/latest.json",
+)
+
+DEFAULT_CODE_SURFACES = (
+    "dharma_swarm/context_compiler.py",
+    "dharma_swarm/engine/event_memory.py",
+    "dharma_swarm/graph_store.py",
+    "dharma_swarm/knowledge_units.py",
+    "dharma_swarm/memory_lattice.py",
+    "dharma_swarm/ontology.py",
+    "dharma_swarm/semantic_gravity.py",
+    "dharma_swarm/semantic_memory_bridge.py",
+    "dharma_swarm/temporal_graph.py",
+    "dharma_swarm/operator_core/operating_facts.py",
+)
+
+
+@dataclass(frozen=True)
+class ExtractorConfig:
+    repo_root: Path
+    wiki_root: Path | None = None
+    doc_paths: tuple[str, ...] = DEFAULT_DOC_PATHS
+    code_surfaces: tuple[str, ...] = DEFAULT_CODE_SURFACES
+    wiki_limit: int = 250
+
+
+class KnowledgeOpsExtractor:
+    """Build a KnowledgeOps projection graph from existing local surfaces."""
+
+    def __init__(self, config: ExtractorConfig | Path | str) -> None:
+        if isinstance(config, ExtractorConfig):
+            self.config = config
+        else:
+            self.config = ExtractorConfig(repo_root=Path(config))
+        self.repo_root = self.config.repo_root.resolve()
+
+    def extract(self) -> KnowledgeOpsSnapshot:
+        nodes: dict[str, KnowledgeNode] = {}
+        edges: dict[str, KnowledgeEdge] = {}
+
+        def add_node(node: KnowledgeNode) -> KnowledgeNode:
+            nodes[node.node_id] = node
+            return node
+
+        def add_edge(edge: KnowledgeEdge) -> None:
+            edges[edge.edge_id] = edge
+
+        doc_nodes: dict[str, KnowledgeNode] = {}
+        for rel_path in self.config.doc_paths:
+            path = self.repo_root / rel_path
+            if not path.exists() or not path.is_file():
+                continue
+            doc_node = add_node(self._doc_node(path, rel_path))
+            doc_nodes[rel_path] = doc_node
+            for concept in self._concepts_from_doc(path, doc_node):
+                add_node(concept)
+                add_edge(
+                    KnowledgeEdge.build(
+                        EdgeKind.EXTRACTS_CONCEPT,
+                        doc_node.node_id,
+                        concept.node_id,
+                        confidence=0.65,
+                        source_refs=concept.source_refs,
+                    )
+                )
+            for broken_item in self._broken_items_from_doc(path, doc_node):
+                add_node(broken_item)
+                add_edge(
+                    KnowledgeEdge.build(
+                        EdgeKind.TRACKS_BROKENNESS_OF,
+                        doc_node.node_id,
+                        broken_item.node_id,
+                        confidence=0.8,
+                        source_refs=broken_item.source_refs,
+                    )
+                )
+            for target in self._code_refs_from_doc(path):
+                target_node = self._node_for_path(target, nodes)
+                if target_node:
+                    add_edge(
+                        KnowledgeEdge.build(
+                            EdgeKind.REFERENCES,
+                            doc_node.node_id,
+                            target_node.node_id,
+                            confidence=0.75,
+                            source_refs=doc_node.source_refs,
+                            metadata={"target": target},
+                        )
+                    )
+
+        for rel_path in self.config.code_surfaces:
+            path = self.repo_root / rel_path
+            if path.exists() and path.is_file():
+                add_node(self._code_surface_node(path, rel_path))
+
+        system_map = self.repo_root / "reports/system_map/latest.json"
+        if system_map.exists():
+            for fact in self._runtime_facts_from_system_map(system_map):
+                add_node(fact)
+                source = doc_nodes.get("reports/system_map/latest.json")
+                if source:
+                    add_edge(
+                        KnowledgeEdge.build(
+                            EdgeKind.OBSERVES,
+                            source.node_id,
+                            fact.node_id,
+                            confidence=0.7,
+                            source_refs=fact.source_refs,
+                        )
+                    )
+
+        if self.config.wiki_root and self.config.wiki_root.exists():
+            for wiki_node in self._wiki_concepts(self.config.wiki_root):
+                add_node(wiki_node)
+                for doc_node in doc_nodes.values():
+                    if self._title_mentions_doc(wiki_node.title, doc_node.title):
+                        add_edge(
+                            KnowledgeEdge.build(
+                                EdgeKind.CONTEXTUALIZES,
+                                wiki_node.node_id,
+                                doc_node.node_id,
+                                confidence=0.35,
+                                source_refs=wiki_node.source_refs,
+                            )
+                        )
+
+        return KnowledgeOpsSnapshot(
+            nodes=tuple(sorted(nodes.values(), key=lambda item: item.node_id)),
+            edges=tuple(sorted(edges.values(), key=lambda item: item.edge_id)),
+        )
+
+    def _doc_node(self, path: Path, rel_path: str) -> KnowledgeNode:
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        title = _first_heading(text) or Path(rel_path).name
+        status = _status_for_doc(rel_path, text)
+        authority_tier = _authority_tier(rel_path)
+        return KnowledgeNode.build(
+            NodeKind.DOC,
+            title,
+            id_parts=[rel_path],
+            status=status,
+            confidence=0.8 if status == LifecycleStatus.CANONICAL else 0.6,
+            authority_tier=authority_tier,
+            owner="repo-docops" if rel_path.startswith("docs/") else "",
+            source_refs=(SourceRef.for_path(path, self.repo_root, role="source"),),
+            metadata={
+                "path": rel_path,
+                "authority_terms": [
+                    term for term in AUTHORITY_TERMS if term in text.lower()
+                ],
+                "line_count": len(text.splitlines()),
+            },
+        )
+
+    def _code_surface_node(self, path: Path, rel_path: str) -> KnowledgeNode:
+        return KnowledgeNode.build(
+            NodeKind.CODE_SURFACE,
+            rel_path,
+            id_parts=[rel_path],
+            status=LifecycleStatus.TRUSTED,
+            confidence=0.75,
+            owner="runtime",
+            source_refs=(SourceRef.for_path(path, self.repo_root, role="code"),),
+            metadata={"path": rel_path, "suffix": path.suffix},
+        )
+
+    def _concepts_from_doc(
+        self, path: Path, doc_node: KnowledgeNode
+    ) -> Iterable[KnowledgeNode]:
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        rel_path = doc_node.metadata["path"]
+        for index, line in enumerate(text.splitlines(), start=1):
+            slot = SLOT_RE.match(line)
+            if slot:
+                title = f"MEGAFILE Slot {slot.group(1)}: {slot.group(2).strip()}"
+                yield KnowledgeNode.build(
+                    NodeKind.CONCEPT,
+                    title,
+                    id_parts=[rel_path, title],
+                    status=LifecycleStatus.TRUSTED,
+                    confidence=0.8,
+                    owner="megafile-index",
+                    source_refs=(
+                        SourceRef.for_path(
+                            path, self.repo_root, role="slot", lines=str(index)
+                        ),
+                    ),
+                    metadata={"slot": int(slot.group(1)), "source_doc": rel_path},
+                )
+                continue
+            heading = HEADING_RE.match(line)
+            if heading and len(heading.group(1)) <= 3:
+                title = heading.group(2).strip().strip("#")
+                if title and not title.lower().startswith("table of contents"):
+                    yield KnowledgeNode.build(
+                        NodeKind.CONCEPT,
+                        title,
+                        id_parts=[rel_path, title],
+                        status=LifecycleStatus.STAGED,
+                        confidence=0.55,
+                        source_refs=(
+                            SourceRef.for_path(
+                                path,
+                                self.repo_root,
+                                role="heading",
+                                lines=str(index),
+                            ),
+                        ),
+                        metadata={"source_doc": rel_path, "heading_level": len(heading.group(1))},
+                    )
+
+    def _broken_items_from_doc(
+        self, path: Path, doc_node: KnowledgeNode
+    ) -> Iterable[KnowledgeNode]:
+        if not doc_node.metadata["path"].endswith("BROKEN_REGISTER.md"):
+            return
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        seen: set[str] = set()
+        for index, line in enumerate(text.splitlines(), start=1):
+            for match in BROKEN_ID_RE.finditer(line):
+                br_id = match.group(1)
+                if br_id in seen:
+                    continue
+                seen.add(br_id)
+                title = line.strip().lstrip("-# ").strip() or br_id
+                yield KnowledgeNode.build(
+                    NodeKind.BROKEN_REGISTER_ITEM,
+                    title,
+                    id_parts=[br_id],
+                    status=LifecycleStatus.TRUSTED,
+                    confidence=0.85,
+                    owner="broken-register",
+                    source_refs=(
+                        SourceRef.for_path(
+                            path, self.repo_root, role="register", lines=str(index)
+                        ),
+                    ),
+                    metadata={"br_id": br_id},
+                )
+
+    def _runtime_facts_from_system_map(self, path: Path) -> Iterable[KnowledgeNode]:
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            return
+        organs = payload.get("organs", [])
+        if isinstance(organs, dict):
+            organs = [{"name": key, **value} for key, value in organs.items()]
+        if not isinstance(organs, list):
+            return
+        for organ in organs:
+            if not isinstance(organ, dict):
+                continue
+            name = str(organ.get("name") or organ.get("organ") or "")
+            if not name:
+                continue
+            coherence = str(organ.get("coherence_state") or organ.get("status") or "unknown")
+            yield KnowledgeNode.build(
+                NodeKind.RUNTIME_FACT,
+                f"{name}: {coherence}",
+                id_parts=["system_map", name, coherence],
+                status=LifecycleStatus.STAGED,
+                confidence=0.7,
+                owner="system-map",
+                source_refs=(SourceRef.for_path(path, self.repo_root, role="projection"),),
+                metadata={"organ": name, "coherence_state": coherence},
+            )
+
+    def _wiki_concepts(self, wiki_root: Path) -> Iterable[KnowledgeNode]:
+        concept_root = wiki_root / "concepts"
+        if not concept_root.exists():
+            concept_root = wiki_root
+        for index, path in enumerate(sorted(concept_root.glob("*.md"))):
+            if index >= self.config.wiki_limit:
+                break
+            text = path.read_text(encoding="utf-8", errors="ignore")
+            title = _first_heading(text) or path.stem.replace("-", " ").title()
+            status = _status_from_frontmatter(text)
+            links = sorted(set(WIKI_LINK_RE.findall(text)))
+            yield KnowledgeNode.build(
+                NodeKind.CONCEPT,
+                title,
+                id_parts=["wiki", path.name],
+                status=status,
+                confidence=0.65,
+                owner="wiki",
+                source_refs=(SourceRef.for_path(path, None, role="wiki"),),
+                metadata={
+                    "path": path.as_posix(),
+                    "wiki_links": links[:25],
+                    "line_count": len(text.splitlines()),
+                },
+            )
+
+    def _code_refs_from_doc(self, path: Path) -> Iterable[str]:
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        for match in CODE_REF_RE.finditer(text):
+            target = match.group(1).split(":", 1)[0]
+            if (self.repo_root / target).exists():
+                yield target
+
+    def _node_for_path(
+        self, rel_path: str, nodes: dict[str, KnowledgeNode]
+    ) -> KnowledgeNode | None:
+        expected_id = KnowledgeNode.build(
+            NodeKind.CODE_SURFACE,
+            rel_path,
+            id_parts=[rel_path],
+        ).node_id
+        if expected_id in nodes:
+            return nodes[expected_id]
+        path = self.repo_root / rel_path
+        if path.exists() and path.is_file():
+            node = self._code_surface_node(path, rel_path)
+            nodes[node.node_id] = node
+            return node
+        return None
+
+    @staticmethod
+    def _title_mentions_doc(title: str, doc_title: str) -> bool:
+        title_words = set(_words(title))
+        doc_words = set(_words(doc_title))
+        return bool(title_words and doc_words and len(title_words & doc_words) >= 2)
+
+
+def _first_heading(text: str) -> str | None:
+    for line in text.splitlines():
+        match = HEADING_RE.match(line)
+        if match:
+            return match.group(2).strip()
+    return None
+
+
+def _status_for_doc(rel_path: str, text: str) -> LifecycleStatus:
+    lowered = f"{rel_path}\n{text[:2000]}".lower()
+    if "/archive/" in rel_path or rel_path.startswith("docs/archive/"):
+        return LifecycleStatus.ARCHIVED
+    if "contested" in lowered:
+        return LifecycleStatus.CONTESTED
+    if "stale" in lowered:
+        return LifecycleStatus.STALE
+    if "canonical" in lowered:
+        return LifecycleStatus.CANONICAL
+    if "seeded" in lowered:
+        return LifecycleStatus.TRUSTED
+    return LifecycleStatus.STAGED
+
+
+def _status_from_frontmatter(text: str) -> LifecycleStatus:
+    match = re.search(r"(?m)^status:\s*([A-Za-z_-]+)\s*$", text[:2000])
+    if not match:
+        return LifecycleStatus.STAGED
+    raw = match.group(1).lower().replace("-", "_")
+    aliases = {
+        "draft": LifecycleStatus.STAGED,
+        "seed": LifecycleStatus.STAGED,
+        "trusted": LifecycleStatus.TRUSTED,
+        "canonical": LifecycleStatus.CANONICAL,
+        "stale": LifecycleStatus.STALE,
+        "contested": LifecycleStatus.CONTESTED,
+        "superseded": LifecycleStatus.SUPERSEDED,
+        "archived": LifecycleStatus.ARCHIVED,
+    }
+    return aliases.get(raw, LifecycleStatus.STAGED)
+
+
+def _authority_tier(rel_path: str) -> str:
+    if rel_path == "CLAUDE.md":
+        return "tier-1"
+    if rel_path.startswith("docs/governance/"):
+        return "tier-1"
+    if rel_path.startswith("docs/architecture/"):
+        return "tier-2"
+    if rel_path.startswith("docs/state/"):
+        return "state"
+    if rel_path.startswith("reports/"):
+        return "projection"
+    return ""
+
+
+def _words(text: str) -> list[str]:
+    return [word for word in re.findall(r"[a-z0-9]{4,}", text.lower())]

--- a/dharma_swarm/knowledge_ops/projections.py
+++ b/dharma_swarm/knowledge_ops/projections.py
@@ -1,0 +1,214 @@
+"""Human and agent-facing projections from KnowledgeOps records."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from dharma_swarm.knowledge_ops.schema import (
+    EdgeKind,
+    KnowledgeEdge,
+    KnowledgeNode,
+    KnowledgeOpsMode,
+    NodeKind,
+)
+
+
+def render_concept_card(
+    node: KnowledgeNode,
+    *,
+    related_edges: tuple[KnowledgeEdge, ...] = (),
+) -> str:
+    """Render a compact concept card with provenance and boundaries."""
+    refs = [
+        f"- `{ref.path}`"
+        + (f":{ref.lines}" if ref.lines else "")
+        + f" ({ref.role})"
+        for ref in node.source_refs
+    ] or ["- No source refs attached."]
+    related = [
+        f"- {edge.kind.value}: `{edge.target_id}`"
+        for edge in related_edges
+        if edge.source_id == node.node_id
+    ][:7] or ["- No related edges in this projection."]
+    title = node.title.strip() or node.node_id
+    return "\n".join(
+        [
+            f"# {title}",
+            "",
+            f"Kind: `{node.kind.value}`",
+            f"Status: `{node.status.value}`",
+            f"Confidence: `{node.confidence:.2f}`",
+            "",
+            "Core claim:",
+            f"- {title}",
+            "",
+            "Operational meaning:",
+            "- Use this card as a compact pointer, not as authority by itself.",
+            "- Verify source refs before promotion into canonical docs or runtime policy.",
+            "",
+            "Boundaries:",
+            "- Do not infer beyond the attached source refs.",
+            "- Do not treat staged or candidate cards as doctrine.",
+            "",
+            "Related:",
+            *related,
+            "",
+            "Provenance:",
+            *refs,
+            "",
+        ]
+    )
+
+
+def render_agent_context_bundle(
+    *,
+    bundle_id: str,
+    role: str,
+    objective: str,
+    nodes: tuple[KnowledgeNode, ...],
+    edges: tuple[KnowledgeEdge, ...],
+    token_budget: int = 12000,
+) -> str:
+    """Render a task-specific, disposable agent context bundle."""
+    now = datetime.now(UTC)
+    expires = now + timedelta(hours=12)
+    node_lines = [
+        f"- `{node.node_id}` [{node.kind.value}/{node.status.value}] {node.title}"
+        for node in nodes[:20]
+    ]
+    stale_lines = [
+        f"- `{node.node_id}` {node.title} stale_after={node.stale_after}"
+        for node in nodes
+        if node.stale_after
+    ][:10]
+    edge_counts: dict[str, int] = {}
+    for edge in edges:
+        edge_counts[edge.kind.value] = edge_counts.get(edge.kind.value, 0) + 1
+    edge_lines = [
+        f"- {kind}: {count}" for kind, count in sorted(edge_counts.items())
+    ] or ["- none"]
+    return "\n".join(
+        [
+            f"# Agent Context Bundle: {bundle_id}",
+            "",
+            f"Role: {role}",
+            f"Generated: {now.isoformat()}",
+            f"Expires: {expires.isoformat()}",
+            f"Token budget: {token_budget}",
+            "",
+            "Objective:",
+            objective,
+            "",
+            "Authority:",
+            "- This bundle is a projection. Source refs outrank summaries.",
+            "- Canonical docs and human/operator approvals outrank generated cards.",
+            "",
+            "Relevant nodes:",
+            *node_lines,
+            "",
+            "Edge summary:",
+            *edge_lines,
+            "",
+            "Stale or time-bound sources:",
+            *(stale_lines or ["- none in selected nodes"]),
+            "",
+            "Evidence to return:",
+            "- Source paths inspected.",
+            "- Any contradictions or stale claims found.",
+            "- Tests or commands run, if implementation follows.",
+            "",
+            "Anti-drift:",
+            "- Do not create new authority docs from this bundle.",
+            "- Do not promote dream/synthesis candidates without evidence and review.",
+            "",
+        ]
+    )
+
+
+def default_mode_schedule() -> list[dict[str, object]]:
+    """Return the advisory KnowledgeOps mode schedule.
+
+    The schedule is data only.  It deliberately does not register cron jobs.
+    """
+    return [
+        {
+            "mode": KnowledgeOpsMode.WAKE.value,
+            "cadence": "daily 04:30",
+            "inputs": ["live_ops_dashboard", "broken_register", "active_tasks"],
+            "outputs": ["morning_context_bundle"],
+            "may_mutate_authority": False,
+        },
+        {
+            "mode": KnowledgeOpsMode.SENSE.value,
+            "cadence": "hourly",
+            "inputs": ["repo_changes", "wiki_changes", "runtime_events", "external_feeds"],
+            "outputs": ["episode_candidates"],
+            "may_mutate_authority": False,
+        },
+        {
+            "mode": KnowledgeOpsMode.LEARNING.value,
+            "cadence": "after work packet",
+            "inputs": ["tests", "reviews", "outcomes", "agentops"],
+            "outputs": ["lesson_candidates", "procedure_candidates"],
+            "may_mutate_authority": False,
+        },
+        {
+            "mode": KnowledgeOpsMode.REFLECTION.value,
+            "cadence": "daily",
+            "inputs": ["episodes", "claims", "evidence", "outcomes"],
+            "outputs": ["claim_candidates", "contradiction_candidates"],
+            "may_mutate_authority": False,
+        },
+        {
+            "mode": KnowledgeOpsMode.SLEEP.value,
+            "cadence": "nightly",
+            "inputs": ["nodes", "edges", "retrieval_logs", "wiki_atoms"],
+            "outputs": ["dedupe_report", "stale_report", "graph_refresh"],
+            "may_mutate_authority": False,
+        },
+        {
+            "mode": KnowledgeOpsMode.DREAM.value,
+            "cadence": "weekly",
+            "inputs": ["distant_concepts", "open_questions", "low_connected_subgraphs"],
+            "outputs": ["synthesis_candidates"],
+            "may_mutate_authority": False,
+            "promotion_rule": "candidate_only_until_evidence_review",
+        },
+        {
+            "mode": KnowledgeOpsMode.IMMUNE.value,
+            "cadence": "daily",
+            "inputs": ["authority_docs", "docops_findings", "broken_links"],
+            "outputs": ["duplicate_authority_findings", "unsupported_claim_findings"],
+            "may_mutate_authority": False,
+        },
+        {
+            "mode": KnowledgeOpsMode.PROMOTION.value,
+            "cadence": "manual or reviewed PR",
+            "inputs": ["trusted_candidates", "evidence", "owner_approval"],
+            "outputs": ["promotion_pr"],
+            "may_mutate_authority": True,
+            "requires_human_review": True,
+        },
+        {
+            "mode": KnowledgeOpsMode.FORGETTING.value,
+            "cadence": "weekly reviewed PR",
+            "inputs": ["stale_docs", "superseded_cards", "archive_candidates"],
+            "outputs": ["archive_pr_with_tombstones"],
+            "may_mutate_authority": True,
+            "requires_human_review": True,
+        },
+    ]
+
+
+def candidate_edges(edges: tuple[KnowledgeEdge, ...]) -> tuple[KnowledgeEdge, ...]:
+    return tuple(
+        edge
+        for edge in edges
+        if edge.kind
+        in {
+            EdgeKind.CONTRADICTS,
+            EdgeKind.SYNTHESIZES,
+            EdgeKind.SUPERSEDES,
+            EdgeKind.PROMOTES,
+        }
+    )

--- a/dharma_swarm/knowledge_ops/schema.py
+++ b/dharma_swarm/knowledge_ops/schema.py
@@ -1,0 +1,241 @@
+"""Schema primitives for the KnowledgeOps semantic metabolism.
+
+The schema separates containers (docs), claims, concepts, evidence, decisions,
+code surfaces, runtime facts, broken-register items, and pre-canonical idea
+candidates.  These records are designed for JSONL projection and later graph
+storage, not as a new source of authority.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, field
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+
+class NodeKind(StrEnum):
+    DOC = "doc"
+    CONCEPT = "concept"
+    CLAIM = "claim"
+    EVIDENCE = "evidence"
+    DECISION = "decision"
+    CODE_SURFACE = "code_surface"
+    RUNTIME_FACT = "runtime_fact"
+    BROKEN_REGISTER_ITEM = "broken_register_item"
+    IDEA_CANDIDATE = "idea_candidate"
+    SYNTHESIS_CANDIDATE = "synthesis_candidate"
+
+
+class EdgeKind(StrEnum):
+    REFERENCES = "references"
+    EXTRACTS_CONCEPT = "extracts_concept"
+    ASSERTS = "asserts"
+    SUPPORTS = "supports"
+    REFUTES = "refutes"
+    CONTEXTUALIZES = "contextualizes"
+    DECIDES = "decides"
+    IMPLEMENTS = "implements"
+    OBSERVES = "observes"
+    TRACKS_BROKENNESS_OF = "tracks_brokenness_of"
+    SUPERSEDES = "supersedes"
+    CONTRADICTS = "contradicts"
+    DEPENDS_ON = "depends_on"
+    DERIVED_FROM = "derived_from"
+    SYNTHESIZES = "synthesizes"
+    PROMOTES = "promotes"
+    DEMOTES = "demotes"
+    ARCHIVES = "archives"
+    GOVERNS = "governs"
+
+
+class LifecycleStatus(StrEnum):
+    STAGED = "staged"
+    TRUSTED = "trusted"
+    CANONICAL = "canonical"
+    STALE = "stale"
+    CONTESTED = "contested"
+    SUPERSEDED = "superseded"
+    ARCHIVED = "archived"
+
+
+class KnowledgeOpsMode(StrEnum):
+    WAKE = "wake"
+    SENSE = "sense"
+    WORK = "work"
+    LEARNING = "learning"
+    REFLECTION = "reflection"
+    SLEEP = "sleep"
+    DREAM = "dream"
+    IMMUNE = "immune"
+    PROMOTION = "promotion"
+    FORGETTING = "forgetting"
+
+
+def stable_hash(parts: list[str]) -> str:
+    payload = "\n".join(part.strip() for part in parts if part is not None)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def stable_id(kind: str, *parts: str) -> str:
+    return f"{kind}:{stable_hash([kind, *parts])[:24]}"
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+@dataclass(frozen=True)
+class SourceRef:
+    path: str
+    role: str = "evidence"
+    lines: str | None = None
+    checksum: str | None = None
+
+    @classmethod
+    def for_path(
+        cls,
+        path: Path,
+        repo_root: Path | None = None,
+        *,
+        role: str = "evidence",
+        lines: str | None = None,
+    ) -> SourceRef:
+        resolved = path.resolve()
+        rendered = (
+            resolved.relative_to(repo_root.resolve()).as_posix()
+            if repo_root is not None
+            and resolved.is_relative_to(repo_root.resolve())
+            else resolved.as_posix()
+        )
+        checksum = file_sha256(resolved) if resolved.is_file() else None
+        return cls(path=rendered, role=role, lines=lines, checksum=checksum)
+
+
+@dataclass(frozen=True)
+class KnowledgeNode:
+    node_id: str
+    kind: NodeKind
+    title: str
+    status: LifecycleStatus = LifecycleStatus.STAGED
+    confidence: float = 0.5
+    owner: str = ""
+    authority_tier: str = ""
+    stale_after: str | None = None
+    source_refs: tuple[SourceRef, ...] = ()
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def build(
+        cls,
+        kind: NodeKind,
+        title: str,
+        *,
+        id_parts: list[str],
+        status: LifecycleStatus = LifecycleStatus.STAGED,
+        confidence: float = 0.5,
+        owner: str = "",
+        authority_tier: str = "",
+        stale_after: str | None = None,
+        source_refs: tuple[SourceRef, ...] = (),
+        metadata: dict[str, Any] | None = None,
+    ) -> KnowledgeNode:
+        return cls(
+            node_id=stable_id(kind.value, *id_parts),
+            kind=kind,
+            title=title,
+            status=status,
+            confidence=confidence,
+            owner=owner,
+            authority_tier=authority_tier,
+            stale_after=stale_after,
+            source_refs=source_refs,
+            metadata=metadata or {},
+        )
+
+    def to_json(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["kind"] = self.kind.value
+        payload["status"] = self.status.value
+        return payload
+
+
+@dataclass(frozen=True)
+class KnowledgeEdge:
+    edge_id: str
+    kind: EdgeKind
+    source_id: str
+    target_id: str
+    confidence: float = 0.5
+    source_refs: tuple[SourceRef, ...] = ()
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def build(
+        cls,
+        kind: EdgeKind,
+        source_id: str,
+        target_id: str,
+        *,
+        confidence: float = 0.5,
+        source_refs: tuple[SourceRef, ...] = (),
+        metadata: dict[str, Any] | None = None,
+    ) -> KnowledgeEdge:
+        return cls(
+            edge_id=stable_id("edge", kind.value, source_id, target_id),
+            kind=kind,
+            source_id=source_id,
+            target_id=target_id,
+            confidence=confidence,
+            source_refs=source_refs,
+            metadata=metadata or {},
+        )
+
+    def to_json(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["kind"] = self.kind.value
+        return payload
+
+
+@dataclass(frozen=True)
+class KnowledgeOpsSnapshot:
+    nodes: tuple[KnowledgeNode, ...]
+    edges: tuple[KnowledgeEdge, ...]
+
+    def node_count_by_kind(self) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        for node in self.nodes:
+            counts[node.kind.value] = counts.get(node.kind.value, 0) + 1
+        return counts
+
+    def edge_count_by_kind(self) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        for edge in self.edges:
+            counts[edge.kind.value] = counts.get(edge.kind.value, 0) + 1
+        return counts
+
+    def write_jsonl(self, output_dir: Path) -> None:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        _write_jsonl(output_dir / "nodes.jsonl", [node.to_json() for node in self.nodes])
+        _write_jsonl(output_dir / "edges.jsonl", [edge.to_json() for edge in self.edges])
+        summary = {
+            "node_count": len(self.nodes),
+            "edge_count": len(self.edges),
+            "node_count_by_kind": self.node_count_by_kind(),
+            "edge_count_by_kind": self.edge_count_by_kind(),
+        }
+        (output_dir / "summary.json").write_text(
+            json.dumps(summary, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+
+def _write_jsonl(path: Path, rows: list[dict[str, Any]]) -> None:
+    text = "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows)
+    path.write_text(text, encoding="utf-8")

--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -6,13 +6,13 @@ Do not hand-edit the generated block.
 <!-- DOCOPS:START metric=repo_inventory -->
 | Metric | Value |
 |---|---:|
-| Dharma Python modules | 553 |
+| Dharma Python modules | 558 |
 | Top-level Dharma Python modules | 385 |
-| Dharma Python LOC | 249,079 |
-| Test files | 563 |
-| Test function occurrences | 10,019 |
-| Markdown files | 685 |
-| Markdown total lines | 175,037 |
+| Dharma Python LOC | 250,073 |
+| Test files | 564 |
+| Test function occurrences | 10,026 |
+| Markdown files | 686 |
+| Markdown total lines | 175,084 |
 | Bridge files | 19 |
 | Adapter files | 14 |
 | Orchestrator files | 4 |

--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -6,13 +6,13 @@ Do not hand-edit the generated block.
 <!-- DOCOPS:START metric=repo_inventory -->
 | Metric | Value |
 |---|---:|
-| Dharma Python modules | 554 |
+| Dharma Python modules | 559 |
 | Top-level Dharma Python modules | 385 |
-| Dharma Python LOC | 249,744 |
-| Test files | 564 |
-| Test function occurrences | 10,040 |
-| Markdown files | 685 |
-| Markdown total lines | 175,016 |
+| Dharma Python LOC | 250,738 |
+| Test files | 565 |
+| Test function occurrences | 10,047 |
+| Markdown files | 686 |
+| Markdown total lines | 175,063 |
 | Bridge files | 19 |
 | Adapter files | 14 |
 | Orchestrator files | 4 |

--- a/docs/governance/SOVEREIGN_MANIFEST.md
+++ b/docs/governance/SOVEREIGN_MANIFEST.md
@@ -2,11 +2,11 @@
 
 **Purpose**: This document is the absolute ground truth for the dharma_swarm repository. All AI agents, regardless of model or tab, MUST ingest, comprehend, and adhere to this context before outputting a single line of code.
 
-**Generated**: 2026-04-04 | Count refresh: 2026-05-07 filesystem verification
+**Generated**: 2026-04-04 | Count refresh: 2026-05-10 filesystem verification
 **Prior audit**: 2026-04-04 | 5-model convergent audit (Claude, DeepSeek, GPT-OSS, Codex, RUFLO)
 **Authority**: This file + `CLAUDE.md` are the two canonical governance surfaces. When they conflict, `CLAUDE.md` wins on behavioral rules; this file wins on architectural truth.
 
-**Verification method**: Count-sensitive claims below were refreshed against the filesystem on 2026-05-07. Architecture prose still reflects the 2026-04-04 audit unless specifically marked otherwise. Recheck counts before citing them in future work.
+**Verification method**: Count-sensitive claims below were refreshed against the filesystem on 2026-05-10. Architecture prose still reflects the 2026-04-04 audit unless specifically marked otherwise. Recheck counts before citing them in future work.
 
 **Substrate-nativeness status**: The current runtime is ~10–15% ontology-native; ~85–90% of runtime work bypasses substrate. The current build track is the ontology-native Operator Brief seam ([`docs/plans/ONTOLOGY_NATIVE_OPERATOR_BRIEF_MASTER_SPEC.md`](../plans/ONTOLOGY_NATIVE_OPERATOR_BRIEF_MASTER_SPEC.md)). Do not open additional tracks until that seam ships. See [`reports/audit/end_to_end/000_MASTER_COHERENCE_SYNTHESIS.md`](../../reports/audit/end_to_end/000_MASTER_COHERENCE_SYNTHESIS.md) for the audit that established this estimate.
 
@@ -17,7 +17,7 @@
 These are immutable engineering laws for this repository. Violation = architectural regression.
 
 ### A1: NO FLAT-PACKAGE GROWTH
-The `dharma_swarm/` package currently has **385 files at its top level (69.5% of 554 total Python modules)** (V). No new .py file may be added to the top level. New modules must go into an appropriate subdirectory. Existing top-level files will be organized over time.
+The `dharma_swarm/` package currently has **385 files at its top level (68.9% of 559 total Python modules)** (V). No new .py file may be added to the top level. New modules must go into an appropriate subdirectory. Existing top-level files will be organized over time.
 
 ### A2: NO DUPLICATE IMPLEMENTATIONS
 Before creating a new file for routing, bridging, adapting, or orchestrating, check if one already exists. The repo currently has **19 bridge files** (V), **3 model_routing copies** (2 are identical, 1 is different) (V), **4 orchestrators** (V), **14 adapter files across 7 locations** (V), and **13 router files** (V). Do not add more without deprecating an existing one.
@@ -52,25 +52,25 @@ The repo has **9 verified circular dependency chains** (V). The worst:
 All 9 cycles were independently confirmed with exact import lines. Most are mitigated by lazy imports but remain architectural debt. **New code must not create circular imports.**
 
 ### A8: FRONTMATTER DISCIPLINE
-Do not inject machine-readable YAML frontmatter into governance or architecture docs unless explicitly requested. Current state: **214 of 685 Markdown files start with YAML frontmatter; 15 of 21 docs/architecture Markdown files do so** (V). Long frontmatter remains an authority/noise risk even when the prose is useful.
+Do not inject machine-readable YAML frontmatter into governance or architecture docs unless explicitly requested. Current state: **214 of 686 Markdown files start with YAML frontmatter; 15 of 21 docs/architecture Markdown files do so** (V). Long frontmatter remains an authority/noise risk even when the prose is useful.
 
 ---
 
-## VERIFIED NUMBERS (2026-05-07 COUNT REFRESH)
+## VERIFIED NUMBERS (2026-05-10 COUNT REFRESH)
 
 These are the ground-truth metrics. All other documents citing different numbers are stale.
 
 | Metric | Value | Verification |
 |--------|-------|-------------|
-| Total Python modules | **554** | find dharma_swarm -name "*.py" -type f |
-| Top-level (flat) modules | **385 (69.5%)** | find dharma_swarm -maxdepth 1 -name "*.py" -type f |
-| Total Python LOC | **249,744** | wc -l across dharma_swarm Python modules |
-| Test files | **564** | find tests -name "*.py" -type f |
-| Test functions | **10,040 `def test_` occurrences under tests/** | rg "def test_" tests |
+| Total Python modules | **559** | find dharma_swarm -name "*.py" -type f |
+| Top-level (flat) modules | **385 (68.9%)** | find dharma_swarm -maxdepth 1 -name "*.py" -type f |
+| Total Python LOC | **250,738** | wc -l across dharma_swarm Python modules |
+| Test files | **565** | find tests -name "*.py" -type f |
+| Test functions | **10,047 `def test_` occurrences under tests/** | rg "def test_" tests |
 | Tests collected (pytest) | **Needs write-permitted refresh** | not run during this DocOps count pass |
 | Collection errors | **Historical: 16 on 2026-04-04** | refresh before relying on this count |
-| Markdown files | **685** | find . -name "*.md" -type f |
-| Markdown total lines | **175,016** | wc -l across all .md |
+| Markdown files | **686** | find . -name "*.md" -type f |
+| Markdown total lines | **175,063** | wc -l across all .md |
 | Bridge files | **19** | find dharma_swarm -name "*bridge*.py" |
 | Adapter files | **14 across 7 locations** | find dharma_swarm -type f \| rg -i "adapter" |
 | Orchestrator files | **4** (6,034 LOC total) | find dharma_swarm -name "*orchestrat*" |

--- a/docs/governance/SOVEREIGN_MANIFEST.md
+++ b/docs/governance/SOVEREIGN_MANIFEST.md
@@ -2,11 +2,11 @@
 
 **Purpose**: This document is the absolute ground truth for the dharma_swarm repository. All AI agents, regardless of model or tab, MUST ingest, comprehend, and adhere to this context before outputting a single line of code.
 
-**Generated**: 2026-04-04 | Count refresh: 2026-05-07 filesystem verification
+**Generated**: 2026-04-04 | Count refresh: 2026-05-10 filesystem verification
 **Prior audit**: 2026-04-04 | 5-model convergent audit (Claude, DeepSeek, GPT-OSS, Codex, RUFLO)
 **Authority**: This file + `CLAUDE.md` are the two canonical governance surfaces. When they conflict, `CLAUDE.md` wins on behavioral rules; this file wins on architectural truth.
 
-**Verification method**: Count-sensitive claims below were refreshed against the filesystem on 2026-05-07. Architecture prose still reflects the 2026-04-04 audit unless specifically marked otherwise. Recheck counts before citing them in future work.
+**Verification method**: Count-sensitive claims below were refreshed against the filesystem on 2026-05-10. Architecture prose still reflects the 2026-04-04 audit unless specifically marked otherwise. Recheck counts before citing them in future work.
 
 **Substrate-nativeness status**: The current runtime is ~10–15% ontology-native; ~85–90% of runtime work bypasses substrate. The current build track is the ontology-native Operator Brief seam ([`docs/plans/ONTOLOGY_NATIVE_OPERATOR_BRIEF_MASTER_SPEC.md`](../plans/ONTOLOGY_NATIVE_OPERATOR_BRIEF_MASTER_SPEC.md)). Do not open additional tracks until that seam ships. See [`reports/audit/end_to_end/000_MASTER_COHERENCE_SYNTHESIS.md`](../../reports/audit/end_to_end/000_MASTER_COHERENCE_SYNTHESIS.md) for the audit that established this estimate.
 
@@ -17,7 +17,7 @@
 These are immutable engineering laws for this repository. Violation = architectural regression.
 
 ### A1: NO FLAT-PACKAGE GROWTH
-The `dharma_swarm/` package currently has **385 files at its top level (70.0% of 550 total Python modules)** (V). No new .py file may be added to the top level. New modules must go into an appropriate subdirectory. Existing top-level files will be organized over time.
+The `dharma_swarm/` package currently has **385 files at its top level (69.0% of 558 total Python modules)** (V). No new .py file may be added to the top level. New modules must go into an appropriate subdirectory. Existing top-level files will be organized over time.
 
 ### A2: NO DUPLICATE IMPLEMENTATIONS
 Before creating a new file for routing, bridging, adapting, or orchestrating, check if one already exists. The repo currently has **19 bridge files** (V), **3 model_routing copies** (2 are identical, 1 is different) (V), **4 orchestrators** (V), **14 adapter files across 7 locations** (V), and **13 router files** (V). Do not add more without deprecating an existing one.
@@ -52,25 +52,25 @@ The repo has **9 verified circular dependency chains** (V). The worst:
 All 9 cycles were independently confirmed with exact import lines. Most are mitigated by lazy imports but remain architectural debt. **New code must not create circular imports.**
 
 ### A8: FRONTMATTER DISCIPLINE
-Do not inject machine-readable YAML frontmatter into governance or architecture docs unless explicitly requested. Current state: **214 of 685 Markdown files start with YAML frontmatter; 15 of 21 docs/architecture Markdown files do so** (V). Long frontmatter remains an authority/noise risk even when the prose is useful.
+Do not inject machine-readable YAML frontmatter into governance or architecture docs unless explicitly requested. Current state: **214 of 686 Markdown files start with YAML frontmatter; 15 of 21 docs/architecture Markdown files do so** (V). Long frontmatter remains an authority/noise risk even when the prose is useful.
 
 ---
 
-## VERIFIED NUMBERS (2026-05-07 COUNT REFRESH)
+## VERIFIED NUMBERS (2026-05-10 COUNT REFRESH)
 
 These are the ground-truth metrics. All other documents citing different numbers are stale.
 
 | Metric | Value | Verification |
 |--------|-------|-------------|
-| Total Python modules | **553** | find dharma_swarm -name "*.py" -type f |
-| Top-level (flat) modules | **385 (70.0%)** | find dharma_swarm -maxdepth 1 -name "*.py" -type f |
-| Total Python LOC | **248,966** | wc -l across dharma_swarm Python modules |
-| Test files | **563** | find tests -name "*.py" -type f |
-| Test functions | **10,019 `def test_` occurrences under tests/** | rg "def test_" tests |
+| Total Python modules | **558** | find dharma_swarm -name "*.py" -type f |
+| Top-level (flat) modules | **385 (69.0%)** | find dharma_swarm -maxdepth 1 -name "*.py" -type f |
+| Total Python LOC | **250,073** | wc -l across dharma_swarm Python modules |
+| Test files | **564** | find tests -name "*.py" -type f |
+| Test functions | **10,026 `def test_` occurrences under tests/** | rg "def test_" tests |
 | Tests collected (pytest) | **Needs write-permitted refresh** | not run during this DocOps count pass |
 | Collection errors | **Historical: 16 on 2026-04-04** | refresh before relying on this count |
-| Markdown files | **685** | find . -name "*.md" -type f |
-| Markdown total lines | **175,037** | wc -l across all .md |
+| Markdown files | **686** | find . -name "*.md" -type f |
+| Markdown total lines | **175,084** | wc -l across all .md |
 | Bridge files | **19** | find dharma_swarm -name "*bridge*.py" |
 | Adapter files | **14 across 7 locations** | find dharma_swarm -type f \| rg -i "adapter" |
 | Orchestrator files | **4** (6,034 LOC total) | find dharma_swarm -name "*orchestrat*" |

--- a/docs/plans/2026-05-10-knowledge-ops-organ-seed.md
+++ b/docs/plans/2026-05-10-knowledge-ops-organ-seed.md
@@ -1,0 +1,47 @@
+# KnowledgeOps Organ Seed
+
+Status: seed plan, 2026-05-10.
+
+KnowledgeOps is the semantic metabolism organ for Dharma Swarm. It turns scattered documents, code surfaces, runtime facts, broken-register entries, wiki material, and outside signals into linked knowledge that agents can retrieve, compress, compare, and act on.
+
+## Role
+
+KnowledgeOps owns semantic flow and lifecycle. It does not own execution, routing, kernel identity, ontology storage, or runtime state. Those remain with their existing organs.
+
+Its loop is:
+
+```text
+ingest -> atomize -> link -> densify -> retrieve -> reflect -> promote/archive proposal
+```
+
+## Inputs
+
+- Governance and architecture documents
+- MEGAFILE slot surfaces
+- Broken-register entries
+- Runtime organ facts and system-map projections
+- Code surfaces and import-facing modules
+- Wiki and cabinet-adjacent knowledge
+- Future Go sense-organ receipts
+
+## Outputs
+
+- JSONL knowledge nodes and edges
+- Summary counts and drift signals
+- Dense concept cards
+- Agent context bundles
+- Mode schedules for wake, sense, work, learning, reflection, sleep, dream, immune, promotion, and forgetting
+
+## Boundaries
+
+- Read-only in v0
+- No database migrations
+- No cron installation
+- No ontology writes
+- No archive moves
+- No changes to execution organs
+- Human review required before promotion or forgetting actions
+
+## First Acceptance Gate
+
+The seed is acceptable when the CLI can project a knowledge graph from the current repo, the focused tests pass, and the branch contains only the organ seed, its test, this plan, and generated DocOps count refreshes required by the repo hooks.

--- a/tests/test_knowledge_ops.py
+++ b/tests/test_knowledge_ops.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from dharma_swarm.knowledge_ops.cli import main
+from dharma_swarm.knowledge_ops.extractor import ExtractorConfig, KnowledgeOpsExtractor
+from dharma_swarm.knowledge_ops.projections import (
+    default_mode_schedule,
+    render_agent_context_bundle,
+    render_concept_card,
+)
+from dharma_swarm.knowledge_ops.schema import (
+    EdgeKind,
+    KnowledgeEdge,
+    KnowledgeNode,
+    KnowledgeOpsMode,
+    LifecycleStatus,
+    NodeKind,
+)
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _fixture_repo(tmp_path: Path) -> tuple[Path, Path]:
+    repo = tmp_path / "repo"
+    wiki = tmp_path / "wiki"
+    _write(repo / "CLAUDE.md", "# CLAUDE\n\nBehavioral guardrails.\n")
+    _write(
+        repo / "docs/MEGAFILE_INDEX.md",
+        "# MEGAFILE INDEX\n\n"
+        "### Slot 1 — Vision Synthesis\n"
+        "See `dharma_swarm/context_compiler.py`.\n",
+    )
+    _write(
+        repo / "docs/governance/CANONICAL_DOC_STACK.md",
+        "# CANONICAL DOC STACK\n\nsource of truth for docs.\n",
+    )
+    _write(
+        repo / "docs/governance/SOVEREIGN_MANIFEST.md",
+        "# SOVEREIGN MANIFEST\n\ncanonical architecture truth.\n",
+    )
+    _write(repo / "docs/governance/BUILD_SESSION_ENTRYPOINT.md", "# Build\n")
+    _write(repo / "docs/governance/REPO_GOVERNANCE_AUDIT.md", "# Audit\n")
+    _write(repo / "docs/architecture/NAVIGATION.md", "# Navigation\n")
+    _write(repo / "docs/architecture/WIRING_AND_LOOPS.md", "# Wiring\n")
+    _write(repo / "docs/architecture/MEMORY_SYSTEM_FUSION_MAP_2026-05-01.md", "# Memory\n")
+    _write(
+        repo / "docs/state/BROKEN_REGISTER.md",
+        "# Broken Register\n\n- BR-001 Cron split-brain.\n- BR-002 Loop open.\n",
+    )
+    _write(repo / "docs/state/LIVE_OPS_DASHBOARD.md", "# Live Ops\n")
+    _write(
+        repo / "reports/system_map/latest.json",
+        json.dumps({"organs": [{"name": "central_loop", "coherence_state": "partial"}]}),
+    )
+    _write(repo / "dharma_swarm/context_compiler.py", '"""Context compiler."""\n')
+    _write(repo / "dharma_swarm/ontology.py", '"""Ontology."""\n')
+    _write(
+        wiki / "concepts/recognition-closure.md",
+        "---\nstatus: trusted\n---\n# Recognition Closure\n\nLinks [[central-loop]].\n",
+    )
+    return repo, wiki
+
+
+def test_stable_node_ids_are_deterministic() -> None:
+    a = KnowledgeNode.build(NodeKind.CONCEPT, "Recognition Closure", id_parts=["x"])
+    b = KnowledgeNode.build(NodeKind.CONCEPT, "Recognition Closure", id_parts=["x"])
+    c = KnowledgeNode.build(NodeKind.CONCEPT, "Recognition Closure", id_parts=["y"])
+
+    assert a.node_id == b.node_id
+    assert a.node_id != c.node_id
+
+
+def test_extractor_builds_docs_concepts_broken_items_and_runtime_facts(tmp_path: Path) -> None:
+    repo, wiki = _fixture_repo(tmp_path)
+
+    snapshot = KnowledgeOpsExtractor(
+        ExtractorConfig(repo_root=repo, wiki_root=wiki, wiki_limit=10)
+    ).extract()
+
+    counts = snapshot.node_count_by_kind()
+    assert counts["doc"] >= 10
+    assert counts["concept"] >= 2
+    assert counts["broken_register_item"] == 2
+    assert counts["runtime_fact"] == 1
+    assert counts["code_surface"] >= 1
+    assert snapshot.edge_count_by_kind()["extracts_concept"] >= 1
+    assert snapshot.edge_count_by_kind()["tracks_brokenness_of"] == 2
+    assert any(edge.kind == EdgeKind.REFERENCES for edge in snapshot.edges)
+
+
+def test_snapshot_write_jsonl_is_machine_readable(tmp_path: Path) -> None:
+    repo, wiki = _fixture_repo(tmp_path)
+    snapshot = KnowledgeOpsExtractor(ExtractorConfig(repo_root=repo, wiki_root=wiki)).extract()
+    out = tmp_path / "out"
+
+    snapshot.write_jsonl(out)
+
+    nodes = [json.loads(line) for line in (out / "nodes.jsonl").read_text().splitlines()]
+    edges = [json.loads(line) for line in (out / "edges.jsonl").read_text().splitlines()]
+    summary = json.loads((out / "summary.json").read_text())
+    assert len(nodes) == summary["node_count"]
+    assert len(edges) == summary["edge_count"]
+
+
+def test_concept_card_preserves_provenance_and_boundaries() -> None:
+    node = KnowledgeNode.build(
+        NodeKind.CONCEPT,
+        "Dream Mode",
+        id_parts=["dream"],
+        status=LifecycleStatus.STAGED,
+    )
+    edge = KnowledgeEdge.build(EdgeKind.SYNTHESIZES, node.node_id, "other")
+
+    card = render_concept_card(node, related_edges=(edge,))
+
+    assert "# Dream Mode" in card
+    assert "Do not treat staged or candidate cards as doctrine" in card
+    assert "synthesizes" in card
+
+
+def test_agent_context_bundle_is_projection_not_authority() -> None:
+    node = KnowledgeNode.build(NodeKind.DOC, "Sovereign Manifest", id_parts=["manifest"])
+
+    bundle = render_agent_context_bundle(
+        bundle_id="test",
+        role="reviewer",
+        objective="Audit KnowledgeOps",
+        nodes=(node,),
+        edges=(),
+    )
+
+    assert "This bundle is a projection" in bundle
+    assert "Audit KnowledgeOps" in bundle
+    assert "Do not create new authority docs" in bundle
+
+
+def test_mode_schedule_keeps_dream_candidate_only_and_promotion_reviewed() -> None:
+    schedule = default_mode_schedule()
+    modes = {item["mode"]: item for item in schedule}
+
+    assert KnowledgeOpsMode.DREAM.value in modes
+    assert modes[KnowledgeOpsMode.DREAM.value]["outputs"] == ["synthesis_candidates"]
+    assert modes[KnowledgeOpsMode.DREAM.value]["may_mutate_authority"] is False
+    assert modes[KnowledgeOpsMode.PROMOTION.value]["requires_human_review"] is True
+    assert modes[KnowledgeOpsMode.FORGETTING.value]["requires_human_review"] is True
+
+
+def test_cli_dry_run_and_report_generation(tmp_path: Path, capsys) -> None:
+    repo, wiki = _fixture_repo(tmp_path)
+    out = tmp_path / "reports"
+
+    assert main(["--repo-root", str(repo), "--wiki-root", str(wiki), "--dry-run"]) == 0
+    dry_output = capsys.readouterr().out
+    assert "node_count" in dry_output
+
+    assert main(["--repo-root", str(repo), "--wiki-root", str(wiki), "--output-dir", str(out)]) == 0
+    assert (out / "nodes.jsonl").exists()
+    assert (out / "edges.jsonl").exists()
+    assert (out / "mode_schedule.json").exists()
+    assert (out / "sample_concept_card.md").exists()
+    assert (out / "sample_agent_context_bundle.md").exists()


### PR DESCRIPTION
## Summary

Seeds KnowledgeOps as Dharma Swarm's semantic metabolism organ.

This PR is intentionally read-only/projection-only:

- adds `dharma_swarm/knowledge_ops/` with schema, extractor, projection helpers, and CLI
- adds focused tests for graph extraction, projection determinism, mode schedule, and CLI output
- adds a short seed plan defining organ role, inputs, outputs, and boundaries
- refreshes generated DocOps count surfaces required by hooks

## Boundaries

- No runtime execution edits
- No ontology writes or migrations
- No cron installation
- No archive moves
- No changes to Shakti, TelicSeam, orchestrator, agent runner, or kernel/gate files

## Verification

- `/Users/dhyana/dharma_swarm/.venv/bin/python -m pytest -q tests/test_knowledge_ops.py`
- `/Users/dhyana/dharma_swarm/.venv/bin/python -m dharma_swarm.knowledge_ops.cli --repo-root . --wiki-root /Users/dhyana/wiki --output-dir /private/tmp/knowledge_ops_seed_probe --wiki-limit 20`
- `/Users/dhyana/dharma_swarm/.venv/bin/python scripts/docops/check_docops_integrity.py --changed-from origin/main`
- `pre-commit run --files dharma_swarm/knowledge_ops/__init__.py dharma_swarm/knowledge_ops/schema.py dharma_swarm/knowledge_ops/extractor.py dharma_swarm/knowledge_ops/projections.py dharma_swarm/knowledge_ops/cli.py tests/test_knowledge_ops.py docs/plans/2026-05-10-knowledge-ops-organ-seed.md docs/docops/AUTO_INVENTORY.md docs/governance/SOVEREIGN_MANIFEST.md`

## Coherence Delta

Organ touched: KnowledgeOps seed, DocOps count surfaces.

Declared-vs-actual gap closed: creates the first bounded KnowledgeOps organ surface instead of leaving semantic metabolism as an architectural idea only.

Proof that re-reads the map: CLI projected the current repo/wiki sample into 383 nodes and 426 edges.

New drift introduced: none intended. Ontology promotion, Go sense-organ receipts, cron sleep/dream modes, and archive/promotion actions remain future work.
