### PR TITLE
Close high-ROI feedback and Guardian gaps

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -108,17 +108,22 @@ jobs:
           import ast
           from pathlib import Path
           errors = []
-          for f in sorted(Path('dharma_swarm').glob('*.py')):
+          excluded = {'__pycache__', '.git', '.mypy_cache', '.pytest_cache', '.ruff_cache', '.tox', '.venv', 'build', 'dist', 'node_modules'}
+          files = [
+              f for f in sorted(Path('dharma_swarm').rglob('*.py'))
+              if not any(part in excluded for part in f.parts)
+          ]
+          for f in files:
               try:
                   ast.parse(f.read_text())
               except SyntaxError as e:
-                  errors.append(f'{f.name}:{e.lineno}: {e.msg}')
+                  errors.append(f'{f}:{e.lineno}: {e.msg}')
           if errors:
               print('SYNTAX ERRORS:')
               for e in errors:
                   print(f'  {e}')
               raise SystemExit(1)
-          print(f'OK: {len(list(Path(\"dharma_swarm\").glob(\"*.py\")))} files, 0 syntax errors')
+          print(f'OK: {len(files)} files, 0 syntax errors')
           "
 
       - name: Check critical module imports

--- a/.semgrep/dharma-anti-slop.yml
+++ b/.semgrep/dharma-anti-slop.yml
@@ -92,6 +92,10 @@ rules:
           $RUN("git add -A", ...)
       - pattern: |
           $RUN("git add .", ...)
+      - pattern: |
+          asyncio.create_subprocess_exec("git", "add", "-A", ...)
+      - pattern: |
+          asyncio.create_subprocess_exec("git", "add", ".", ...)
 
   # ===========================================================================
   # Rule 6: dharma.providers-canonical

--- a/INTERFACE_MISMATCH_MAP.md
+++ b/INTERFACE_MISMATCH_MAP.md
@@ -19,6 +19,7 @@
 | MM-09: samvara.current_power None chain | DEGRADED | ✅ RESOLVED | Double guard present at `swarm.py:2182-2184` |
 | MM-10: AutoProposer stigmergy guard | DEGRADED | ✅ RESOLVED | `auto_proposer.py:297` has `if self._stigmergy is None: return` |
 | MM-11: WitnessAuditor ModelRouter provider | DEGRADED | ✅ RESOLVED | `swarm.py:456-457` now uses `OpenRouterFreeProvider()` |
+| MM-07: MetaEvolutionEngine cadence mismatch | DEGRADED | ✅ RESOLVED | `run_evolution_loop()` now feeds `observe_cycle_result()` at most once per outer cycle, preferring real `auto_evolve()` results over synthetic observed-fitness estimates. |
 | NEW-01: archaeology_ingestion palace.query | BLOCKER | ✅ FIXED THIS SESSION | Replaced with `palace.recall(PalaceQuery(...))` + correct `max_results=` |
 | NEW-02: dgm_loop _provider attr | DEGRADED | ✅ FIXED THIS SESSION | Removed nonexistent `hasattr(engine, '_provider')` check |
 
@@ -28,13 +29,13 @@
 | NEW-05: task_board ↔ runtime_state split lifecycle | — | ⚠️ GUARDED | `run_task_consistency_guard` added to guardian_crew — detects COMPLETED tasks with still-OPEN claims |
 | NEW-07: 54 stores lack common trace_id | — | ⚠️ PARTIAL+ | `trace_id` column added to task_board, runtime_state, telemetry_plane, stigmergy, traces, artifact_manifest, handoff. CorrelationContext auto-populates memory_palace.ingest() and economic_engine transactions. |
 | NEW-08: 12 independent record_outcome() | ⚠️ PARTIAL | ⚠️ PARTIAL+ | TelicSeam emits signals + SignalBus subscriber pattern added for automatic fanout |
-| NEW-09: orchestrator → TelicSeam registry_path kwarg | — | ✅ FIXED | `orchestrator.py:154` used `registry_path=` but TelicSeam accepts `path=`. TypeError at runtime. |
+| NEW-09: orchestrator → TelicSeam registry_path kwarg | — | ✅ FIXED | `TelicSeam.__init__()` now accepts `registry_path=` as an alias for `path=`, and uses the same path for lineage persistence. |
 | NEW-10: lineage edges lack delegation chain | — | ✅ FIXED | `LineageEdge.delegated_by` + `trace_id` fields added; `agent_runner.spawn_worker` records delegation lineage |
 | NEW-11: TelicSeam singleton missing signal_bus | — | ✅ FIXED | `get_seam()` now passes `signal_bus=SignalBus.get()` to singleton |
 | BR-007: runtime.db path drift + store split | BLOCKER | ✅ RESOLVED | `_record_memory_fact()` now writes `state/runtime.db`; `engine/store_sync.py` materializes ontology Outcomes into runtime ArtifactRecords; cron + room-health guards wired. |
 | BR-008: VentureCell room/ontology split | BLOCKER | ✅ RESOLVED | `fractal/room_bridge.py` uses deterministic room IDs for ontology objects, updates through `put_object()`, preserves `room_status`, and room-health persists ontology sync. |
 
-**Net change:** 11 resolved, 5 fixed prior sessions, 6 new entries (NEW-05 guarded, NEW-07/NEW-08 partially resolved, NEW-09/10/11 fixed), plus BR-007/BR-008 closure notes from PR #187. 0 open BLOCKERs, 4 structural degraded remain.
+**Net change:** 12 resolved, 5 fixed prior sessions, 6 new entries (NEW-05 guarded, NEW-07/NEW-08 partially resolved, NEW-09/10/11 fixed), plus BR-007/BR-008 closure notes from PR #187. 0 open BLOCKERs, 3 structural degraded remain.
 
 ---
 
@@ -54,12 +55,10 @@
 
 ---
 
-### MM-07 — DEGRADED: MetaEvolutionEngine cadence mismatch
+### MM-07 — RESOLVED: MetaEvolutionEngine cadence mismatch
 
-**File:** `orchestrate_live.py:399,407`
-**What's wrong:** `observe_cycle_result()` is called twice per cycle number (once with synthetic fitness, once with `auto_evolve` result). `n_object_cycles_per_meta=2` fires after 2 total calls — so meta-adaptation can trigger within a single evolution cycle, not after 2 separate cycles as intended.
-
-**Fix:** Only call `observe_cycle_result` once per cycle — with the actual `CycleResult` from `auto_evolve`, not the synthetic fitness estimate.
+**File:** `orchestrate_live.py`
+**Status:** ✅ RESOLVED — `run_evolution_loop()` now stores a single per-cycle meta input and calls `observe_cycle_result()` once after the auto-evolve branch. Real `auto_evolve()` output wins when present; synthetic observed-fitness output is only the fallback.
 
 ---
 
@@ -140,14 +139,14 @@ ROUTER_PROBE   — Reads circuit_breakers.json for open providers
 | 3 | `swarm` → `orchestrator._classify_failure` (private) | ⚠️ DEGRADED |
 | 4 | `swarm` → `agent_runner.AgentPool` | ✅ |
 | 5 | `swarm` → `evolution.DarwinEngine` | ✅ |
-| 6 | `swarm` → `meta_evolution.MetaEvolutionEngine` | ⚠️ DEGRADED (cadence) |
+| 6 | `swarm` → `meta_evolution.MetaEvolutionEngine` | ✅ |
 | 7 | `swarm` → `auto_proposer.AutoProposer` (stigmergy) | ✅ |
 | 8 | `swarm` → `organism.OrganismRuntime.samvara` | ✅ |
 | 9 | `swarm` → `witness.WitnessAuditor` | ✅ |
 | 10 | `swarm` → `stigmergy.StigmergyStore` | ✅ |
-| 11 | `orchestrate_live` → `persistent_agent.PersistentAgent` (replication) | ⚠️ BLOCKER |
+| 11 | `orchestrate_live` → `persistent_agent.PersistentAgent` (replication) | ✅ |
 | 12 | `orchestrate_live` → `message_bus.receive()` semantics | ⚠️ DEGRADED |
-| 13 | `orchestrate_live` → `meta_evolution.observe_cycle_result` cadence | ⚠️ DEGRADED |
+| 13 | `orchestrate_live` → `meta_evolution.observe_cycle_result` cadence | ✅ |
 | 14 | `orchestrate_live` → `living_layers` (dual StigmergyStore) | ✅ |
 | 15 | `archaeology_ingestion` → `memory_palace.recall()` | ✅ (fixed this session) |
 | 16 | `dgm_loop` → `evolution.DarwinEngine.auto_evolve()` | ✅ (fixed this session) |

--- a/dharma_swarm/cron_scheduler.py
+++ b/dharma_swarm/cron_scheduler.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 
 # ── Configuration ────────────────────────────────────────────────────
 
-DHARMA_DIR = dharma_state_dir("DHARMA_HOME")
+DHARMA_DIR = dharma_state_dir("DHARMA_STATE_DIR", "DHARMA_HOME")
 CRON_DIR = DHARMA_DIR / "cron"
 JOBS_FILE = CRON_DIR / "jobs.json"
 OUTPUT_DIR = CRON_DIR / "output"

--- a/dharma_swarm/engine/store_sync.py
+++ b/dharma_swarm/engine/store_sync.py
@@ -28,6 +28,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from dharma_swarm.daemon_config import dharma_state_dir
+
 logger = logging.getLogger(__name__)
 
 
@@ -42,12 +44,12 @@ class SyncResult:
 
 
 def _resolve_runtime_db(state_dir: Path | None = None) -> Path:
-    root = state_dir or (Path.home() / ".dharma")
+    root = state_dir or dharma_state_dir()
     return root / "state" / "runtime.db"
 
 
 def _resolve_ontology_db(state_dir: Path | None = None) -> Path:
-    root = state_dir or (Path.home() / ".dharma")
+    root = state_dir or dharma_state_dir()
     return root / "ontology.db"
 
 

--- a/dharma_swarm/evolution.py
+++ b/dharma_swarm/evolution.py
@@ -137,6 +137,27 @@ class Proposal(BaseModel):
         return v
 
 
+def _paths_from_unified_diff(diff_text: str) -> list[str]:
+    """Extract explicit repo-relative paths from unified diff headers."""
+    paths: list[str] = []
+    seen: set[str] = set()
+    for line in diff_text.splitlines():
+        if not (line.startswith("--- ") or line.startswith("+++ ")):
+            continue
+        raw = line[4:].strip().split("\t", 1)[0]
+        if raw == "/dev/null":
+            continue
+        if raw.startswith("a/") or raw.startswith("b/"):
+            raw = raw[2:]
+        path = Path(raw)
+        if path.is_absolute() or ".." in path.parts:
+            continue
+        if raw and raw not in seen:
+            seen.add(raw)
+            paths.append(raw)
+    return paths
+
+
 class CycleResult(BaseModel):
     """Summary of a single evolution cycle run."""
 
@@ -3236,9 +3257,13 @@ class DarwinEngine:
             f"Proposal: {proposal.id}\n"
             f"Change-type: {proposal.change_type}"
         )
+        changed_paths = _paths_from_unified_diff(proposal.diff)
+        if not changed_paths:
+            logger.warning("Refusing to auto-commit proposal %s with no explicit diff paths", proposal.id)
+            return None
 
         proc = await asyncio.create_subprocess_exec(
-            "git", "add", "-A",
+            "git", "add", "--", *changed_paths,
             cwd=str(ws),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,

--- a/dharma_swarm/guardian_crew.py
+++ b/dharma_swarm/guardian_crew.py
@@ -28,7 +28,7 @@ The crew has three specialist agents:
         - Identifies dead providers before they waste agent budgets
         - Writes findings to ~/.dharma/guardian/router_health.md
 
-Combined output → ~/.dharma/guardian/GUARDIAN_REPORT.md (overwritten each cycle)
+Combined output -> ~/.dharma/guardian/GUARDIAN_REPORT.md (overwritten each cycle)
 GitHub issue created when severity >= BLOCKER and no open issue exists for that mismatch.
 
 Cycle: every 4 hours (configurable via GUARDIAN_INTERVAL_SECONDS env var).
@@ -151,6 +151,65 @@ _IMPORT_CHECKS: list[tuple[str, str]] = [
 ]
 
 
+_SYNTAX_SCAN_EXCLUDE_DIRS = frozenset(
+    {
+        "__pycache__",
+        ".git",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".tox",
+        ".venv",
+        "build",
+        "dist",
+        "node_modules",
+    }
+)
+
+
+def _iter_python_sources(src_root: Path) -> list[Path]:
+    """Return package Python sources, including nested subpackages."""
+    if not src_root.exists():
+        return []
+    sources: list[Path] = []
+    for py_file in src_root.rglob("*.py"):
+        if any(part in _SYNTAX_SCAN_EXCLUDE_DIRS for part in py_file.parts):
+            continue
+        sources.append(py_file)
+    return sorted(sources)
+
+
+def _module_source_candidates(module_name: str, src_root: Path) -> list[Path]:
+    """Return source-file candidates for a package module.
+
+    Guardian usually receives ``src_root`` as the repo's ``dharma_swarm/``
+    directory, but live daemons have historically run from stale worktree paths.
+    Resolve through importlib as a fallback so a bad root does not create false
+    BLOCKER issues for modules that are importable in the active environment.
+    """
+    module_path = module_name.replace(".", "/")
+    candidates = [
+        src_root / (module_path.replace("dharma_swarm/", "") + ".py"),
+        src_root / (module_path + ".py"),
+    ]
+    try:
+        spec = importlib.util.find_spec(module_name)
+    except Exception:
+        spec = None
+    origin = getattr(spec, "origin", None) if spec is not None else None
+    if origin and origin not in {"built-in", "namespace"}:
+        candidates.append(Path(origin))
+
+    unique: list[Path] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        key = str(candidate)
+        if key not in seen:
+            seen.add(key)
+            unique.append(candidate)
+    return unique
+
+
 async def run_auditor(src_root: Path) -> list[GuardianFinding]:
     """AUDITOR: Check import chains, method existence, and known contract violations."""
     findings: list[GuardianFinding] = []
@@ -179,12 +238,7 @@ async def run_auditor(src_root: Path) -> list[GuardianFinding]:
 
     # 2. Method existence checks (parse AST, don't import)
     for module_name, class_name, method_name, severity in _METHOD_EXISTENCE_CHECKS:
-        module_path = module_name.replace('.', '/')
-        # Try both dharma_swarm/ prefix styles
-        candidates = [
-            src_root / (module_path.replace('dharma_swarm/', '') + '.py'),
-            src_root / (module_path + '.py'),
-        ]
+        candidates = _module_source_candidates(module_name, src_root)
         found_file = next((p for p in candidates if p.exists()), None)
         if found_file is None:
             findings.append(GuardianFinding(
@@ -236,17 +290,21 @@ async def run_auditor(src_root: Path) -> list[GuardianFinding]:
                 fix_hint=f"Fix syntax at line {exc.lineno}",
             ))
 
-    # 3. Scan all Python files for syntax errors (catches regressions)
-    for py_file in sorted(src_root.glob("*.py")):
+    # 3. Scan all Python files for syntax errors (catches nested-package regressions)
+    for py_file in _iter_python_sources(src_root):
+        try:
+            relative_file = str(py_file.relative_to(src_root.parent))
+        except ValueError:
+            relative_file = str(py_file)
         try:
             ast.parse(py_file.read_text(encoding="utf-8"))
         except SyntaxError as exc:
             findings.append(GuardianFinding(
                 severity="BLOCKER",
                 check="AUDITOR:syntax",
-                title=f"Syntax error: {py_file.name}",
+                title=f"Syntax error: {relative_file}",
                 detail=f"Line {exc.lineno}: {exc.msg}",
-                file=py_file.name,
+                file=relative_file,
                 line=exc.lineno or 0,
                 fix_hint=f"Fix syntax error at line {exc.lineno}",
             ))
@@ -787,6 +845,45 @@ def synthesize_report(
 # GitHub issue creation for BLOCKERs
 # ---------------------------------------------------------------------------
 
+def _github_issue_already_open(repo: str, title: str) -> bool:
+    """Best-effort remote dedupe for Guardian issues.
+
+    The local ``issues_created.json`` file is host-local. When Guardian runs from
+    another machine or a rebuilt state dir, it can otherwise reopen the same
+    BLOCKER every cycle.
+    """
+    try:
+        proc = subprocess.run(
+            [
+                "gh",
+                "issue",
+                "list",
+                "--repo",
+                repo,
+                "--state",
+                "open",
+                "--search",
+                f"{title} in:title",
+                "--json",
+                "number",
+                "--limit",
+                "1",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except Exception:
+        return False
+    if proc.returncode != 0:
+        return False
+    try:
+        return bool(json.loads(proc.stdout or "[]"))
+    except json.JSONDecodeError:
+        return False
+
+
 async def _create_issue_if_needed(finding: GuardianFinding, repo: str, state_dir: Path) -> bool:
     """Create a GitHub issue for a BLOCKER finding if one doesn't already exist."""
     # Check dedup registry
@@ -804,6 +901,13 @@ async def _create_issue_if_needed(finding: GuardianFinding, repo: str, state_dir
         logger.debug("Issue already created for: %s", issue_key)
         return False
 
+    remote_title = f"[GUARDIAN] {finding.title}"
+    if _github_issue_already_open(repo, remote_title):
+        existing[issue_key] = "remote-open"
+        issues_log.write_text(json.dumps(existing, indent=2), encoding="utf-8")
+        logger.debug("Open GitHub issue already exists for: %s", remote_title)
+        return False
+
     try:
         from dharma_swarm.world_actions import github_create_issue
 
@@ -815,7 +919,7 @@ async def _create_issue_if_needed(finding: GuardianFinding, repo: str, state_dir
             f"**Suggested Fix:**\n{finding.fix_hint or 'See detail above.'}\n\n"
             f"---\n*Auto-generated by Guardian Crew at {datetime.now(timezone.utc).isoformat()}*"
         )
-        result = github_create_issue(repo=repo, title=f"[GUARDIAN] {finding.title}", body=body)
+        result = github_create_issue(repo=repo, title=remote_title, body=body)
         if result.success:
             existing[issue_key] = result.url or "created"
             issues_log.write_text(json.dumps(existing, indent=2), encoding="utf-8")
@@ -887,13 +991,6 @@ async def run_guardian_cycle(
     report_dir.mkdir(parents=True, exist_ok=True)
     report_path = report_dir / "GUARDIAN_REPORT.md"
     report_path.write_text(report, encoding="utf-8")
-
-    # Also write to repo root (version-controlled visibility)
-    try:
-        repo_report_path = src_root.parent / "GUARDIAN_REPORT.md"
-        repo_report_path.write_text(report, encoding="utf-8")
-    except Exception:
-        pass
 
     # Create GitHub issues for BLOCKERs
     issues_created = 0

--- a/dharma_swarm/launchd_job_runner.py
+++ b/dharma_swarm/launchd_job_runner.py
@@ -21,6 +21,7 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 
+from dharma_swarm.daemon_config import dharma_state_dir
 from dharma_swarm.cron_job_runtime import (
     CronJobExecutionResult,
     CronJobRun,
@@ -38,6 +39,10 @@ def _output_preview(text: str, *, limit: int = 240) -> str:
     if len(collapsed) <= limit:
         return collapsed
     return collapsed[: limit - 3] + "..."
+
+
+def _state_dir() -> Path:
+    return dharma_state_dir("DHARMA_STATE_DIR", "DHARMA_HOME")
 
 
 def _write_last_run(
@@ -112,7 +117,7 @@ def main() -> int:
         return 1
 
     # Ensure output directories exist
-    output_dir = Path.home() / ".dharma" / "cron"
+    output_dir = _state_dir() / "cron"
     last_run_dir = output_dir / "last_run"
     runtime_store = CronJobRuntimeStore(output_dir / "state")
     output_dir.mkdir(parents=True, exist_ok=True)

--- a/dharma_swarm/opportunity_dispatcher.py
+++ b/dharma_swarm/opportunity_dispatcher.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
+from dharma_swarm.daemon_config import dharma_state_dir
 from dharma_swarm.models import Task, TaskPriority, TaskStatus
 from dharma_swarm.runtime_state import (
     DelegationRun,
@@ -48,7 +49,7 @@ def _resolve_state_root() -> Path:
             return Path(cfg_root)
     except Exception:
         pass
-    return Path.home() / ".dharma" / "state"
+    return dharma_state_dir() / "state"
 
 
 OPPORTUNITY_STAGES = (
@@ -234,7 +235,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--max", type=int, default=3, help="Max promotions per run")
     args = parser.parse_args(argv)
 
-    board_path = Path.home() / ".dharma" / "meta" / "opportunity_board.json"
+    board_path = dharma_state_dir() / "meta" / "opportunity_board.json"
     if not board_path.exists():
         logger.info("No opportunity board found at %s", board_path)
         return 0

--- a/dharma_swarm/opportunity_refill.py
+++ b/dharma_swarm/opportunity_refill.py
@@ -32,6 +32,7 @@ from dharma_swarm.opportunity_dispatcher import (
     DispatchResult,
     OpportunityDispatcher,
 )
+from dharma_swarm.daemon_config import dharma_state_dir
 
 logger = logging.getLogger(__name__)
 
@@ -101,7 +102,7 @@ class OpportunityRefill:
             telic_seam=telic_seam,
             economic_engine=economic_engine,
         )
-        self._output_dir = output_dir or (Path.home() / ".dharma" / "revenue_packets")
+        self._output_dir = output_dir or (dharma_state_dir() / "revenue_packets")
         self._output_dir.mkdir(parents=True, exist_ok=True)
 
     def refill(self, row: OpportunityRow) -> RefillResult:
@@ -305,6 +306,7 @@ class FrontierRefillResult(BaseModel):
 
     paused: bool = False
     board_count: int = 0
+    queued_count: int = 0
     addressed_count: int = 0
     appended_rows: int = 0
     appended_opportunity_ids: list[str] = Field(default_factory=list)
@@ -313,7 +315,7 @@ class FrontierRefillResult(BaseModel):
 
 def _read_board(board_path: Path | None = None) -> list[dict[str, Any]]:
     """Read the opportunity board, returning an empty list on any failure."""
-    path = (board_path or Path.home() / ".dharma" / "meta" / "opportunity_board.json").expanduser()
+    path = (board_path or dharma_state_dir() / "meta" / "opportunity_board.json").expanduser()
     if not path.exists():
         return []
     try:
@@ -347,10 +349,10 @@ def _select_pending(
     top_k: int = 3,
     min_telos_alignment: float = 0.5,
 ) -> list[dict[str, Any]]:
-    """Pick the top-k board entries that haven't been addressed yet."""
+    """Pick the top-k board entries that are neither addressed nor queued."""
     pending = []
     for row in board:
-        if row.get("addressed"):
+        if row.get("addressed") or row.get("queued"):
             continue
         telos = _safe_float(row.get("telos_alignment", row.get("final_score", 0)))
         if telos < min_telos_alignment:
@@ -365,7 +367,7 @@ def _append_frontier_rows(
     frontier_path: Path | None = None,
 ) -> int:
     """Append opportunity-sourced task rows to frontier_tasks_pending.jsonl."""
-    path = (frontier_path or Path.home() / ".dharma" / "meta" / "frontier_tasks_pending.jsonl").expanduser()
+    path = (frontier_path or dharma_state_dir() / "meta" / "frontier_tasks_pending.jsonl").expanduser()
     path.parent.mkdir(parents=True, exist_ok=True)
     count = 0
     with open(path, "a", encoding="utf-8") as f:
@@ -375,17 +377,18 @@ def _append_frontier_rows(
     return count
 
 
-def _mark_addressed(
+def _mark_queued(
     board: list[dict[str, Any]],
     opp_ids: set[str],
     board_path: Path | None = None,
 ) -> None:
-    """Mark addressed opportunities on the board so they aren't re-promoted."""
-    path = (board_path or Path.home() / ".dharma" / "meta" / "opportunity_board.json").expanduser()
+    """Mark queued opportunities so refill does not duplicate pending work."""
+    path = (board_path or dharma_state_dir() / "meta" / "opportunity_board.json").expanduser()
+    queued_at = datetime.now(timezone.utc).isoformat()
     for row in board:
         if _opportunity_id(row) in opp_ids:
-            row["addressed"] = True
-            row["addressed_at"] = datetime.now(timezone.utc).isoformat()
+            row["queued"] = True
+            row["queued_at"] = queued_at
     tmp = path.with_suffix(path.suffix + f".tmp.{int(time.time() * 1000)}")
     tmp.write_text(json.dumps(board, indent=2, sort_keys=True), encoding="utf-8")
     tmp.replace(path)
@@ -409,7 +412,7 @@ def refill_frontier_tasks_pending(
 
     Called by cron_runner handler ``frontier_refill``.
     """
-    pause_file = Path.home() / ".dharma" / ".PAUSE"
+    pause_file = dharma_state_dir() / ".PAUSE"
     if pause_file.exists():
         return FrontierRefillResult(paused=True)
 
@@ -422,13 +425,13 @@ def refill_frontier_tasks_pending(
         return FrontierRefillResult(board_count=len(board))
 
     frontier_rows: list[dict[str, Any]] = []
-    addressed_ids: set[str] = set()
+    queued_ids: set[str] = set()
 
     for opp in selected:
         opp_id = _opportunity_id(opp)
         opp_title = str(opp.get("title", "Untitled opportunity"))
         opp_type = str(opp.get("type") or opp.get("domain") or "external_revenue")
-        addressed_ids.add(opp_id)
+        queued_ids.add(opp_id)
 
         for stage in OPPORTUNITY_STAGES:
             frontier_rows.append({
@@ -447,17 +450,19 @@ def refill_frontier_tasks_pending(
     if dry_run:
         return FrontierRefillResult(
             board_count=len(board),
-            addressed_count=len(selected),
+            queued_count=len(selected),
+            addressed_count=0,
             appended_rows=len(frontier_rows),
-            appended_opportunity_ids=sorted(addressed_ids),
+            appended_opportunity_ids=sorted(queued_ids),
         )
 
     appended = _append_frontier_rows(frontier_rows, frontier_path)
-    _mark_addressed(board, addressed_ids, board_path)
+    _mark_queued(board, queued_ids, board_path)
 
     return FrontierRefillResult(
         board_count=len(board),
-        addressed_count=len(selected),
+        queued_count=len(selected),
+        addressed_count=0,
         appended_rows=appended,
-        appended_opportunity_ids=sorted(addressed_ids),
+        appended_opportunity_ids=sorted(queued_ids),
     )

--- a/dharma_swarm/orchestrate_live.py
+++ b/dharma_swarm/orchestrate_live.py
@@ -498,6 +498,8 @@ async def run_evolution_loop(shutdown_event: asyncio.Event) -> None:
 
             # ── ACTIVE EVOLUTION: run cycle + meta-adaptation ──
             cycle_count += 1
+            meta_cycle_result: CycleResult | None = None
+            meta_cycle_source = "observed fitness"
 
             # Extract live fitness from AGENT_FITNESS event payloads and persist
             live_fitness_scores: list[float] = []
@@ -538,21 +540,7 @@ async def run_evolution_loop(shutdown_event: asyncio.Event) -> None:
                     best_fitness=best_fitness,
                     proposals_submitted=len(fitness_events),
                 )
-                meta_result = meta_engine.observe_cycle_result(synthetic_result)
-                if meta_result is not None:
-                    if meta_result.evolved_parameters:
-                        _log(
-                            "evolution",
-                            f"Meta-evolution adapted parameters "
-                            f"(meta_fitness={meta_result.meta_fitness:.3f}, "
-                            f"applied={meta_result.applied_parameters})",
-                        )
-                    else:
-                        _log(
-                            "evolution",
-                            f"Meta-evolution: no adaptation needed "
-                            f"(meta_fitness={meta_result.meta_fitness:.3f})",
-                        )
+                meta_cycle_result = synthetic_result
 
             # Drain active inference prediction errors — bias evolution toward high-error areas
             try:
@@ -658,6 +646,8 @@ async def run_evolution_loop(shutdown_event: asyncio.Event) -> None:
                                 timeout=30.0,
                                 context=f"Fitness avg={avg_fitness:.3f}, completions={completions}",
                             )
+                            meta_cycle_result = result
+                            meta_cycle_source = "auto-evolve"
                             _log(
                                 "evolution",
                                 f"Auto-evolve result ({mode_label}): fitness={result.best_fitness:.3f}, "
@@ -708,13 +698,29 @@ async def run_evolution_loop(shutdown_event: asyncio.Event) -> None:
                                         stderr=asyncio.subprocess.PIPE,
                                     )
                                 _log("evolution", f"Live cycle: {_committed} commits on {_branch}")
-
-                            # Feed result to meta-evolution
-                            meta_engine.observe_cycle_result(result)
                     else:
                         _log("evolution", "Auto-evolve skipped: OPENROUTER_API_KEY not set")
                 except Exception as exc:
                     _log("evolution", f"Auto-evolve error: {exc}")
+
+            # Feed meta-evolution at most once per outer cycle. Prefer the real
+            # auto_evolve result when present; otherwise use observed fitness.
+            if meta_cycle_result is not None:
+                meta_result = meta_engine.observe_cycle_result(meta_cycle_result)
+                if meta_result is not None:
+                    if meta_result.evolved_parameters:
+                        _log(
+                            "evolution",
+                            f"Meta-evolution adapted parameters from {meta_cycle_source} "
+                            f"(meta_fitness={meta_result.meta_fitness:.3f}, "
+                            f"applied={meta_result.applied_parameters})",
+                        )
+                    else:
+                        _log(
+                            "evolution",
+                            f"Meta-evolution from {meta_cycle_source}: no adaptation needed "
+                            f"(meta_fitness={meta_result.meta_fitness:.3f})",
+                        )
 
             # Bus metrics for observability
             try:
@@ -1766,7 +1772,7 @@ async def _run_guardian_loop(
       LOOP_WATCHER   — cybernetic loop health, evolution archive freshness
       ROUTER_PROBE   — circuit breaker state, dead providers, missing keys
 
-    Writes GUARDIAN_REPORT.md to repo root and ~/.dharma/guardian/.
+    Writes GUARDIAN_REPORT.md to ~/.dharma/guardian/.
     Creates GitHub issues for BLOCKER-severity findings.
     """
     try:
@@ -1965,7 +1971,7 @@ async def orchestrate(background: bool = False) -> None:
         # lessons_learned.md at ~/.dharma/meta/ — the anti-amnesia mechanism.
         "archaeology": lambda: _run_archaeology_loop(shutdown_event),
         # ── Guardian Crew: continuous interface + loop + router health checks ──
-        # Runs at boot + every 4 hours. Writes GUARDIAN_REPORT.md.
+        # Runs at boot + every 4 hours. Writes state-local GUARDIAN_REPORT.md.
         # Creates GitHub issues for BLOCKER-severity findings.
         "guardian": lambda: _run_guardian_loop(shutdown_event, room_registry=room_registry),
         # ── Health API: curl http://localhost:7433/health ──

--- a/dharma_swarm/shakti_executive/feedback_writer.py
+++ b/dharma_swarm/shakti_executive/feedback_writer.py
@@ -49,9 +49,18 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from dharma_swarm.daemon_config import dharma_state_dir
+
 logger = logging.getLogger(__name__)
 
-DEFAULT_BOARD_PATH = Path.home() / ".dharma" / "meta" / "opportunity_board.json"
+_FALLBACK_BOARD_PATH = Path("~/.dharma/meta/opportunity_board.json")
+DEFAULT_BOARD_PATH = _FALLBACK_BOARD_PATH
+
+
+def _default_board_path() -> Path:
+    if DEFAULT_BOARD_PATH != _FALLBACK_BOARD_PATH:
+        return Path(DEFAULT_BOARD_PATH)
+    return dharma_state_dir() / "meta" / "opportunity_board.json"
 
 
 @dataclass(frozen=True)
@@ -120,7 +129,7 @@ def update_opportunity_outcome(
     no matching opportunity is found, or the outcome was already recorded
     (idempotent). Writes atomically via tmp+rename.
     """
-    path = (board_path or DEFAULT_BOARD_PATH).expanduser()
+    path = (board_path or _default_board_path()).expanduser()
     if not path.exists():
         logger.debug("opportunity_board.json missing at %s; skipping", path)
         return False
@@ -172,6 +181,15 @@ def update_opportunity_outcome(
         row["learned_score_delta"] = (
             float(row.get("learned_score_delta", 0.0)) + _learned_score_delta(outcome)
         )
+        row["queued"] = False
+        recorded_ts = outcome.recorded_at or time.time()
+        recorded_at_iso = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(recorded_ts))
+        row["last_outcome_at"] = recorded_at_iso
+        if outcome.success:
+            row["addressed"] = True
+            row["addressed_at"] = recorded_at_iso
+        else:
+            row["last_failed_outcome_at"] = recorded_at_iso
         break
 
     if not matched:

--- a/dharma_swarm/telic_seam.py
+++ b/dharma_swarm/telic_seam.py
@@ -63,12 +63,15 @@ class TelicSeam:
         registry: OntologyRegistry | None = None,
         lineage: LineageGraph | None = None,
         path: str | Path | None = None,
+        registry_path: str | Path | None = None,
         signal_bus: SignalBus | None = None,
     ) -> None:
+        if path is None and registry_path is not None:
+            path = registry_path
         self._path = path
         self._registry = registry or get_shared_registry(path)
         self._persist_registry = registry is None
-        self._lineage = lineage or LineageGraph()
+        self._lineage = lineage or LineageGraph(path)
         self._signal_bus = signal_bus
         self._proposal_map: dict[str, str] = {}  # task_id -> proposal obj_id
         self._duplicate_suppressions: dict[str, int] = {

--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -8,11 +8,11 @@ Do not hand-edit the generated block.
 |---|---:|
 | Dharma Python modules | 555 |
 | Top-level Dharma Python modules | 386 |
-| Dharma Python LOC | 249,790 |
+| Dharma Python LOC | 249,952 |
 | Test files | 564 |
-| Test function occurrences | 10,040 |
+| Test function occurrences | 10,047 |
 | Markdown files | 685 |
-| Markdown total lines | 175,016 |
+| Markdown total lines | 175,008 |
 | Bridge files | 19 |
 | Adapter files | 14 |
 | Orchestrator files | 4 |

--- a/docs/governance/SOVEREIGN_MANIFEST.md
+++ b/docs/governance/SOVEREIGN_MANIFEST.md
@@ -64,13 +64,13 @@ These are the ground-truth metrics. All other documents citing different numbers
 |--------|-------|-------------|
 | Total Python modules | **555** | find dharma_swarm -name "*.py" -type f |
 | Top-level (flat) modules | **386 (69.5%)** | find dharma_swarm -maxdepth 1 -name "*.py" -type f |
-| Total Python LOC | **249,744** | wc -l across dharma_swarm Python modules |
+| Total Python LOC | **249,952** | wc -l across dharma_swarm Python modules |
 | Test files | **564** | find tests -name "*.py" -type f |
-| Test functions | **10,040 `def test_` occurrences under tests/** | rg "def test_" tests |
+| Test functions | **10,047 `def test_` occurrences under tests/** | rg "def test_" tests |
 | Tests collected (pytest) | **Needs write-permitted refresh** | not run during this DocOps count pass |
 | Collection errors | **Historical: 16 on 2026-04-04** | refresh before relying on this count |
 | Markdown files | **685** | find . -name "*.md" -type f |
-| Markdown total lines | **175,016** | wc -l across all .md |
+| Markdown total lines | **175,008** | wc -l across all .md |
 | Bridge files | **19** | find dharma_swarm -name "*bridge*.py" |
 | Adapter files | **14 across 7 locations** | find dharma_swarm -type f \| rg -i "adapter" |
 | Orchestrator files | **4** (6,034 LOC total) | find dharma_swarm -name "*orchestrat*" |

--- a/docs/state/BROKEN_REGISTER.md
+++ b/docs/state/BROKEN_REGISTER.md
@@ -21,11 +21,11 @@
 
 ---
 
-## OPEN ITEMS (10 open after PR #187 closure pass 2026-05-10; 9 closed below)
+## OPEN ITEMS (9 open/partial after 2026-05-11 truth pass; 10 closed below)
 
 > **Convergence pass executed 2026-05-07 18:00–18:10:** Plan at `~/.claude/plans/yes-write-a-plan-wobbly-cerf.md`. Closed items moved to CLOSED section: BR-001 (cron daemon plist fixed), BR-016 (SOVEREIGN_MANIFEST counts refreshed and now DocOps-verified), BR-017 (BUILD_SESSION_ENTRYPOINT.md present), BR-018 (MEGAFILE_INDEX referenced from CLAUDE.md + README), BR-019 (Coherence Delta CI validator installed). BR-015 was already CLOSED. Total CLOSED = 6; OPEN = 13.
 
-*(BR-001, BR-002, BR-007, and BR-008 moved to CLOSED ITEMS — see below)*
+*(BR-001, BR-002, BR-006, BR-007, and BR-008 moved to CLOSED ITEMS — see below)*
 
 ### BR-003 — Apply gate present but closed (self-evolution loop)
 - **first_observed:** 2026-05-07
@@ -44,10 +44,10 @@
 - **age_days:** 1+
 - **severity:** DEGRADED
 - **domain:** cron / docs
-- **root_cause:** Repo `dharma_swarm/cron_jobs.json` has 17 jobs (schema A); live `~/.dharma/cron/jobs.json` has 484 lines (schema B); 1 shared id; 16 orphaned. `scripts/cron_unify.py:5-9` documents the split. No doc declares which is canonical.
-- **blast_radius:** Operator-loop documentation (Slot 8) cannot be written until canonical declared.
-- **evidence:** `~/.dharma/audit/cron_split_brain_*.json` (3 snapshots, latest 2026-05-06 22:30); `ten_megafiles_q5_2026-05-07.md`.
-- **status:** OPEN.
+- **root_cause:** Repo `dharma_swarm/cron_jobs.json` and live `~/.dharma/cron/jobs.json` still use different schemas and job populations. The original sub-claim "No doc declares which is canonical" is now stale.
+- **blast_radius:** Job-level health can still diverge between repo intent and launchd reality, but the scheduler state authority is no longer ambiguous.
+- **evidence:** `docs/governance/METABOLIC_CLOCK.md` declares `~/.dharma/cron/jobs.json` as scheduler state authority and says to fix failed jobs as separate scoped work packets. `scripts/cron_unify.py` remains the non-mutating unification helper.
+- **status:** PARTIAL — canonical authority declared; actual repo/live job reconciliation remains a scoped follow-up.
 
 ### BR-005 — Algedonic stream in degenerate steady-state
 - **first_observed:** ~2026-05-02 (5 days prior to audit)
@@ -55,21 +55,10 @@
 - **age_days:** ~5
 - **severity:** DEGRADED
 - **domain:** runtime
-- **root_cause:** Current last-200 algedonic rows contain only `omega_divergence medium rebalance_priorities`: 116 rows at `0.683`, 84 rows at `0.6527`. Not literally one identical value, but still a low-information steady-state. Consumer side likely dead or under-wired. **POST-BR-001 VERIFICATION**: 2 hours after the cron-daemon plist fix landed (PID 35207 running lf5-venv binary), `tail -50 ~/.dharma/algedonic_signals.jsonl | jq '.value' | sort -u` returns ONLY `0.683` (1 distinct value). Conclusion: BR-005 root cause is NOT the cron daemon path/version drift. Independent issue.
-- **blast_radius:** No rich causal feedback into the swarm. EMERGENCY_HOLD never escalates. Algedonic channel is structurally present (`vsm_channels.py:373`, `organism.py:968` — note duplicate types) but operationally inert.
-- **evidence:** `tail -200 ~/.dharma/algedonic_signals.jsonl | jq '[.kind,.severity,.action,.value]'` summary on 2026-05-07; `~/.dharma/audit/ten_megafiles_q3_2026-05-07.md`; `vsm_channels.py:373`; `organism.py:968`. Post-fix verification: `launchctl print gui/501/com.dharma.cron-daemon` shows running PID 35207 with lf5-venv binary; algedonic stream still emits one value.
-- **status:** OPEN — needs SCOPED INVESTIGATION (likely consumer-side: where does `algedonic_signals.jsonl` get read, and does that reader emit anything OTHER than the one stuck signal?). Not auto-resolved by cron daemon fix.
-
-### BR-006 — Recognition seed stale
-- **first_observed:** ~2026-05-01 (6 days prior to audit)
-- **last_verified:** 2026-05-07 20:30 (post-BR-001-fix verification)
-- **age_days:** 6
-- **severity:** DEGRADED
-- **domain:** runtime / agent
-- **root_cause:** `~/.dharma/meta/recognition_seed.md` is 6 days old despite metabolic-clock doctrine claiming nightly regeneration. Correlates with BR-001 cron LaunchAgent drift; direct causality is not proven because launchd reports the daemon process still running. **POST-BR-001 VERIFICATION**: 2 hours after cron-daemon plist fix landed, `stat -f "%Sm" ~/.dharma/meta/recognition_seed.md` returns `May 1 08:58:32 2026` — seed mtime is UNCHANGED. Conclusion: BR-006 is NOT downstream of BR-001. The cron daemon firing more reliably does not by itself trigger recognition_seed regeneration. Independent issue.
-- **blast_radius:** Agents loading context get stale self-model. Recognition is recognition of yesterday's state.
-- **evidence:** `~/.dharma/audit/ten_megafiles_q6_2026-05-07.md`; vision_maps `04_recognition_self_model.md`. Post-fix verification: cron daemon PID 35207 running lf5-venv binary; recognition_seed mtime unchanged at May 1.
-- **status:** OPEN — needs SCOPED INVESTIGATION (where in the metabolic clock does recognition_seed regeneration happen? `meta_daemon.py:RecognitionEngine`? Is there a separate cron handler that should fire it? The `meta_daemon.py:272-285` hard-coded March 2026 thesis-timing logic — does that gate regeneration?). Not auto-resolved by cron daemon fix.
+- **root_cause:** The original "last-200 rows are only omega_divergence" finding is now stale. The live stream contains chronic `omega_divergence` plus many `task_retries_exhausted` dead-letter warning signals. The remaining gap is consumer/action coherence: some actions emitted by `algedonic_activation.py` are unsupported or only partially consumed by `Organism`/VSM paths.
+- **blast_radius:** Sensing is richer than actuation. Signals exist, but not every signal class has an explicit consumer policy: log-only, prompt-context, scheduling bias, review, hold, or dispatch stop.
+- **evidence:** 2026-05-11 live tail of `~/.dharma/algedonic_signals.jsonl`; `dharma_swarm/algedonic_activation.py` defines `rebalance_priorities`, `enforce_glossary`, and `recalibrate_from_metrics`; `dharma_swarm/organism.py` concretely handles only a subset of algedonic actions.
+- **status:** PARTIAL — degenerate steady-state claim corrected; causal consumption/action coverage remains open.
 
 ### BR-009 — Roadmap is contested (3 docs claim primacy)
 - **first_observed:** 2026-05-07
@@ -135,7 +124,7 @@
 - **root_cause:** `dharma_swarm/telos_gates.py:512-513` literal hard-pass. The Gnani check defined to be most central is structurally inert.
 - **blast_radius:** Recognition layer's hardest gate is a no-op. Witness emits but doesn't gate.
 - **evidence:** vision_maps `01_gnani_prakruti.md`; `telos_gates.py:512-513`.
-- **status:** OPEN.
+- **status:** OPEN — direct edits to `telos_gates.py` are governance-forbidden by `CLAUDE.md`; closure must go through `GateRegistry.propose()` / gate pressure policy rather than a hard-coded gate mutation.
 
 ### BR-015 — `.FOCUS` writer with stale claim "no reader"
 - **first_observed:** 2026-05-07
@@ -201,9 +190,13 @@
 
 ## CLOSED ITEMS
 
+### BR-006 (CLOSED 2026-05-11) — Recognition seed stale
+- **Closing evidence:** Live `~/.dharma/meta/recognition_seed.md` was refreshed on 2026-05-10 and now reports current recognition context (`R_V=0.998 static`, archive entries, witness logs, DGC agents, recent cascade loops). `dharma_swarm/meta_daemon.py` owns recognition synthesis and `dharma_swarm/context.py` injects the seed into agent context.
+- **Verification:** 2026-05-11 live stat showed `May 10 21:25:11 2026` mtime, replacing the stale May 1 observation. Residual work is not freshness but making recognition more directly causal in routing/gates.
+
 ### BR-002 (CLOSED 2026-05-10 via PR #187) — central VentureCell loop feedback
-- **Closing evidence:** `dharma_swarm/opportunity_refill.py:409-438` promotes canonical Shakti `opportunity_id` rows into `frontier_tasks_pending.jsonl` and marks those same board rows addressed. `dharma_swarm/orchestrate_live.py:75-122` drains the frontier queue into `TaskBoard` entries with `opportunity_id` metadata and typed `TaskPriority`. `dharma_swarm/telic_seam.py:338-358` feeds completed outcomes back through `update_opportunity_outcome()`. `cron_jobs.json` registers the enabled `frontier_refill` scheduler entry.
-- **Verification:** `tests/test_br_closures.py` covers canonical `opportunity_id`, malformed scores, queue drain into `TaskBoard`, and metadata preservation. Manual probe confirmed canonical board row `opp-canonical` round-trips to frontier metadata and `update_opportunity_outcome()` returns `True`.
+- **Closing evidence:** `dharma_swarm/opportunity_refill.py` promotes canonical Shakti `opportunity_id` rows into `frontier_tasks_pending.jsonl` and now marks board rows `queued`, not falsely `addressed`. `dharma_swarm/orchestrate_live.py` drains the frontier queue into `TaskBoard` entries with `opportunity_id` metadata and typed `TaskPriority`. `dharma_swarm/telic_seam.py` feeds completed outcomes back through `update_opportunity_outcome()`, and `feedback_writer.py` marks successful outcomes as `addressed`.
+- **Verification:** `tests/test_br_closures.py` covers canonical `opportunity_id`, malformed scores, queued-not-addressed refill behavior, queue drain into `TaskBoard`, and metadata preservation. `tests/test_feedback_writer.py` verifies successful outcomes clear `queued` and set `addressed`, while failed outcomes clear `queued` without marking addressed.
 
 ### BR-007 (CLOSED 2026-05-10 via PR #187) — runtime.db and ontology.db sync
 - **Closing evidence:** `dharma_swarm/swarm.py:3061` now writes `_record_memory_fact()` to `self.state_dir / "state" / "runtime.db"`, matching the live runtime path. `dharma_swarm/engine/store_sync.py` materializes ontology `Outcome` objects as runtime `artifact_records` with `artifact_id = f"ont-{outcome.id}"`; sync is idempotent through the runtime primary key and explicit existing-row check. `dharma_swarm/cron_runner.py:577-596` exposes the `store_sync` handler, `cron_jobs.json` registers the enabled `store_sync` interval job, and `dharma_swarm/orchestrate_live.py:1732-1738` runs sync from the room-health loop under a guard.
@@ -230,7 +223,7 @@
 - **Closing evidence:** Backed up plist to `~/.dharma/audit/_backup_com.dharma.cron-daemon.plist.2026-05-07`. Used `plutil -replace ProgramArguments` to update `~/Library/LaunchAgents/com.dharma.cron-daemon.plist` from `/opt/homebrew/bin/dgc cron daemon` to `/Users/dhyana/dharma_swarm_lf5/.venv/bin/dgc cron daemon`. `launchctl bootout gui/501/com.dharma.cron-daemon && launchctl bootstrap gui/501 ~/Library/LaunchAgents/com.dharma.cron-daemon.plist` reloaded the daemon. Verified: old PID 10579 gone; new PID 14989 running with `/Users/dhyana/dharma_swarm_lf5/.venv/bin/dgc cron daemon`; `launchctl print gui/501/com.dharma.cron-daemon` reports state=running, `last exit code = (never exited)`, program = lf5-venv binary.
 - **Verified `dgc cron daemon` is valid on lf5-venv:** `dgc cron --help` lists `{add,list,remove,tick,daemon}` subcommands.
 - **Dependency note:** metabolic clock now pinned to `dharma_swarm_lf5` worktree. If lf5 is deleted, the daemon breaks. This dependency is intentional per user decision (smallest change, least risk path).
-- **Likely auto-resolves:** BR-006 (recognition_seed stale) within 24-48h once metabolic clock fires regeneration. May also un-stick BR-005 (algedonic degenerate steady-state) if consumer was waiting on the daemon.
+- **Follow-up verification:** BR-006 did later close after recognition seed regeneration; BR-005 narrowed but did not fully close because signal consumption remains uneven.
 - **Convergence pass action 7.**
 
 ### BR-019 (CLOSED 2026-05-07) — Coherence Delta gate enforced honor-system only

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,11 +25,12 @@ dependencies = [
     "uvicorn>=0.24",
     "numpy>=1.24",
     "pyyaml>=6.0",
+    "croniter>=2.0",
 ]
 
 [project.optional-dependencies]
 mcp = ["mcp>=1.0"]
-dev = ["pytest>=7.0", "pytest-asyncio>=0.21", "pytest-cov>=4.0"]
+dev = ["pytest>=7.0", "pytest-asyncio>=0.21", "pytest-cov>=4.0", "pytest-timeout>=2.3"]
 router = ["fasttext-wheel>=0.9.2", "redis>=5.0.0"]
 infra = [
     "langgraph>=0.2.0",

--- a/reports/system_map/latest.json
+++ b/reports/system_map/latest.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-07T13:30:02.701537+00:00",
+  "generated_at": "2026-05-11T07:22:39.806082+00:00",
   "organs": [
     {
       "actual_runtime_primitive": "no AgentOps reports loaded",
@@ -14,7 +14,7 @@
         "kaizen_review"
       ],
       "gates_enforced": [],
-      "last_observed": "2026-05-07T13:30:02.706637+00:00",
+      "last_observed": "2026-05-11T07:22:39.807002+00:00",
       "merged_to_main": "UNKNOWN",
       "name": "agentops",
       "next_bindable_gap": "run one bounded AgentOps packet and load its report.json",
@@ -42,17 +42,17 @@
         "/Users/dhyana/.dharma/audit/48h_status_2026-05-07.md:286",
         "/Users/dhyana/.dharma/audit/48h_status_2026-05-07.md:302",
         "/Users/dhyana/.dharma/audit/48h_status_2026-05-07.md:333",
-        "/Users/dhyana/.dharma/audit/central_loop_trace_2026-05-07.md:17",
-        "/Users/dhyana/.dharma/audit/central_loop_trace_2026-05-07.md:24",
-        "/Users/dhyana/.dharma/audit/central_loop_trace_2026-05-07.md:29",
-        "/Users/dhyana/.dharma/audit/central_loop_trace_2026-05-07.md:30",
-        "/Users/dhyana/.dharma/audit/central_loop_trace_2026-05-07.md:31",
-        "/Users/dhyana/.dharma/audit/central_loop_trace_2026-05-07.md:43",
-        "/Users/dhyana/.dharma/audit/central_loop_trace_2026-05-07.md:46"
+        "/Users/dhyana/.dharma/audit/agentic_coordination_deep_scan_2026-05-08.md:11",
+        "/Users/dhyana/.dharma/audit/agentic_coordination_deep_scan_2026-05-08.md:36",
+        "/Users/dhyana/.dharma/audit/agentic_coordination_deep_scan_2026-05-08.md:40",
+        "/Users/dhyana/.dharma/audit/agentic_coordination_deep_scan_2026-05-08.md:52",
+        "/Users/dhyana/.dharma/audit/agentic_coordination_deep_scan_2026-05-08.md:91",
+        "/Users/dhyana/.dharma/audit/agentic_coordination_deep_scan_2026-05-08.md:93",
+        "/Users/dhyana/.dharma/audit/agentic_coordination_deep_scan_2026-05-08.md:98"
       ],
       "gates_declared": [],
       "gates_enforced": [],
-      "last_observed": "2026-05-07T13:30:02.701537+00:00",
+      "last_observed": "2026-05-11T07:22:39.806082+00:00",
       "merged_to_main": "UNKNOWN",
       "name": "algedonic_stream",
       "next_bindable_gap": "show which runtime path consumes the latest algedonic value",
@@ -90,7 +90,7 @@
         "telic_value"
       ],
       "gates_enforced": [],
-      "last_observed": "2026-05-07T13:30:02.706668+00:00",
+      "last_observed": "2026-05-11T07:22:39.807034+00:00",
       "merged_to_main": "UNKNOWN",
       "name": "burn_cost",
       "next_bindable_gap": "load a cost report before scaling more agent execution",
@@ -116,21 +116,21 @@
       "drift": "loop edges can be documented without a complete observed chain",
       "evidence_refs": [
         "/Users/dhyana/.dharma/audit/48h_status_2026-05-07.md:248",
+        "/Users/dhyana/.dharma/audit/agentic_coordination_deep_scan_2026-05-08.md:27",
+        "/Users/dhyana/.dharma/audit/agentic_coordination_deep_scan_2026-05-08.md:37",
+        "/Users/dhyana/.dharma/audit/agentic_coordination_deep_scan_2026-05-08.md:61",
+        "/Users/dhyana/.dharma/audit/agentic_coordination_deep_scan_2026-05-08.md:301",
+        "/Users/dhyana/.dharma/audit/agentic_coordination_deep_scan_2026-05-08.md:306",
+        "/Users/dhyana/.dharma/audit/agentic_coordination_deep_scan_2026-05-08.md:352",
         "/Users/dhyana/.dharma/audit/central_loop_trace_2026-05-07.md:1",
         "/Users/dhyana/.dharma/audit/central_loop_trace_2026-05-07.md:13",
         "/Users/dhyana/.dharma/audit/central_loop_trace_2026-05-07.md:15",
         "/Users/dhyana/.dharma/audit/central_loop_trace_2026-05-07.md:27",
-        "/Users/dhyana/.dharma/audit/central_loop_trace_2026-05-07.md:28",
-        "/Users/dhyana/.dharma/audit/central_loop_trace_2026-05-07.md:40",
-        "/Users/dhyana/.dharma/audit/central_loop_trace_2026-05-07.md:41",
-        "/Users/dhyana/.dharma/audit/central_loop_trace_2026-05-07.md:43",
-        "/Users/dhyana/.dharma/audit/central_loop_trace_2026-05-07.md:53",
-        "/Users/dhyana/.dharma/audit/repo_hot_items_scratchpad_2026-05-07.md:16",
-        "/Users/dhyana/.dharma/audit/repo_hot_items_scratchpad_2026-05-07.md:31"
+        "/Users/dhyana/.dharma/audit/central_loop_trace_2026-05-07.md:28"
       ],
       "gates_declared": [],
       "gates_enforced": [],
-      "last_observed": "2026-05-07T13:30:02.701537+00:00",
+      "last_observed": "2026-05-11T07:22:39.806082+00:00",
       "merged_to_main": "UNKNOWN",
       "name": "central_loop",
       "next_bindable_gap": "prove one proposal-to-value chain with file evidence",
@@ -145,9 +145,9 @@
       ],
       "source_stores": [
         "/Users/dhyana/.dharma/audit/48h_status_2026-05-07.md",
-        "/Users/dhyana/.dharma/audit/central_loop_trace_2026-05-07.md",
-        "/Users/dhyana/.dharma/audit/central_loop_trace_2026-05-07.md",
-        "/Users/dhyana/.dharma/audit/central_loop_trace_2026-05-07.md"
+        "/Users/dhyana/.dharma/audit/agentic_coordination_deep_scan_2026-05-08.md",
+        "/Users/dhyana/.dharma/audit/agentic_coordination_deep_scan_2026-05-08.md",
+        "/Users/dhyana/.dharma/audit/agentic_coordination_deep_scan_2026-05-08.md"
       ],
       "witness_writes": [
         "reports/system_map/latest.json"
@@ -168,7 +168,7 @@
         "telic_value"
       ],
       "gates_enforced": [],
-      "last_observed": "2026-05-07T13:30:02.706682+00:00",
+      "last_observed": "2026-05-11T07:22:39.807053+00:00",
       "merged_to_main": "UNKNOWN",
       "name": "command_spine",
       "next_bindable_gap": "run the drafted packet through AgentOps and reload facts",
@@ -209,7 +209,7 @@
         "telic_value"
       ],
       "gates_enforced": [],
-      "last_observed": "2026-05-07T13:30:02.706678+00:00",
+      "last_observed": "2026-05-11T07:22:39.807047+00:00",
       "merged_to_main": "UNKNOWN",
       "name": "daily_operating_brief",
       "next_bindable_gap": "feed at least one operating fact source into the brief builder",
@@ -248,7 +248,7 @@
         "daily_operating_brief"
       ],
       "gates_enforced": [],
-      "last_observed": "2026-05-07T13:30:02.706663+00:00",
+      "last_observed": "2026-05-11T07:22:39.807027+00:00",
       "merged_to_main": "UNKNOWN",
       "name": "human_yds",
       "next_bindable_gap": "record one human-authoritative YDS rating for the latest useful artifact",
@@ -281,7 +281,7 @@
         "daily_operating_brief"
       ],
       "gates_enforced": [],
-      "last_observed": "2026-05-07T13:30:02.706656+00:00",
+      "last_observed": "2026-05-11T07:22:39.807018+00:00",
       "merged_to_main": "UNKNOWN",
       "name": "kaizen_review",
       "next_bindable_gap": "run KaizenReview from a completed AgentOps report",
@@ -324,7 +324,7 @@
       ],
       "gates_declared": [],
       "gates_enforced": [],
-      "last_observed": "2026-05-07T13:30:02.701537+00:00",
+      "last_observed": "2026-05-11T07:22:39.806082+00:00",
       "merged_to_main": "UNKNOWN",
       "name": "metabolic_clock",
       "next_bindable_gap": "bind one canonical clock doc to live jobs.json and installed dgc command surface",
@@ -354,22 +354,22 @@
       "declared_state": "owns cold-start reading order and megafile map",
       "drift": "onboarding files can exist without becoming the path an agent actually follows",
       "evidence_refs": [
-        "/Users/dhyana/.dharma/audit/phase_0_1_backlog_2026-05-07.md:10",
-        "/Users/dhyana/.dharma/audit/phase_0_1_completion_2026-05-07.md:10",
-        "/Users/dhyana/.dharma/audit/phase_0_1_completion_2026-05-07.md:11",
-        "/Users/dhyana/.dharma/audit/phase_0_1_completion_2026-05-07.md:42",
-        "/Users/dhyana/.dharma/audit/phase_0_verification_2026-05-07.md:61",
-        "/Users/dhyana/.dharma/audit/phase_0_verification_2026-05-07.md:65",
-        "/Users/dhyana/.dharma/audit/phase_0_verification_2026-05-07.md:66",
-        "/Users/dhyana/.dharma/audit/phase_0_verification_2026-05-07.md:67",
-        "/Users/dhyana/.dharma/audit/phase_0_verification_2026-05-07.md:71",
-        "/Users/dhyana/.dharma/audit/phase_0_verification_2026-05-07.md:72",
-        "/Users/dhyana/.dharma/audit/phase_0_verification_2026-05-07.md:79",
-        "/Users/dhyana/.dharma/audit/phase_0_verification_2026-05-07.md:113"
+        "/Users/dhyana/.dharma/audit/jagat_kalyan_hierarchy_seeds_2026-05-08.md:73",
+        "/Users/dhyana/.dharma/audit/phase5_1_internal_inventory_2026-05-08.md:58",
+        "/Users/dhyana/.dharma/audit/phase5_1_internal_inventory_2026-05-08.md:63",
+        "/Users/dhyana/.dharma/audit/phase5_1_internal_inventory_2026-05-08.md:92",
+        "/Users/dhyana/.dharma/audit/phase5_1_internal_inventory_2026-05-08.md:119",
+        "/Users/dhyana/.dharma/audit/phase5_2_internal_gaps_2026-05-08.md:11",
+        "/Users/dhyana/.dharma/audit/phase5_2_internal_gaps_2026-05-08.md:15",
+        "/Users/dhyana/.dharma/audit/phase5_2_internal_gaps_2026-05-08.md:48",
+        "/Users/dhyana/.dharma/audit/phase5_2_internal_gaps_2026-05-08.md:78",
+        "/Users/dhyana/.dharma/audit/phase5_2_internal_gaps_2026-05-08.md:107",
+        "/Users/dhyana/.dharma/audit/phase5_2_internal_gaps_2026-05-08.md:110",
+        "/Users/dhyana/.dharma/audit/phase5_2_internal_gaps_2026-05-08.md:158"
       ],
       "gates_declared": [],
       "gates_enforced": [],
-      "last_observed": "2026-05-07T13:30:02.701537+00:00",
+      "last_observed": "2026-05-11T07:22:39.806082+00:00",
       "merged_to_main": "UNKNOWN",
       "name": "onboarding_spine",
       "next_bindable_gap": "keep the megafile survey tied to the first file an agent loads",
@@ -383,10 +383,10 @@
         "reports/system_map/latest.json"
       ],
       "source_stores": [
-        "/Users/dhyana/.dharma/audit/phase_0_1_backlog_2026-05-07.md",
-        "/Users/dhyana/.dharma/audit/phase_0_1_completion_2026-05-07.md",
-        "/Users/dhyana/.dharma/audit/phase_0_1_completion_2026-05-07.md",
-        "/Users/dhyana/.dharma/audit/phase_0_1_completion_2026-05-07.md"
+        "/Users/dhyana/.dharma/audit/jagat_kalyan_hierarchy_seeds_2026-05-08.md",
+        "/Users/dhyana/.dharma/audit/phase5_1_internal_inventory_2026-05-08.md",
+        "/Users/dhyana/.dharma/audit/phase5_1_internal_inventory_2026-05-08.md",
+        "/Users/dhyana/.dharma/audit/phase5_1_internal_inventory_2026-05-08.md"
       ],
       "witness_writes": [
         "reports/system_map/latest.json"
@@ -408,13 +408,13 @@
         "/Users/dhyana/.dharma/audit/48h_status_2026-05-07.md:212",
         "/Users/dhyana/.dharma/audit/48h_status_2026-05-07.md:341",
         "/Users/dhyana/.dharma/audit/48h_status_2026-05-07.md:358",
-        "/Users/dhyana/.dharma/audit/central_loop_trace_2026-05-07.md:24",
-        "/Users/dhyana/.dharma/audit/phase_0_1_backlog_2026-05-07.md:9",
-        "/Users/dhyana/.dharma/audit/repo_hot_items_scratchpad_2026-05-07.md:37"
+        "/Users/dhyana/.dharma/audit/agentic_coordination_deep_scan_2026-05-08.md:36",
+        "/Users/dhyana/.dharma/audit/agentic_coordination_deep_scan_2026-05-08.md:87",
+        "/Users/dhyana/.dharma/audit/agentic_coordination_deep_scan_2026-05-08.md:88"
       ],
       "gates_declared": [],
       "gates_enforced": [],
-      "last_observed": "2026-05-07T13:30:02.701537+00:00",
+      "last_observed": "2026-05-11T07:22:39.806082+00:00",
       "merged_to_main": "UNKNOWN",
       "name": "recognition_seed",
       "next_bindable_gap": "trace one recognized drift into a runtime decision",
@@ -452,7 +452,7 @@
         "telic_value"
       ],
       "gates_enforced": [],
-      "last_observed": "2026-05-07T13:30:02.706673+00:00",
+      "last_observed": "2026-05-11T07:22:39.807040+00:00",
       "merged_to_main": "UNKNOWN",
       "name": "revenue",
       "next_bindable_gap": "bind one revenue or product-wedge note to the operating brief inputs",
@@ -492,7 +492,7 @@
       ],
       "gates_declared": [],
       "gates_enforced": [],
-      "last_observed": "2026-05-07T13:30:02.701537+00:00",
+      "last_observed": "2026-05-11T07:22:39.806082+00:00",
       "merged_to_main": "UNKNOWN",
       "name": "self_evolution",
       "next_bindable_gap": "summarize latest accepted/rejected changes as operating facts",
@@ -530,7 +530,7 @@
         "daily_operating_brief"
       ],
       "gates_enforced": [],
-      "last_observed": "2026-05-07T13:30:02.706686+00:00",
+      "last_observed": "2026-05-11T07:22:39.807059+00:00",
       "merged_to_main": "UNKNOWN",
       "name": "telic_value",
       "next_bindable_gap": "add a read-only Telic value fact adapter before using value as map authority",
@@ -557,16 +557,22 @@
       "declared_state": "owns declared-vs-actual operating fact projection",
       "drift": "declared organs remain advisory until observed facts are loaded",
       "evidence_refs": [
+        "/Users/dhyana/.dharma/audit/phase5_1_internal_inventory_2026-05-08.md:59",
+        "/Users/dhyana/.dharma/audit/phase5_2_internal_gaps_2026-05-08.md:44",
+        "/Users/dhyana/.dharma/audit/phase5_synthesis_multi_agent_coordination_2026-05-08.md:30",
+        "/Users/dhyana/.dharma/audit/phase5_synthesis_multi_agent_coordination_2026-05-08.md:44",
+        "/Users/dhyana/.dharma/audit/phase5_synthesis_multi_agent_coordination_2026-05-08.md:150",
+        "/Users/dhyana/.dharma/audit/phase5_synthesis_multi_agent_coordination_2026-05-08.md:224",
+        "/Users/dhyana/.dharma/audit/phase5_synthesis_multi_agent_coordination_2026-05-08.md:241",
+        "/Users/dhyana/.dharma/audit/phase5_synthesis_multi_agent_coordination_2026-05-08.md:247",
         "/Users/dhyana/.dharma/audit/phase_0_1_completion_2026-05-07.md:16",
+        "/Users/dhyana/.dharma/audit/pr_queue_triage_2026-05-08.md:68",
         "/Users/dhyana/.dharma/audit/triage_plan_2026-05-07.md:25",
-        "/Users/dhyana/.dharma/audit/triage_plan_2026-05-07.md:379",
-        "/Users/dhyana/.dharma/audit/truth_spine_convergence_2026-05-07.md:1",
-        "/Users/dhyana/.dharma/audit/truth_spine_convergence_2026-05-07.md:5",
-        "/Users/dhyana/.dharma/audit/truth_spine_convergence_2026-05-07.md:61"
+        "/Users/dhyana/.dharma/audit/triage_plan_2026-05-07.md:379"
       ],
       "gates_declared": [],
       "gates_enforced": [],
-      "last_observed": "2026-05-07T13:30:02.701537+00:00",
+      "last_observed": "2026-05-11T07:22:39.806082+00:00",
       "merged_to_main": "UNKNOWN",
       "name": "truth_spine",
       "next_bindable_gap": "load current organ facts into reports/system_map/latest.json",
@@ -580,10 +586,10 @@
         "reports/system_map/latest.json"
       ],
       "source_stores": [
-        "/Users/dhyana/.dharma/audit/phase_0_1_completion_2026-05-07.md",
-        "/Users/dhyana/.dharma/audit/triage_plan_2026-05-07.md",
-        "/Users/dhyana/.dharma/audit/triage_plan_2026-05-07.md",
-        "/Users/dhyana/.dharma/audit/truth_spine_convergence_2026-05-07.md"
+        "/Users/dhyana/.dharma/audit/phase5_1_internal_inventory_2026-05-08.md",
+        "/Users/dhyana/.dharma/audit/phase5_2_internal_gaps_2026-05-08.md",
+        "/Users/dhyana/.dharma/audit/phase5_synthesis_multi_agent_coordination_2026-05-08.md",
+        "/Users/dhyana/.dharma/audit/phase5_synthesis_multi_agent_coordination_2026-05-08.md"
       ],
       "witness_writes": [
         "reports/system_map/latest.json"
@@ -593,10 +599,21 @@
   "schema_version": "system_map.v0",
   "sources": [
     "/Users/dhyana/.dharma/audit/48h_status_2026-05-07.md",
+    "/Users/dhyana/.dharma/audit/agentic_coordination_deep_scan_2026-05-08.md",
     "/Users/dhyana/.dharma/audit/central_loop_trace_2026-05-07.md",
+    "/Users/dhyana/.dharma/audit/jagat_kalyan_hierarchy_seeds_2026-05-08.md",
+    "/Users/dhyana/.dharma/audit/phase5_1_internal_inventory_2026-05-08.md",
+    "/Users/dhyana/.dharma/audit/phase5_2_internal_gaps_2026-05-08.md",
+    "/Users/dhyana/.dharma/audit/phase5_3_world_frontier_2026-05-08.md",
+    "/Users/dhyana/.dharma/audit/phase5_4_beyond_python_2026-05-08.md",
+    "/Users/dhyana/.dharma/audit/phase5_5_agentic_pain_frontier_2026-05-08.md",
+    "/Users/dhyana/.dharma/audit/phase5_6_adversarial_2026-05-08.md",
+    "/Users/dhyana/.dharma/audit/phase5_synthesis_multi_agent_coordination_2026-05-08.md",
     "/Users/dhyana/.dharma/audit/phase_0_1_backlog_2026-05-07.md",
     "/Users/dhyana/.dharma/audit/phase_0_1_completion_2026-05-07.md",
     "/Users/dhyana/.dharma/audit/phase_0_verification_2026-05-07.md",
+    "/Users/dhyana/.dharma/audit/pr_queue_triage_2026-05-08.md",
+    "/Users/dhyana/.dharma/audit/relationship_surface_2026-05-07.md",
     "/Users/dhyana/.dharma/audit/repo_hot_items_scratchpad_2026-05-07.md",
     "/Users/dhyana/.dharma/audit/self_evolution_trace_2026-05-07.md",
     "/Users/dhyana/.dharma/audit/system_inventory_2026-05-07.md",
@@ -612,6 +629,8 @@
     "/Users/dhyana/.dharma/audit/ten_megafiles_q5_2026-05-07.md",
     "/Users/dhyana/.dharma/audit/ten_megafiles_q6_2026-05-07.md",
     "/Users/dhyana/.dharma/audit/ten_megafiles_survey_2026-05-07.md",
+    "/Users/dhyana/.dharma/audit/track1_handoff_2026-05-08.md",
+    "/Users/dhyana/.dharma/audit/tracks_1_5_integration_readiness_2026-05-09.md",
     "/Users/dhyana/.dharma/audit/triage_executed_2026-05-07.md",
     "/Users/dhyana/.dharma/audit/triage_plan_2026-05-07.md",
     "/Users/dhyana/.dharma/audit/truth_spine_convergence_2026-05-07.md"

--- a/tests/test_br_closures.py
+++ b/tests/test_br_closures.py
@@ -52,7 +52,7 @@ class TestFrontierRefill:
             top_k=2, board_path=board_path, frontier_path=frontier_path,
         )
         assert result.board_count == 4
-        assert result.addressed_count == 2
+        assert result.queued_count == 2
         assert result.appended_rows == 2 * len(OPPORTUNITY_STAGES)
         assert set(result.appended_opportunity_ids) == {"opp-1", "opp-2"}
 
@@ -86,9 +86,24 @@ class TestFrontierRefill:
         result = refill_frontier_tasks_pending(
             board_path=board_path, frontier_path=frontier_path,
         )
-        assert result.addressed_count == 1
+        assert result.queued_count == 1
         assert "opp-2" in result.appended_opportunity_ids
         assert "opp-1" not in result.appended_opportunity_ids
+
+    def test_refill_skips_already_queued(self, tmp_path: Path) -> None:
+        from dharma_swarm.opportunity_refill import refill_frontier_tasks_pending
+
+        board_path = tmp_path / "board.json"
+        frontier_path = tmp_path / "frontier.jsonl"
+        self._write_board(board_path, [
+            {"id": "opp-1", "title": "Queued", "final_score": 90, "queued": True},
+            {"id": "opp-2", "title": "Pending", "final_score": 80},
+        ])
+        result = refill_frontier_tasks_pending(
+            board_path=board_path, frontier_path=frontier_path,
+        )
+        assert result.queued_count == 1
+        assert result.appended_opportunity_ids == ["opp-2"]
 
     def test_refill_dry_run(self, tmp_path: Path) -> None:
         from dharma_swarm.opportunity_refill import refill_frontier_tasks_pending
@@ -104,7 +119,7 @@ class TestFrontierRefill:
         assert result.appended_rows > 0
         assert not frontier_path.exists()
 
-    def test_refill_marks_addressed(self, tmp_path: Path) -> None:
+    def test_refill_marks_queued_until_outcome_feedback(self, tmp_path: Path) -> None:
         from dharma_swarm.opportunity_refill import refill_frontier_tasks_pending
 
         board_path = tmp_path / "board.json"
@@ -116,7 +131,9 @@ class TestFrontierRefill:
             board_path=board_path, frontier_path=frontier_path,
         )
         updated_board = json.loads(board_path.read_text())
-        assert updated_board[0]["addressed"] is True
+        assert updated_board[0]["queued"] is True
+        assert "queued_at" in updated_board[0]
+        assert "addressed" not in updated_board[0]
 
     def test_refill_respects_min_telos(self, tmp_path: Path) -> None:
         from dharma_swarm.opportunity_refill import refill_frontier_tasks_pending
@@ -132,7 +149,7 @@ class TestFrontierRefill:
             board_path=board_path,
             frontier_path=frontier_path,
         )
-        assert result.addressed_count == 1
+        assert result.queued_count == 1
         assert "opp-2" in result.appended_opportunity_ids
 
     def test_refill_ignores_malformed_scores(self, tmp_path: Path) -> None:
@@ -148,7 +165,7 @@ class TestFrontierRefill:
             board_path=board_path,
             frontier_path=frontier_path,
         )
-        assert result.addressed_count == 1
+        assert result.queued_count == 1
         assert result.appended_opportunity_ids == ["good"]
 
     async def test_drain_frontier_queue_creates_taskboard_entries(

--- a/tests/test_evolution.py
+++ b/tests/test_evolution.py
@@ -15,6 +15,7 @@ from dharma_swarm.evolution import (
     EvolutionPlan,
     EvolutionStatus,
     Proposal,
+    _paths_from_unified_diff,
 )
 from dharma_swarm.landscape import BasinType, LandscapeProbe
 from dharma_swarm.meta_evolution import MetaParameters
@@ -83,6 +84,25 @@ _THINK_NOTES_HARMFUL = (
     "Alternatives: selective cleanup. "
     "Expected: free disk space."
 )
+
+
+def test_paths_from_unified_diff_filters_to_explicit_repo_paths() -> None:
+    diff = """diff --git a/dharma_swarm/a.py b/dharma_swarm/a.py
+--- a/dharma_swarm/a.py
++++ b/dharma_swarm/a.py
+@@ -1 +1 @@
+-old
++new
+--- /dev/null
++++ b/tests/test_a.py
+--- a/../secret.txt
++++ b/../secret.txt
+"""
+
+    assert _paths_from_unified_diff(diff) == [
+        "dharma_swarm/a.py",
+        "tests/test_a.py",
+    ]
 
 _THINK_NOTES_REVIEW = (
     "Risk: moderate — force override bypasses normal flow. "

--- a/tests/test_feedback_writer.py
+++ b/tests/test_feedback_writer.py
@@ -39,7 +39,7 @@ def _outcome(**kwargs) -> OutcomeRecord:
 def test_appends_outcome_to_matching_opportunity(tmp_path: Path):
     board = _board(
         tmp_path,
-        {"opportunity_id": "opp-A", "title": "Reforest"},
+        {"opportunity_id": "opp-A", "title": "Reforest", "queued": True},
         {"opportunity_id": "opp-B", "title": "Compost"},
     )
     out = _outcome(outcome_id="out-1", success=True, fitness_score=0.9)
@@ -55,12 +55,15 @@ def test_appends_outcome_to_matching_opportunity(tmp_path: Path):
     assert a["realized_outcomes"][0]["outcome_id"] == "out-1"
     assert a["realized_outcomes"][0]["success"] is True
     assert a["learned_score_delta"] == 0.9
+    assert a["queued"] is False
+    assert a["addressed"] is True
+    assert a["addressed_at"] == "2023-11-14T22:13:20Z"
     assert "realized_outcomes" not in b
     assert "learned_score_delta" not in b
 
 
 def test_failure_outcome_decreases_score(tmp_path: Path):
-    board = _board(tmp_path, {"opportunity_id": "opp-A"})
+    board = _board(tmp_path, {"opportunity_id": "opp-A", "queued": True})
     out = _outcome(outcome_id="out-fail", success=False, fitness_score=0.0)
 
     ok = update_opportunity_outcome("opp-A", out, board_path=board)
@@ -69,6 +72,9 @@ def test_failure_outcome_decreases_score(tmp_path: Path):
     rows = json.loads(board.read_text())
     assert rows[0]["learned_score_delta"] == -0.5
     assert rows[0]["realized_outcomes"][0]["success"] is False
+    assert rows[0]["queued"] is False
+    assert "addressed" not in rows[0]
+    assert rows[0]["last_failed_outcome_at"] == "2023-11-14T22:13:20Z"
 
 
 def test_idempotent_on_duplicate_outcome_id(tmp_path: Path):

--- a/tests/test_guardian_crew.py
+++ b/tests/test_guardian_crew.py
@@ -7,7 +7,13 @@ from pathlib import Path
 
 import pytest
 
-from dharma_swarm.guardian_crew import run_guardian_warning_checks, run_ledger_watcher
+from dharma_swarm import guardian_crew
+from dharma_swarm.guardian_crew import (
+    run_auditor,
+    run_guardian_cycle,
+    run_guardian_warning_checks,
+    run_ledger_watcher,
+)
 from dharma_swarm.runtime_state import RuntimeStateStore
 
 
@@ -136,6 +142,77 @@ def _repo_src_root(tmp_path: Path) -> Path:
     src_root.mkdir(parents=True)
     (src_root / "__init__.py").write_text("", encoding="utf-8")
     return src_root
+
+
+def test_github_issue_remote_dedupe_detects_open_issue(monkeypatch: pytest.MonkeyPatch) -> None:
+    class Proc:
+        returncode = 0
+        stdout = '[{"number": 194}]'
+
+    monkeypatch.setattr(guardian_crew.subprocess, "run", lambda *args, **kwargs: Proc())
+
+    assert guardian_crew._github_issue_already_open(
+        "AmitabhainArunachala/dharma_swarm",
+        "[GUARDIAN] File not found for dharma_swarm.evolution",
+    )
+
+
+@pytest.mark.asyncio
+async def test_auditor_resolves_importable_modules_when_src_root_is_stale(tmp_path: Path) -> None:
+    stale_src_root = tmp_path / "missing" / "dharma_swarm"
+
+    findings = await run_auditor(stale_src_root)
+
+    stale_file_titles = {
+        finding.title
+        for finding in findings
+        if finding.check == "AUDITOR:method_exists"
+        and finding.title.startswith("File not found for")
+    }
+    assert "File not found for dharma_swarm.memory_palace" not in stale_file_titles
+    assert "File not found for dharma_swarm.evolution" not in stale_file_titles
+
+
+@pytest.mark.asyncio
+async def test_auditor_scans_nested_python_sources(tmp_path: Path) -> None:
+    src_root = _repo_src_root(tmp_path)
+    nested = src_root / "nested"
+    nested.mkdir()
+    (nested / "__init__.py").write_text("", encoding="utf-8")
+    (nested / "broken.py").write_text("def broken(:\n", encoding="utf-8")
+
+    findings = await run_auditor(src_root)
+
+    syntax_titles = [finding.title for finding in findings if finding.check == "AUDITOR:syntax"]
+    assert "Syntax error: dharma_swarm/nested/broken.py" in syntax_titles
+
+
+@pytest.mark.asyncio
+async def test_guardian_cycle_writes_state_report_not_repo_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    src_root = _repo_src_root(tmp_path)
+    state_dir = tmp_path / ".dharma"
+
+    async def _empty_findings(*args: object, **kwargs: object) -> list[object]:
+        return []
+
+    monkeypatch.setattr(guardian_crew, "run_auditor", _empty_findings)
+    monkeypatch.setattr(guardian_crew, "run_loop_watcher", _empty_findings)
+    monkeypatch.setattr(guardian_crew, "run_router_probe", _empty_findings)
+    monkeypatch.setattr(guardian_crew, "run_ledger_watcher", _empty_findings)
+    monkeypatch.setattr(guardian_crew, "run_guardian_warning_checks", _empty_findings)
+    monkeypatch.setattr(guardian_crew, "run_task_consistency_guard", _empty_findings)
+
+    from dharma_swarm.fractal import room_health
+
+    monkeypatch.setattr(room_health, "run_room_health_watcher", _empty_findings)
+
+    result = await run_guardian_cycle(src_root=src_root, state_dir=state_dir, create_issues=False)
+
+    assert Path(result["report_path"]).exists()
+    assert not (src_root.parent / "GUARDIAN_REPORT.md").exists()
 
 
 @pytest.mark.asyncio

--- a/tests/test_launchd_job_runner.py
+++ b/tests/test_launchd_job_runner.py
@@ -17,7 +17,7 @@ def _configure_runner_paths(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> 
     package_dir = repo_root / "dharma_swarm"
     package_dir.mkdir(parents=True, exist_ok=True)
     monkeypatch.setattr(runner, "__file__", str(package_dir / "launchd_job_runner.py"))
-    monkeypatch.setattr(runner.Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("DHARMA_STATE_DIR", str(tmp_path / ".dharma"))
     return repo_root
 
 

--- a/tests/test_telic_seam.py
+++ b/tests/test_telic_seam.py
@@ -54,6 +54,12 @@ def sample_task():
     )
 
 
+def test_registry_path_alias_constructs_seam(tmp_path):
+    seam = TelicSeam(registry_path=tmp_path / "ontology.db")
+    assert seam._path == tmp_path / "ontology.db"
+    assert seam.lineage.db_path == tmp_path / "ontology.db"
+
+
 @pytest.fixture
 def gate_allow():
     return GateCheckResult(


### PR DESCRIPTION
## Summary
- close BR-002 forward-only gap by marking opportunity rows queued until outcome feedback marks successful rows addressed
- harden Guardian against stale worktree false positives, duplicate issue creation, root report leaks, and nested syntax blind spots
- fix TelicSeam registry_path compatibility, meta-evolution cadence, explicit Darwin staging, cron/state-root drift, and governance docs/system map freshness

## Coherence Delta
- **Organ touched:** Runtime metabolism and governance immune system: opportunity feedback loop, TelicSeam, Guardian Crew, cron/state-root helpers, Darwin auto-commit staging, and the docs/system-map truth surfaces that witness them.
- **Declared-vs-actual gap closed:** Closes the remaining BR-002 forward-only behavior by making refill queue work instead of marking it addressed before execution; narrows the cron split-brain and algedonic register items with current evidence; closes the stale recognition-seed item; resolves MM-07 meta-evolution cadence; makes NEW-09 TelicSeam registry_path compatibility true in code.
- **Proof that re-reads the map:** `tests/test_br_closures.py`, `tests/test_feedback_writer.py`, `tests/test_telic_seam.py`, `tests/test_authority_revenue_loop.py`, `tests/test_guardian_crew.py`, `tests/test_orchestrate_live.py`, and `tests/test_meta_evolution.py` exercise the changed seams; `DocOps`, module budget, test hygiene, and `git diff --check` were run after rebasing on current `origin/main`.
- **New drift introduced:** No new substrate. Known residual drift is documented rather than hidden: cron still needs repo/live job reconciliation, algedonic signals still need explicit consumer policy, and the Bhed Gnan hard-pass remains open because direct `telos_gates.py` mutation is governance-forbidden.

Impact acknowledgment: [impact-checked]

## Verification
- `python -m pytest tests/test_guardian_crew.py tests/test_br_closures.py tests/test_feedback_writer.py tests/test_telic_seam.py tests/test_authority_revenue_loop.py tests/test_evolution.py::test_paths_from_unified_diff_filters_to_explicit_repo_paths tests/test_launchd_job_runner.py tests/test_cron_scheduler.py tests/test_orchestrate_live.py tests/test_meta_evolution.py -q`
- `python scripts/docops/check_docops_integrity.py --changed-from origin/main`
- `python scripts/governance/check_module_budget.py --base-ref origin/main --head-ref HEAD`
- `python scripts/governance/check_test_hygiene.py`
- `git diff --check origin/main..HEAD`
