### PR TITLE
feat(go): add world signal receipt ingestor [impact-checked]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ STATE_DIR    := $(HOME)/.dharma
 GO_EVIDENCE_MODULE := tools/evidence_ingestor_go
 GO_SDK_MODULE := tools/go_sdk
 GO_GITHUB_INGESTOR_MODULE := tools/github_ingestor_go
-GO_MODULES := $(GO_SDK_MODULE) $(GO_EVIDENCE_MODULE) $(GO_GITHUB_INGESTOR_MODULE)
+GO_WORLD_SIGNAL_INGESTOR_MODULE := tools/world_signal_ingestor_go
+GO_MODULES := $(GO_SDK_MODULE) $(GO_EVIDENCE_MODULE) $(GO_GITHUB_INGESTOR_MODULE) $(GO_WORLD_SIGNAL_INGESTOR_MODULE)
 GO_CACHE_DIR ?= /tmp/dharma-swarm-go-build
 GO_MOD_CACHE_DIR ?= /tmp/dharma-swarm-go-mod
 

--- a/tests/fixtures/go_world_signal_ingestor/bad_score.json
+++ b/tests/fixtures/go_world_signal_ingestor/bad_score.json
@@ -1,0 +1,11 @@
+{
+  "correlation_id": "world_corr_bad_score_001",
+  "source": "world_signal",
+  "source_url": "https://example.com/bad-score",
+  "observed_at": "2026-05-12T00:00:00Z",
+  "payload": {
+    "title": "Bad score signal",
+    "category": "model_release",
+    "relevance_score": "high"
+  }
+}

--- a/tests/fixtures/go_world_signal_ingestor/malformed_payload.json
+++ b/tests/fixtures/go_world_signal_ingestor/malformed_payload.json
@@ -1,0 +1,7 @@
+{
+  "correlation_id": "world_corr_malformed_001",
+  "source": "world_signal",
+  "source_url": "https://example.com/malformed",
+  "observed_at": "2026-05-12T00:00:00Z",
+  "payload_text": "{\"title\":\"bad\","
+}

--- a/tests/fixtures/go_world_signal_ingestor/missing_title.json
+++ b/tests/fixtures/go_world_signal_ingestor/missing_title.json
@@ -1,0 +1,10 @@
+{
+  "correlation_id": "world_corr_missing_title_001",
+  "source": "world_signal",
+  "source_url": "https://example.com/missing-title",
+  "observed_at": "2026-05-12T00:00:00Z",
+  "payload": {
+    "category": "model_release",
+    "relevance_score": 0.42
+  }
+}

--- a/tests/fixtures/go_world_signal_ingestor/raw_observation.json
+++ b/tests/fixtures/go_world_signal_ingestor/raw_observation.json
@@ -1,0 +1,16 @@
+{
+  "correlation_id": "world_corr_raw_001",
+  "source": "world_raw_observation",
+  "source_url": "https://example.com/subq",
+  "observed_at": "2026-05-12T00:00:00Z",
+  "payload": {
+    "source_id": "operator_drop",
+    "source_family": "manual",
+    "publisher": "Operator",
+    "title": "SubQ claims subquadratic long-context LLM for coding agents",
+    "description": "SubQ announces a million-token model release with coding-agent positioning.",
+    "published_at": "2026-05-11T20:00:00Z",
+    "keywords": ["subquadratic", "long context", "coding agents"],
+    "scout_version": "world_scout_go.v0"
+  }
+}

--- a/tests/fixtures/go_world_signal_ingestor/scout_health.json
+++ b/tests/fixtures/go_world_signal_ingestor/scout_health.json
@@ -1,0 +1,14 @@
+{
+  "correlation_id": "world_corr_health_001",
+  "source": "world_scout_health",
+  "source_url": "file://world-scout-health",
+  "observed_at": "2026-05-12T00:00:00Z",
+  "payload": {
+    "source_count": 19,
+    "reachable_count": 17,
+    "item_count": 83,
+    "timeout_ms": 750,
+    "max_body_bytes": 1048576,
+    "fetch_enabled": false
+  }
+}

--- a/tests/fixtures/go_world_signal_ingestor/unsupported_event.json
+++ b/tests/fixtures/go_world_signal_ingestor/unsupported_event.json
@@ -1,0 +1,9 @@
+{
+  "correlation_id": "world_corr_unsupported_001",
+  "source": "world_strategy_decision",
+  "source_url": "https://example.com/unsupported",
+  "observed_at": "2026-05-12T00:00:00Z",
+  "payload": {
+    "title": "Unsupported decision payload"
+  }
+}

--- a/tests/fixtures/go_world_signal_ingestor/world_signal.json
+++ b/tests/fixtures/go_world_signal_ingestor/world_signal.json
@@ -1,0 +1,30 @@
+{
+  "correlation_id": "world_corr_signal_001",
+  "source": "world_signal",
+  "source_url": "https://example.com/subq",
+  "observed_at": "2026-05-12T00:00:00Z",
+  "payload": {
+    "raw_observation_event_uid": "evt_raw_subq",
+    "title": "SubQ claims subquadratic long-context LLM for coding agents",
+    "category": "model_release",
+    "relevance_score": 0.91,
+    "matched_terms": ["subquadratic", "long context", "coding agent"],
+    "keywords": ["subquadratic", "long context", "coding agents"],
+    "first_principles_questions": [
+      "What capability curve is moving?",
+      "What can be verified independently within one day?"
+    ],
+    "iteration_steps": [
+      "Capture source and provenance.",
+      "Verify claims against primary evidence."
+    ],
+    "adjacent_search_queries": [
+      "SubQ competitors alternatives",
+      "subquadratic long context papers"
+    ],
+    "strategic_moves": ["claim_verification", "teardown"],
+    "human_review_required": true,
+    "raw_signal_not_final_judgment": true,
+    "radar_version": "world_radar_go.v0"
+  }
+}

--- a/tools/world_signal_ingestor_go/adapter.go
+++ b/tools/world_signal_ingestor_go/adapter.go
@@ -1,0 +1,134 @@
+// Package world_signal_ingestor_go adapts outside-world observations into
+// canonical Go evidence receipts.
+//
+// Boundary: this adapter validates and receipts world-signal payloads only.
+// It does not fetch live sources, decide strategy, dispatch agents, write
+// runtime DB, write ontology DB, or call Python policy. Python consumers may
+// project accepted receipts into Zeitgeist/Shakti surfaces.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/AmitabhainArunachala/dharma_swarm/tools/go_sdk/adaptercontract"
+	"github.com/AmitabhainArunachala/dharma_swarm/tools/go_sdk/receipt"
+)
+
+// WorldEventType is the discriminator carried in the fixture source field.
+type WorldEventType string
+
+const (
+	EventWorldRawObservation WorldEventType = "world_raw_observation"
+	EventWorldSignal         WorldEventType = "world_signal"
+	EventWorldScoutHealth    WorldEventType = "world_scout_health"
+)
+
+// requiredFields maps each supported world event to JSON fields that must be
+// present in the fixture payload. Order is canonical for deterministic reject
+// reasons.
+var requiredFields = map[WorldEventType][]string{
+	EventWorldRawObservation: {"title"},
+	EventWorldSignal:         {"title", "category", "relevance_score"},
+	EventWorldScoutHealth:    {"source_count", "reachable_count", "item_count"},
+}
+
+// Adapter validates world-signal fixtures and emits accepted/rejected receipts.
+// The zero value is usable.
+type Adapter struct{}
+
+// Adapt routes a fixture through per-event-type validation and returns either
+// an accepted Receipt or a rejected Receipt plus RejectError.
+func (Adapter) Adapt(_ context.Context, fixture adaptercontract.Fixture) (adaptercontract.Receipt, error) {
+	eventType := WorldEventType(fixture.Source)
+	required, ok := requiredFields[eventType]
+	if !ok {
+		reason := fmt.Sprintf("unsupported_event_type:%s", fixture.Source)
+		return rejectedReceipt(fixture, reason)
+	}
+
+	payload, err := decodePayload(fixture.Payload)
+	if err != nil {
+		return rejectedReceipt(fixture, "malformed_json")
+	}
+
+	if missing := missingRequiredFields(payload, required); len(missing) > 0 {
+		reason := "missing_required_fields:" + strings.Join(missing, ",")
+		return rejectedReceipt(fixture, reason)
+	}
+
+	if eventType == EventWorldSignal && !isNumber(payload["relevance_score"]) {
+		return rejectedReceipt(fixture, "invalid_field_type:relevance_score")
+	}
+
+	return receipt.Build(adaptercontract.BuildSpec(fixture), []byte(fixture.Payload))
+}
+
+// SupportedEventTypes returns the canonical sorted list of source strings the
+// adapter accepts.
+func SupportedEventTypes() []WorldEventType {
+	out := make([]WorldEventType, 0, len(requiredFields))
+	for k := range requiredFields {
+		out = append(out, k)
+	}
+	sort.Slice(out, func(i, j int) bool { return string(out[i]) < string(out[j]) })
+	return out
+}
+
+// RequiredFields returns a defensive copy of required fields for an event type.
+func RequiredFields(eventType WorldEventType) ([]string, bool) {
+	required, ok := requiredFields[eventType]
+	if !ok {
+		return nil, false
+	}
+	out := make([]string, len(required))
+	copy(out, required)
+	return out, true
+}
+
+func decodePayload(raw json.RawMessage) (map[string]any, error) {
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, err
+	}
+	if out == nil {
+		return nil, fmt.Errorf("payload is null")
+	}
+	return out, nil
+}
+
+func missingRequiredFields(payload map[string]any, required []string) []string {
+	var missing []string
+	for _, field := range required {
+		value, ok := payload[field]
+		if !ok || isBlankString(value) {
+			missing = append(missing, field)
+		}
+	}
+	return missing
+}
+
+func isBlankString(value any) bool {
+	text, ok := value.(string)
+	return ok && strings.TrimSpace(text) == ""
+}
+
+func isNumber(value any) bool {
+	switch value.(type) {
+	case float64, float32, int, int64, int32:
+		return true
+	default:
+		return false
+	}
+}
+
+func rejectedReceipt(fixture adaptercontract.Fixture, reason string) (adaptercontract.Receipt, error) {
+	rejected, err := receipt.Reject(adaptercontract.BuildSpec(fixture), []byte(fixture.Payload), reason)
+	if err != nil {
+		return adaptercontract.Receipt{}, err
+	}
+	return rejected, adaptercontract.RejectError{Reason: reason}
+}

--- a/tools/world_signal_ingestor_go/adapter_test.go
+++ b/tools/world_signal_ingestor_go/adapter_test.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/AmitabhainArunachala/dharma_swarm/tools/go_sdk/adaptercontract"
+)
+
+// fixturePath resolves a fixture file in the shared tests/fixtures tree.
+func fixturePath(name string) string {
+	return filepath.Join("..", "..", "tests", "fixtures", "go_world_signal_ingestor", name)
+}
+
+func loadFixture(t *testing.T, name string) adaptercontract.Fixture {
+	t.Helper()
+	f, err := adaptercontract.LoadFixture(fixturePath(name))
+	if err != nil {
+		t.Fatalf("load fixture %s: %v", name, err)
+	}
+	return f
+}
+
+func loadMalformedFixture(t *testing.T, name string) adaptercontract.Fixture {
+	t.Helper()
+	raw, err := os.ReadFile(fixturePath(name))
+	if err != nil {
+		t.Fatalf("read malformed fixture %s: %v", name, err)
+	}
+	var file struct {
+		CorrelationID string `json:"correlation_id"`
+		Source        string `json:"source"`
+		SourceURL     string `json:"source_url"`
+		ObservedAt    string `json:"observed_at"`
+		PayloadText   string `json:"payload_text"`
+	}
+	if err := json.Unmarshal(raw, &file); err != nil {
+		t.Fatalf("decode malformed fixture %s: %v", name, err)
+	}
+	return adaptercontract.Fixture{
+		CorrelationID: file.CorrelationID,
+		Source:        file.Source,
+		SourceURL:     file.SourceURL,
+		ObservedAt:    file.ObservedAt,
+		Payload:       json.RawMessage(file.PayloadText),
+	}
+}
+
+func TestAdapterAcceptsSupportedWorldEvents(t *testing.T) {
+	cases := []struct {
+		name    string
+		fixture string
+	}{
+		{"raw_observation", "raw_observation.json"},
+		{"world_signal", "world_signal.json"},
+		{"scout_health", "scout_health.json"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := loadFixture(t, tc.fixture)
+			r, err := Adapter{}.Adapt(context.Background(), fixture)
+			if err != nil {
+				t.Fatalf("Adapt returned error for valid %s fixture: %v", tc.name, err)
+			}
+			if err := adaptercontract.ValidateAccepted(fixture, r); err != nil {
+				t.Fatalf("ValidateAccepted failed for %s: %v", tc.name, err)
+			}
+		})
+	}
+}
+
+func TestAdapterIsDeterministic(t *testing.T) {
+	fixture := loadFixture(t, "world_signal.json")
+	first, err := Adapter{}.Adapt(context.Background(), fixture)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := Adapter{}.Adapt(context.Background(), fixture)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("adapter must be deterministic; got %+v vs %+v", first, second)
+	}
+}
+
+func TestAdapterRejectsMalformedJSON(t *testing.T) {
+	fixture := loadMalformedFixture(t, "malformed_payload.json")
+	r, err := Adapter{}.Adapt(context.Background(), fixture)
+	if err := adaptercontract.ValidateRejected(fixture, r, err); err != nil {
+		t.Fatalf("ValidateRejected failed: %v", err)
+	}
+	var rejectErr adaptercontract.RejectError
+	if !errors.As(err, &rejectErr) {
+		t.Fatalf("expected RejectError, got %T: %v", err, err)
+	}
+	if rejectErr.Reason != "malformed_json" {
+		t.Fatalf("reason = %q, want malformed_json", rejectErr.Reason)
+	}
+}
+
+func TestAdapterRejectsMissingRequiredFields(t *testing.T) {
+	fixture := loadFixture(t, "missing_title.json")
+	r, err := Adapter{}.Adapt(context.Background(), fixture)
+	if err := adaptercontract.ValidateRejected(fixture, r, err); err != nil {
+		t.Fatalf("ValidateRejected failed: %v", err)
+	}
+	var rejectErr adaptercontract.RejectError
+	if !errors.As(err, &rejectErr) {
+		t.Fatalf("expected RejectError, got %T: %v", err, err)
+	}
+	if rejectErr.Reason != "missing_required_fields:title" {
+		t.Fatalf("reason = %q, want missing_required_fields:title", rejectErr.Reason)
+	}
+}
+
+func TestAdapterRejectsInvalidScoreType(t *testing.T) {
+	fixture := loadFixture(t, "bad_score.json")
+	r, err := Adapter{}.Adapt(context.Background(), fixture)
+	if err := adaptercontract.ValidateRejected(fixture, r, err); err != nil {
+		t.Fatalf("ValidateRejected failed: %v", err)
+	}
+	var rejectErr adaptercontract.RejectError
+	if !errors.As(err, &rejectErr) {
+		t.Fatalf("expected RejectError, got %T: %v", err, err)
+	}
+	if rejectErr.Reason != "invalid_field_type:relevance_score" {
+		t.Fatalf("reason = %q, want invalid_field_type:relevance_score", rejectErr.Reason)
+	}
+}
+
+func TestAdapterRejectsUnsupportedEventType(t *testing.T) {
+	fixture := loadFixture(t, "unsupported_event.json")
+	r, err := Adapter{}.Adapt(context.Background(), fixture)
+	if err := adaptercontract.ValidateRejected(fixture, r, err); err != nil {
+		t.Fatalf("ValidateRejected failed: %v", err)
+	}
+	var rejectErr adaptercontract.RejectError
+	if !errors.As(err, &rejectErr) {
+		t.Fatalf("expected RejectError, got %T: %v", err, err)
+	}
+	if !strings.HasPrefix(rejectErr.Reason, "unsupported_event_type:") {
+		t.Fatalf("reason = %q, want prefix unsupported_event_type:", rejectErr.Reason)
+	}
+}
+
+func TestSupportedEventTypesIsCanonicalSorted(t *testing.T) {
+	got := SupportedEventTypes()
+	gotStrs := make([]string, len(got))
+	for i, v := range got {
+		gotStrs[i] = string(v)
+	}
+	sortedCopy := append([]string(nil), gotStrs...)
+	sort.Strings(sortedCopy)
+	if !reflect.DeepEqual(gotStrs, sortedCopy) {
+		t.Fatalf("SupportedEventTypes must be sorted: %v", gotStrs)
+	}
+	wantSet := map[string]struct{}{
+		"world_raw_observation": {},
+		"world_signal":          {},
+		"world_scout_health":    {},
+	}
+	if len(got) != len(wantSet) {
+		t.Fatalf("event type count = %d, want %d", len(got), len(wantSet))
+	}
+	for _, v := range got {
+		if _, ok := wantSet[string(v)]; !ok {
+			t.Fatalf("unexpected event type %q", v)
+		}
+	}
+}
+
+func TestRequiredFieldsReturnsCopy(t *testing.T) {
+	a, ok := RequiredFields(EventWorldSignal)
+	if !ok {
+		t.Fatal("EventWorldSignal must be supported")
+	}
+	if len(a) == 0 {
+		t.Fatal("required fields must be non-empty")
+	}
+	a[0] = "TAMPERED"
+	b, _ := RequiredFields(EventWorldSignal)
+	if b[0] == "TAMPERED" {
+		t.Fatal("RequiredFields must return a defensive copy")
+	}
+}

--- a/tools/world_signal_ingestor_go/go.mod
+++ b/tools/world_signal_ingestor_go/go.mod
@@ -1,0 +1,7 @@
+module github.com/AmitabhainArunachala/dharma_swarm/tools/world_signal_ingestor_go
+
+go 1.26
+
+require github.com/AmitabhainArunachala/dharma_swarm/tools/go_sdk v0.0.0
+
+replace github.com/AmitabhainArunachala/dharma_swarm/tools/go_sdk => ../go_sdk

--- a/tools/world_signal_ingestor_go/main.go
+++ b/tools/world_signal_ingestor_go/main.go
@@ -1,0 +1,119 @@
+// Command world_signal_ingestor_go converts world observation/signal payloads
+// into normalized evidence receipts.
+//
+// Boundary: this binary emits receipts only. It does not fetch live sources,
+// decide, dispatch, write runtime DB, write ontology DB, or call Python policy.
+// Tests are fixture-driven; live network belongs to a later gated scout packet.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/AmitabhainArunachala/dharma_swarm/tools/go_sdk/adaptercontract"
+	"github.com/AmitabhainArunachala/dharma_swarm/tools/go_sdk/receipt"
+)
+
+// Options is the CLI surface for this binary.
+type Options struct {
+	InputPath     string
+	OutputPath    string
+	EventType     string
+	SourceURL     string
+	CorrelationID string
+	ObservedAt    string
+}
+
+func main() {
+	opts := parseFlags()
+	if err := run(opts); err != nil {
+		fmt.Fprintf(os.Stderr, "world_signal_ingestor_go: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func parseFlags() Options {
+	var opts Options
+	flag.StringVar(&opts.InputPath, "input", "", "path to world observation/signal payload JSON")
+	flag.StringVar(&opts.OutputPath, "output", "", "path for normalized evidence receipt")
+	flag.StringVar(&opts.EventType, "event-type", "",
+		"world event type: "+joinEventTypes())
+	flag.StringVar(&opts.SourceURL, "source-url", "", "stable source URL or file URI")
+	flag.StringVar(&opts.CorrelationID, "correlation-id", "", "mandatory closure correlation id")
+	flag.StringVar(&opts.ObservedAt, "observed-at", "", "RFC3339 timestamp; defaults to now UTC")
+	flag.Parse()
+	return opts
+}
+
+func run(opts Options) error {
+	if opts.InputPath == "" {
+		return errors.New("--input is required")
+	}
+	if opts.OutputPath == "" {
+		return errors.New("--output is required")
+	}
+	if opts.EventType == "" {
+		return errors.New("--event-type is required")
+	}
+	if opts.CorrelationID == "" {
+		return errors.New("--correlation-id is required")
+	}
+
+	payload, err := os.ReadFile(opts.InputPath)
+	if err != nil {
+		return err
+	}
+
+	sourceURL := opts.SourceURL
+	if sourceURL == "" {
+		abs, err := filepath.Abs(opts.InputPath)
+		if err != nil {
+			return err
+		}
+		sourceURL = "file://" + filepath.ToSlash(abs)
+	}
+
+	observedAt := opts.ObservedAt
+	if observedAt == "" {
+		observedAt = time.Now().UTC().Format(time.RFC3339)
+	}
+
+	fixture := adaptercontract.Fixture{
+		CorrelationID: opts.CorrelationID,
+		Source:        opts.EventType,
+		SourceURL:     sourceURL,
+		ObservedAt:    observedAt,
+		Payload:       json.RawMessage(payload),
+	}
+
+	r, adaptErr := Adapter{}.Adapt(context.Background(), fixture)
+	if adaptErr != nil {
+		var rejectErr adaptercontract.RejectError
+		if !errors.As(adaptErr, &rejectErr) {
+			return adaptErr
+		}
+		if writeErr := receipt.Write(opts.OutputPath, r); writeErr != nil {
+			return writeErr
+		}
+		fmt.Fprintf(os.Stderr, "world_signal_ingestor_go: rejected: %s\n", rejectErr.Reason)
+		return nil
+	}
+
+	return receipt.Write(opts.OutputPath, r)
+}
+
+func joinEventTypes() string {
+	types := SupportedEventTypes()
+	parts := make([]string, len(types))
+	for i, t := range types {
+		parts[i] = string(t)
+	}
+	return strings.Join(parts, ", ")
+}


### PR DESCRIPTION
## Why

G14 needs the world-radar prototype to link into the merged Go receipt lane instead of creating a second JSONL evidence substrate. This PR adds the receipt-native foundation only: no live fetch, no runtime wiring, no Python decision path.

Closes part of #231.

## What Changed

- Adds `tools/world_signal_ingestor_go` as a Go adapter/CLI using `tools/go_sdk/receipt` and `tools/go_sdk/adaptercontract`.
- Supports three receipt sources:
  - `world_raw_observation`
  - `world_signal`
  - `world_scout_health`
- Rejects malformed payloads, missing required fields, invalid signal scores, and unsupported event types with canonical rejected receipts.
- Adds fixture-driven tests under `tests/fixtures/go_world_signal_ingestor`.
- Wires the module into `GO_MODULES` so `make go-ci` covers it.

## Boundaries

- No live network access.
- No `go run` from runtime.
- No runtime DB, ontology DB, dispatch, strategy, or Python policy calls.
- This emits receipts only; Python projection into Zeitgeist/Shakti/Control Surface should be a follow-up.

## Coherence Delta

- **Organ touched:** Go sense-organ lane / evidence adapter substrate.
- **Declared-vs-actual gap closed:** The world-radar prototype now has a canonical receipt-native target contract instead of needing to bypass G0-G4 with direct JSONL world-feed output.
- **Proof that re-reads the map:** `make go-ci` now includes `tools/world_signal_ingestor_go` via `GO_MODULES`, and fixture tests validate accepted and rejected world observation/signal/health receipts.
- **New drift introduced:** None intentional. This PR adds no live network fetch, no runtime wiring, no Python policy path, and no new canonical store.

## Verification

- `make go-ci` passed.
- `python3 scripts/docops/check_docops_integrity.py --changed-from origin/main` passed.
- `git diff --check origin/main...HEAD` passed.
- `pre-commit run --files Makefile tools/world_signal_ingestor_go/go.mod tools/world_signal_ingestor_go/main.go tools/world_signal_ingestor_go/adapter.go tools/world_signal_ingestor_go/adapter_test.go tests/fixtures/go_world_signal_ingestor/raw_observation.json tests/fixtures/go_world_signal_ingestor/world_signal.json tests/fixtures/go_world_signal_ingestor/scout_health.json tests/fixtures/go_world_signal_ingestor/missing_title.json tests/fixtures/go_world_signal_ingestor/bad_score.json tests/fixtures/go_world_signal_ingestor/malformed_payload.json tests/fixtures/go_world_signal_ingestor/unsupported_event.json` passed.
