### PR TITLE
feat(control-surface): project Go world signal receipts [impact-checked]

### DIFF
--- a/ACTIVE_SURFACE_MANIFEST.yaml
+++ b/ACTIVE_SURFACE_MANIFEST.yaml
@@ -10,7 +10,7 @@
 # Your workflow: Declare → Observe → Reconcile → Dispatch → Verify.
 
 schema_version: 2
-last_updated: "2026-05-11"
+last_updated: "2026-05-13"
 
 state_dir:
   canonical: "~/.dharma"
@@ -20,6 +20,7 @@ state_dir:
   sessions: "~/.dharma/sessions"
   economics: "~/.dharma/economics"
   revenue_packets: "~/.dharma/revenue_packets"
+  go_world_receipts: "~/.dharma/go_receipts/world"
   env_override: "DHARMA_STATE_DIR"
 
 api_routers:
@@ -162,6 +163,9 @@ health_check_registry:
   api_health_responds:
     description: "Verify /api/health returns 200"
     type: api_probe
+  go_world_receipts_present:
+    description: "Verify canonical Go world-radar receipts exist under ~/.dharma/go_receipts/world"
+    type: file_exists
 
 # ── Dashboard Surfaces ────────────────────────────────────────────
 # Every dashboard page: desired state, observed-state checks, gap info.
@@ -457,6 +461,14 @@ integrations:
     health_check_ids: [ontology_db_present]
     used_by: [ontology_registry, ontology]
 
+  - id: go_world_signal_receipts
+    label: "Go World Signal Receipts"
+    type: evidence_receipts
+    path: "~/.dharma/go_receipts/world"
+    status: incubating
+    health_check_ids: [go_world_receipts_present]
+    used_by: [control_surface, world_radar_receipt_projection]
+
 # ── Feedback Loops ────────────────────────────────────────────────
 # The cybernetic loops declared in CYBERNETIC_LOOP_MAP.md.
 
@@ -496,6 +508,18 @@ loops:
     health_check_ids: [module_file_exists]
     priority: p2
     next_action: "Wire shakti observations to evolution pipeline"
+
+  - id: world_radar_receipt_projection
+    label: "World Radar Receipt Projection"
+    sense: "canonical Go world receipts"
+    act: "project world_signal receipts into Zeitgeist/Shakti surfaces"
+    evaluate: "receipt freshness, accepted count, rejected reasons"
+    adapt: "tighten scout/ingestor wiring and source weighting"
+    module: dharma_swarm/operator_core/world_radar/receipt_bridge.py
+    status: degraded
+    health_check_ids: [module_file_exists, go_world_receipts_present]
+    priority: p1
+    next_action: "Wire projected receipt rows into Zeitgeist/Shakti after G14 receipt flow is producing live receipts"
 
   - id: stigmergy_coordination
     label: "Stigmergy Coordination"

--- a/dharma_swarm/operator_core/control_surface.py
+++ b/dharma_swarm/operator_core/control_surface.py
@@ -26,6 +26,10 @@ import yaml
 from dharma_swarm.operator_core.control_surface_handoff import (  # noqa: F401
     generate_handoff_prompt,
 )
+from dharma_swarm.operator_core.control_surface_go import (  # noqa: F401
+    _go_receipt_rows,
+    _go_world_receipt_summary_rows,
+)
 from dharma_swarm.operator_core.control_surface_models import (
     AUTHORITY_ROLES,
     COHERENCE_STATES,
@@ -85,7 +89,6 @@ def _module_importable(dotted: str) -> bool:
         return True
     except Exception:
         return False
-
 
 
 # ---------------------------------------------------------------------------
@@ -769,92 +772,6 @@ def _runtime_state_row(repo_root: Path | None = None) -> ControlSurfaceRow | Non
         )
 
     return row
-
-
-# ---------------------------------------------------------------------------
-# K) Go receipt adapter (optional)
-# ---------------------------------------------------------------------------
-
-def _go_receipt_rows(repo_root: Path | None = None) -> list[ControlSurfaceRow]:
-    root = repo_root or _repo_root()
-    rows: list[ControlSurfaceRow] = []
-
-    def _append_file_row(
-        *,
-        row_id: str,
-        label: str,
-        authority_role: str,
-        owner_module: str,
-        evidence_label: str,
-    ) -> None:
-        path = root / owner_module
-        if not path.exists():
-            return
-        row = ControlSurfaceRow(
-            id=row_id,
-            kind="go_receipt",
-            label=label,
-            authority_role=authority_role,
-            declared_state="incubating",
-            desired_state="live",
-            observed_state="file present",
-            coherence_state="partial",
-            priority="p2",
-            owner_module=owner_module,
-            truth_owner="go_sdk",
-        )
-        row.add_evidence(
-            "go_receipt", str(path.relative_to(root)),
-            status="present",
-            provenance_chain=["go_sdk", "file_check"],
-        )
-        row.add_source_ref("go_module", owner_module, exists=True)
-        rows.append(row)
-
-    _append_file_row(
-        row_id="go.evidence_bridge",
-        label="Go Evidence Bridge",
-        authority_role="adapter",
-        owner_module="dharma_swarm/operator_core/go_evidence_bridge.py",
-        evidence_label="bridge file exists",
-    )
-    _append_file_row(
-        row_id="go.github_bridge",
-        label="Go GitHub Bridge",
-        authority_role="adapter",
-        owner_module="dharma_swarm/operator_core/go_github_bridge.py",
-        evidence_label="bridge file exists",
-    )
-    _append_file_row(
-        row_id="go.receipt_sdk",
-        label="Go Receipt SDK",
-        authority_role="evidence",
-        owner_module="tools/go_sdk/receipt/receipt.go",
-        evidence_label="receipt.go exists",
-    )
-    _append_file_row(
-        row_id="go.adapter_contract",
-        label="Go Adapter Contract",
-        authority_role="adapter",
-        owner_module="tools/go_sdk/adaptercontract/contract.go",
-        evidence_label="contract.go exists",
-    )
-    _append_file_row(
-        row_id="go.evidence_ingestor",
-        label="Go Evidence Ingestor",
-        authority_role="adapter",
-        owner_module="tools/evidence_ingestor_go/main.go",
-        evidence_label="ingestor exists",
-    )
-    _append_file_row(
-        row_id="go.github_ingestor",
-        label="Go GitHub Ingestor",
-        authority_role="adapter",
-        owner_module="tools/github_ingestor_go/adapter.go",
-        evidence_label="ingestor exists",
-    )
-
-    return rows
 
 
 # ---------------------------------------------------------------------------

--- a/dharma_swarm/operator_core/control_surface_go.py
+++ b/dharma_swarm/operator_core/control_surface_go.py
@@ -1,0 +1,213 @@
+"""Go receipt rows for the operator control surface.
+
+This module keeps optional Go-side evidence projection out of the central
+control-surface projector. It is read-only: it checks files and receipt
+summaries, then returns typed ``ControlSurfaceRow`` instances.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from dharma_swarm.operator_core.control_surface_models import ControlSurfaceRow
+
+
+_REPO_ROOT: Path | None = None
+
+
+def _repo_root() -> Path:
+    global _REPO_ROOT
+    if _REPO_ROOT is not None:
+        return _REPO_ROOT
+    here = Path(__file__).resolve()
+    for parent in (here.parent, here.parent.parent, here.parent.parent.parent):
+        if (parent / "ACTIVE_SURFACE_MANIFEST.yaml").exists():
+            _REPO_ROOT = parent
+            return parent
+    _REPO_ROOT = Path.cwd()
+    return _REPO_ROOT
+
+
+def _go_receipt_rows(repo_root: Path | None = None) -> list[ControlSurfaceRow]:
+    repo_root = repo_root or _repo_root()
+    rows: list[ControlSurfaceRow] = []
+
+    def _append_file_row(
+        *,
+        row_id: str,
+        label: str,
+        authority_role: str,
+        owner_module: str,
+    ) -> None:
+        path = repo_root / owner_module
+        if not path.exists():
+            return
+        row = ControlSurfaceRow(
+            id=row_id,
+            kind="go_receipt",
+            label=label,
+            authority_role=authority_role,
+            declared_state="incubating",
+            desired_state="live",
+            observed_state="file present",
+            coherence_state="partial",
+            priority="p2",
+            owner_module=owner_module,
+            truth_owner="go_sdk",
+        )
+        row.add_evidence(
+            "go_receipt", str(path.relative_to(repo_root)),
+            status="present",
+            provenance_chain=["go_sdk", "file_check"],
+        )
+        row.add_source_ref("go_module", owner_module, exists=True)
+        rows.append(row)
+
+    _append_file_row(
+        row_id="go.evidence_bridge",
+        label="Go Evidence Bridge",
+        authority_role="adapter",
+        owner_module="dharma_swarm/operator_core/go_evidence_bridge.py",
+    )
+    _append_file_row(
+        row_id="go.github_bridge",
+        label="Go GitHub Bridge",
+        authority_role="adapter",
+        owner_module="dharma_swarm/operator_core/go_github_bridge.py",
+    )
+    _append_file_row(
+        row_id="go.receipt_sdk",
+        label="Go Receipt SDK",
+        authority_role="evidence",
+        owner_module="tools/go_sdk/receipt/receipt.go",
+    )
+    _append_file_row(
+        row_id="go.adapter_contract",
+        label="Go Adapter Contract",
+        authority_role="adapter",
+        owner_module="tools/go_sdk/adaptercontract/contract.go",
+    )
+    _append_file_row(
+        row_id="go.evidence_ingestor",
+        label="Go Evidence Ingestor",
+        authority_role="adapter",
+        owner_module="tools/evidence_ingestor_go/main.go",
+    )
+    _append_file_row(
+        row_id="go.github_ingestor",
+        label="Go GitHub Ingestor",
+        authority_role="adapter",
+        owner_module="tools/github_ingestor_go/adapter.go",
+    )
+    _append_file_row(
+        row_id="go.world_signal_ingestor",
+        label="Go World Signal Ingestor",
+        authority_role="adapter",
+        owner_module="tools/world_signal_ingestor_go/adapter.go",
+    )
+
+    rows.extend(_go_world_receipt_summary_rows())
+    return rows
+
+
+def _go_world_receipt_summary_rows() -> list[ControlSurfaceRow]:
+    try:
+        from dharma_swarm.operator_core.world_radar.receipt_bridge import (
+            summarize_go_world_receipts,
+        )
+    except Exception as exc:
+        row = ControlSurfaceRow(
+            id="go.world_signal_receipts",
+            kind="go_receipt",
+            label="Go World Signal Receipts",
+            authority_role="evidence",
+            declared_state="incubating",
+            desired_state="live",
+            observed_state="bridge import failed",
+            coherence_state="drifted",
+            priority="p1",
+            owner_module="dharma_swarm/operator_core/world_radar/receipt_bridge.py",
+            truth_owner="go_sdk",
+            gap_codes=["go_world_receipt_bridge_import_failed"],
+        )
+        row.add_evidence(
+            "go_receipt", f"world receipt bridge import failed: {exc}",
+            status="error",
+            provenance_chain=["go_sdk", "world_radar", "bridge_import"],
+        )
+        row.add_source_ref(
+            "file",
+            "dharma_swarm/operator_core/world_radar/receipt_bridge.py",
+            exists=True,
+        )
+        return [row]
+
+    summary = summarize_go_world_receipts()
+    gaps: list[str] = []
+    if not summary["exists"]:
+        observed_state = "receipts dir missing"
+        coherence_state = "declared_only"
+        gaps.append("go_world_receipts_dir_missing")
+    elif summary["total"] == 0:
+        observed_state = "no receipts"
+        coherence_state = "declared_only"
+        gaps.append("go_world_receipts_empty")
+    elif summary["rejected"]:
+        observed_state = "receipts have rejections"
+        coherence_state = "partial"
+        gaps.append("go_world_receipt_rejections")
+    else:
+        observed_state = "receipts accepted"
+        coherence_state = "bound"
+
+    row = ControlSurfaceRow(
+        id="go.world_signal_receipts",
+        kind="go_receipt",
+        label="Go World Signal Receipts",
+        authority_role="evidence",
+        declared_state="incubating",
+        desired_state="live",
+        observed_state=observed_state,
+        coherence_state=coherence_state,
+        priority="p1",
+        owner_module="dharma_swarm/operator_core/world_radar/receipt_bridge.py",
+        truth_owner="go_sdk",
+        freshness=summary["freshest_observed_at"],
+        gap_codes=gaps,
+        next_action="Project accepted world_signal receipts into Zeitgeist/Shakti surfaces",
+        raw=summary,
+    )
+    row.add_evidence(
+        "go_receipt", f"receipts_dir={summary['receipts_dir']}",
+        status="present" if summary["exists"] else "missing",
+        provenance_chain=["go_sdk", "world_receipts_dir"],
+    )
+    row.add_evidence(
+        "go_receipt",
+        (
+            f"total={summary['total']} accepted={summary['accepted']} "
+            f"rejected={summary['rejected']} world_signal={summary['world_signal']}"
+        ),
+        status="present",
+        provenance_chain=["go_sdk", "world_receipts_summary"],
+    )
+    row.add_evidence(
+        "go_receipt",
+        f"projected_world_signals={summary['projected_world_signals']}",
+        status="present",
+        provenance_chain=["go_sdk", "world_signal_projection"],
+    )
+    if summary["rejected"]:
+        row.add_evidence(
+            "go_receipt", f"rejected_reasons={summary['rejected_reasons']}",
+            status="rejected",
+            provenance_chain=["go_sdk", "world_receipts_summary", "rejections"],
+        )
+    row.add_source_ref(
+        "file",
+        "dharma_swarm/operator_core/world_radar/receipt_bridge.py",
+        exists=True,
+    )
+    row.add_source_ref("go_module", "tools/world_signal_ingestor_go/adapter.go", exists=True)
+    row.add_source_ref("file", summary["receipts_dir"], exists=bool(summary["exists"]))
+    return [row]

--- a/dharma_swarm/operator_core/control_surface_models.py
+++ b/dharma_swarm/operator_core/control_surface_models.py
@@ -213,6 +213,8 @@ def _needs_human_decision(row: ControlSurfaceRow) -> bool:
         return True
     if row.kind == "broken_register" and "OPEN" in row.declared_state.upper():
         return True
+    if "go_world_receipt_rejections" in row.gap_codes:
+        return True
     label_lower = row.label.lower()
     for kw in _HUMAN_DECISION_KEYWORDS:
         if kw in label_lower or kw in row.owner_module.lower():

--- a/dharma_swarm/operator_core/world_radar/__init__.py
+++ b/dharma_swarm/operator_core/world_radar/__init__.py
@@ -1,0 +1,25 @@
+"""Read-only world-radar receipt projection helpers."""
+
+from dharma_swarm.operator_core.world_radar.receipt_bridge import (
+    GO_EVIDENCE_SCHEMA_V0,
+    SUPPORTED_WORLD_EVENT_TYPES,
+    GoWorldBridgeError,
+    GoWorldReceipt,
+    load_go_world_receipt,
+    project_world_signal_receipts,
+    summarize_go_world_receipts,
+    world_feed_row_from_signal_receipt,
+    world_receipts_dir,
+)
+
+__all__ = [
+    "GO_EVIDENCE_SCHEMA_V0",
+    "SUPPORTED_WORLD_EVENT_TYPES",
+    "GoWorldBridgeError",
+    "GoWorldReceipt",
+    "load_go_world_receipt",
+    "project_world_signal_receipts",
+    "summarize_go_world_receipts",
+    "world_feed_row_from_signal_receipt",
+    "world_receipts_dir",
+]

--- a/dharma_swarm/operator_core/world_radar/receipt_bridge.py
+++ b/dharma_swarm/operator_core/world_radar/receipt_bridge.py
@@ -1,0 +1,248 @@
+"""Read-only bridge for world-radar Go evidence receipts.
+
+The Go side emits canonical ``go_evidence_receipt.v0`` receipts. This module
+parses those sidecar receipts and projects accepted ``world_signal`` receipts
+into the existing world-feed shape consumed by Zeitgeist/Shakti surfaces.
+
+It does not fetch the network, run Go, write runtime state, dispatch agents, or
+decide strategy. Those remain outside this bridge.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+from dharma_swarm.daemon_config import dharma_state_dir
+
+GO_EVIDENCE_SCHEMA_V0 = "go_evidence_receipt.v0"
+
+WorldEventType = Literal[
+    "world_raw_observation",
+    "world_signal",
+    "world_scout_health",
+]
+
+SUPPORTED_WORLD_EVENT_TYPES: tuple[WorldEventType, ...] = (
+    "world_raw_observation",
+    "world_signal",
+    "world_scout_health",
+)
+
+
+class GoWorldBridgeError(ValueError):
+    """Raised when a Go world-radar receipt cannot be admitted."""
+
+
+@dataclass(frozen=True)
+class GoWorldReceipt:
+    """Typed view of a Go-emitted world-radar receipt."""
+
+    receipt_id: str
+    correlation_id: str
+    source: WorldEventType
+    source_url: str
+    observed_at: str
+    content_hash: str
+    event_uid: str
+    schema_version: str
+    status: str
+    payload: dict[str, Any]
+    rejected_reason: str = ""
+
+    def __post_init__(self) -> None:
+        required = (
+            self.receipt_id,
+            self.correlation_id,
+            self.source,
+            self.observed_at,
+            self.content_hash,
+            self.event_uid,
+            self.schema_version,
+            self.status,
+        )
+        if not all(required):
+            raise GoWorldBridgeError("GoWorldReceipt missing required identity fields")
+        if self.schema_version != GO_EVIDENCE_SCHEMA_V0:
+            raise GoWorldBridgeError(
+                f"unsupported Go evidence schema: {self.schema_version}"
+            )
+        if self.source not in SUPPORTED_WORLD_EVENT_TYPES:
+            raise GoWorldBridgeError(f"unsupported world event type: {self.source}")
+        if self.status not in {"accepted", "rejected"}:
+            raise GoWorldBridgeError(f"unsupported receipt status: {self.status}")
+        if self.status == "rejected" and not self.rejected_reason:
+            raise GoWorldBridgeError("rejected receipt must carry rejected_reason")
+
+
+def world_receipts_dir(state_dir: Path | None = None) -> Path:
+    """Return the default sidecar directory for world-radar Go receipts."""
+    state = state_dir or dharma_state_dir("DHARMA_STATE_DIR")
+    return state / "go_receipts" / "world"
+
+
+def load_go_world_receipt(path: Path) -> GoWorldReceipt:
+    """Read a JSON receipt produced by world_signal_ingestor_go."""
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    payload = raw.get("payload")
+    if not isinstance(payload, dict):
+        raise GoWorldBridgeError("Go world receipt payload must be a JSON object")
+    source = str(raw.get("source", ""))
+    if source not in SUPPORTED_WORLD_EVENT_TYPES:
+        raise GoWorldBridgeError(f"unsupported world event type: {source!r}")
+    return GoWorldReceipt(
+        receipt_id=str(raw.get("receipt_id", "")),
+        correlation_id=str(raw.get("correlation_id", "")),
+        source=source,  # type: ignore[arg-type]
+        source_url=str(raw.get("source_url", "")),
+        observed_at=str(raw.get("observed_at", "")),
+        content_hash=str(raw.get("content_hash", "")),
+        event_uid=str(raw.get("event_uid", "")),
+        schema_version=str(raw.get("schema_version", "")),
+        status=str(raw.get("status", "")),
+        rejected_reason=str(raw.get("rejected_reason", "")),
+        payload=payload,
+    )
+
+
+def load_go_world_receipts(paths: list[Path] | tuple[Path, ...]) -> list[GoWorldReceipt]:
+    """Load receipts from explicit paths, skipping unreadable/malformed files."""
+    receipts: list[GoWorldReceipt] = []
+    for path in sorted(paths):
+        try:
+            receipts.append(load_go_world_receipt(path))
+        except (OSError, json.JSONDecodeError, GoWorldBridgeError):
+            continue
+    return receipts
+
+
+def receipt_paths(receipts_dir: Path | None = None) -> tuple[Path, ...]:
+    """Return candidate receipt JSON files from a sidecar directory."""
+    directory = receipts_dir or world_receipts_dir()
+    if not directory.exists():
+        return ()
+    return tuple(sorted(path for path in directory.glob("*.json") if path.is_file()))
+
+
+def project_world_signal_receipts(
+    paths: list[Path] | tuple[Path, ...],
+) -> list[dict[str, Any]]:
+    """Project accepted world-signal receipts into world-feed rows."""
+    rows: list[dict[str, Any]] = []
+    for receipt in load_go_world_receipts(tuple(paths)):
+        if receipt.status != "accepted" or receipt.source != "world_signal":
+            continue
+        rows.append(world_feed_row_from_signal_receipt(receipt))
+    return sorted(
+        rows,
+        key=lambda row: (
+            -_float(row.get("relevance_score")),
+            str(row.get("title", "")),
+        ),
+    )
+
+
+def world_feed_row_from_signal_receipt(receipt: GoWorldReceipt) -> dict[str, Any]:
+    """Convert one accepted ``world_signal`` receipt to world-feed JSON."""
+    if receipt.source != "world_signal":
+        raise GoWorldBridgeError(f"expected world_signal receipt, got {receipt.source!r}")
+    if receipt.status != "accepted":
+        raise GoWorldBridgeError(f"cannot project rejected receipt: {receipt.rejected_reason}")
+
+    payload = receipt.payload
+    title = str(payload.get("title", "")).strip()
+    category = str(payload.get("category", "opportunity")).strip() or "opportunity"
+    score = _float(payload.get("relevance_score"))
+    keywords = _string_list(payload.get("keywords"))
+    description = str(payload.get("description") or title).strip()
+
+    metadata = {
+        "receipt_id": receipt.receipt_id,
+        "correlation_id": receipt.correlation_id,
+        "content_hash": receipt.content_hash,
+        "event_uid": receipt.event_uid,
+        "raw_observation_event_uid": str(payload.get("raw_observation_event_uid", "")),
+        "matched_terms": _string_list(payload.get("matched_terms")),
+        "first_principles_questions": _string_list(
+            payload.get("first_principles_questions")
+        ),
+        "iteration_steps": _string_list(payload.get("iteration_steps")),
+        "adjacent_search_queries": _string_list(payload.get("adjacent_search_queries")),
+        "strategic_moves": _string_list(payload.get("strategic_moves")),
+        "human_review_required": bool(payload.get("human_review_required", True)),
+        "raw_signal_not_final_judgment": bool(
+            payload.get("raw_signal_not_final_judgment", True)
+        ),
+        "radar_version": str(payload.get("radar_version", "")),
+    }
+
+    return {
+        "id": receipt.event_uid,
+        "source": "go_world_signal_receipt",
+        "source_url": receipt.source_url,
+        "category": category,
+        "title": title,
+        "relevance_score": score,
+        "keywords": keywords,
+        "description": description,
+        "observed_at": receipt.observed_at,
+        "metadata": metadata,
+    }
+
+
+def summarize_go_world_receipts(receipts_dir: Path | None = None) -> dict[str, Any]:
+    """Return a compact control-surface summary for world-radar receipts."""
+    directory = receipts_dir or world_receipts_dir()
+    paths = receipt_paths(directory)
+    receipts = load_go_world_receipts(paths)
+    by_source = Counter(receipt.source for receipt in receipts)
+    by_status = Counter(receipt.status for receipt in receipts)
+    rejected_reasons = Counter(
+        receipt.rejected_reason for receipt in receipts if receipt.rejected_reason
+    )
+    freshest = max((receipt.observed_at for receipt in receipts), default="")
+    signal_rows = project_world_signal_receipts(paths)
+    return {
+        "receipts_dir": str(directory),
+        "exists": directory.exists(),
+        "total": len(receipts),
+        "accepted": by_status.get("accepted", 0),
+        "rejected": by_status.get("rejected", 0),
+        "world_raw_observation": by_source.get("world_raw_observation", 0),
+        "world_signal": by_source.get("world_signal", 0),
+        "world_scout_health": by_source.get("world_scout_health", 0),
+        "freshest_observed_at": freshest,
+        "rejected_reasons": dict(sorted(rejected_reasons.items())),
+        "projected_world_signals": len(signal_rows),
+    }
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value if str(item).strip()]
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+__all__ = [
+    "GO_EVIDENCE_SCHEMA_V0",
+    "SUPPORTED_WORLD_EVENT_TYPES",
+    "GoWorldBridgeError",
+    "GoWorldReceipt",
+    "load_go_world_receipt",
+    "load_go_world_receipts",
+    "project_world_signal_receipts",
+    "receipt_paths",
+    "summarize_go_world_receipts",
+    "world_feed_row_from_signal_receipt",
+    "world_receipts_dir",
+]

--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -6,14 +6,14 @@ Do not hand-edit the generated block.
 <!-- DOCOPS:START metric=repo_inventory -->
 | Metric | Value |
 |---|---:|
-| Dharma Python modules | 591 |
+| Dharma Python modules | 594 |
 | Top-level Dharma Python modules | 386 |
-| Dharma Python LOC | 256,707 |
-| Test files | 575 |
-| Test function occurrences | 10,205 |
+| Dharma Python LOC | 257,112 |
+| Test files | 576 |
+| Test function occurrences | 10,209 |
 | Markdown files | 691 |
-| Markdown total lines | 176,025 |
-| Bridge files | 21 |
+| Markdown total lines | 176,029 |
+| Bridge files | 22 |
 | Adapter files | 14 |
 | Orchestrator files | 4 |
 | Router files | 13 |

--- a/docs/governance/SOVEREIGN_MANIFEST.md
+++ b/docs/governance/SOVEREIGN_MANIFEST.md
@@ -17,10 +17,10 @@
 These are immutable engineering laws for this repository. Violation = architectural regression.
 
 ### A1: NO FLAT-PACKAGE GROWTH
-The `dharma_swarm/` package currently has **386 files at its top level (65.6% of 588 total Python modules)** (V). No new .py file may be added to the top level. New modules must go into an appropriate subdirectory. Existing top-level files will be organized over time.
+The `dharma_swarm/` package currently has **386 files at its top level (65.0% of 594 total Python modules)** (V). No new .py file may be added to the top level. New modules must go into an appropriate subdirectory. Existing top-level files will be organized over time.
 
 ### A2: NO DUPLICATE IMPLEMENTATIONS
-Before creating a new file for routing, bridging, adapting, or orchestrating, check if one already exists. The repo currently has **21 bridge files** (V), **3 model_routing copies** (2 are identical, 1 is different) (V), **4 orchestrators** (V), **14 adapter files across 7 locations** (V), and **13 router files** (V). Do not add more without deprecating an existing one.
+Before creating a new file for routing, bridging, adapting, or orchestrating, check if one already exists. The repo currently has **22 bridge files** (V), **3 model_routing copies** (2 are identical, 1 is different) (V), **4 orchestrators** (V), **14 adapter files across 7 locations** (V), and **13 router files** (V). Do not add more without deprecating an existing one.
 
 ### A3: NO UNDOCUMENTED SEAMS
 If your code creates a new interface between domains (a bridge, adapter, or protocol), you must update `NAVIGATION.md` with its purpose, entry point, and boundary constraints. Undocumented seams become invisible coupling.
@@ -62,16 +62,16 @@ These are the ground-truth metrics. All other documents citing different numbers
 
 | Metric | Value | Verification |
 |--------|-------|-------------|
-| Total Python modules | **591** | find dharma_swarm -name "*.py" -type f |
-| Top-level (flat) modules | **386 (65.6%)** | find dharma_swarm -maxdepth 1 -name "*.py" -type f |
-| Total Python LOC | **256,707** | wc -l across dharma_swarm Python modules |
-| Test files | **575** | find tests -name "*.py" -type f |
-| Test functions | **10,205 `def test_` occurrences under tests/** | rg "def test_" tests |
+| Total Python modules | **594** | find dharma_swarm -name "*.py" -type f |
+| Top-level (flat) modules | **386 (65.0%)** | find dharma_swarm -maxdepth 1 -name "*.py" -type f |
+| Total Python LOC | **257,112** | wc -l across dharma_swarm Python modules |
+| Test files | **576** | find tests -name "*.py" -type f |
+| Test functions | **10,209 `def test_` occurrences under tests/** | rg "def test_" tests |
 | Tests collected (pytest) | **Needs write-permitted refresh** | not run during this DocOps count pass |
 | Collection errors | **Historical: 16 on 2026-04-04** | refresh before relying on this count |
 | Markdown files | **691** | find . -name "*.md" -type f |
-| Markdown total lines | **176,025** | wc -l across all .md |
-| Bridge files | **21** | find dharma_swarm -name "*bridge*.py" |
+| Markdown total lines | **176,029** | wc -l across all .md |
+| Bridge files | **22** | find dharma_swarm -name "*bridge*.py" |
 | Adapter files | **14 across 7 locations** | find dharma_swarm -type f \| rg -i "adapter" |
 | Orchestrator files | **4** (6,034 LOC total) | find dharma_swarm -name "*orchestrat*" |
 | Router files | **13** (4,976 LOC total) | find dharma_swarm -type f \| rg -i "rout" |
@@ -171,7 +171,7 @@ These are the ground-truth metrics. All other documents citing different numbers
 
 ### Domain 6: Bridges (Integration Layer)
 
-**21 bridge files** (V), **10,418 total LOC**:
+**22 bridge files** (V), **11,453 total LOC**:
 
 | Bridge | Lines | Importers | Status |
 |--------|-------|-----------|--------|
@@ -192,6 +192,10 @@ These are the ground-truth metrics. All other documents citing different numbers
 | skill_bridge.py | 202 | 2 | ALIVE |
 | optimizer_bridge.py | 191 | 8 | ALIVE |
 | ecosystem_bridge.py | 170 | 3 | ALIVE |
+| revenue/telic_bridge.py | 340 | 3 | ALIVE |
+| operator_core/go_github_bridge.py | 198 | 1 | ALIVE |
+| operator_core/go_evidence_bridge.py | 113 | 1 | ALIVE |
+| operator_core/world_radar/receipt_bridge.py | 248 | 2 | INCUBATING |
 | ginko_bridge.py | 94 | 1 | ALIVE |
 
 - **Primary Entry Points**: `terminal_bridge.py` (Bun<->Python), `bridge.py` (core abstraction)
@@ -351,13 +355,13 @@ This re-audit found errors in the earlier 5-model audit:
 | Error in prior audit | Corrected value |
 |---------------------|----------------|
 | "codex_overnight.py is 10K lines" | **1,008 lines** (V) |
-| "17 bridge files" / "19 bridge files" (self-contradicting) | **21 bridge files** (V) |
+| "17 bridge files" / "19 bridge files" (self-contradicting) | **22 bridge files** (V) |
 | "16 TUI test errors" | **16 total errors: 10 numpy, 2 textual, 1 typer, 1 pytest_asyncio, 1 yaml, 1 tui.app** -- only 3 are TUI-specific (V) |
 | "10 pillars" with "PILLAR_04 missing, PILLAR_11 present" | **10 pillar files exist** (PILLAR_01-03, 05-11; PILLAR_04 never created). Sparse numbering, not 11. (V) |
 | "router_v1.py is LEGACY" | **router_v1.py is ALIVE** -- actively used by providers.py for signal generation (V) |
 | "18 provider classes" (VIVEKA) | **19 classes** (including abstract LLMProvider base); **18 ProviderType enum values** (V) |
 | "engine/ is legacy duplicate of tui/engine/" | **Both are ALIVE** -- engine/ has 41 importers, tui/engine/ has 31 importers. Different purposes. (V) |
-| Bridge count of "30" (Phase 3A) | **21 actual bridge files** -- the "30" counted test files and non-bridge files with "bridge" in name (V) |
+| Bridge count of "30" (Phase 3A) | **22 actual bridge files** -- the "30" counted test files and non-bridge files with "bridge" in name (V) |
 
 ---
 

--- a/tests/test_control_surface.py
+++ b/tests/test_control_surface.py
@@ -384,7 +384,12 @@ class TestFullBuild:
 class TestGoReceiptRows:
     """Existing G-track files should project through their real repo paths."""
 
-    def test_go_receipt_rows_use_operator_core_bridge_paths(self, tmp_repo: Path) -> None:
+    def test_go_receipt_rows_use_operator_core_bridge_paths(
+        self,
+        tmp_repo: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("DHARMA_STATE_DIR", str(tmp_repo / ".dharma"))
         paths = [
             "dharma_swarm/operator_core/go_evidence_bridge.py",
             "dharma_swarm/operator_core/go_github_bridge.py",
@@ -392,6 +397,7 @@ class TestGoReceiptRows:
             "tools/go_sdk/adaptercontract/contract.go",
             "tools/evidence_ingestor_go/main.go",
             "tools/github_ingestor_go/adapter.go",
+            "tools/world_signal_ingestor_go/adapter.go",
         ]
         for rel in paths:
             path = tmp_repo / rel
@@ -408,6 +414,8 @@ class TestGoReceiptRows:
             "go.adapter_contract",
             "go.evidence_ingestor",
             "go.github_ingestor",
+            "go.world_signal_ingestor",
+            "go.world_signal_receipts",
         }
         assert (
             by_id["go.evidence_bridge"].owner_module
@@ -421,6 +429,7 @@ class TestGoReceiptRows:
             row.owner_module == "dharma_swarm/go_evidence_bridge.py"
             for row in rows
         )
+        assert by_id["go.world_signal_receipts"].coherence_state == "declared_only"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_go_world_signal_bridge.py
+++ b/tests/test_go_world_signal_bridge.py
@@ -1,0 +1,167 @@
+"""Tests for Go world-radar receipt projection.
+
+The Go side emits receipts only. Python parses those sidecar receipts and
+projects accepted world-signal evidence into existing world-feed rows.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from dharma_swarm.operator_core.control_surface import _go_world_receipt_summary_rows
+from dharma_swarm.operator_core.world_radar.receipt_bridge import (
+    GO_EVIDENCE_SCHEMA_V0,
+    GoWorldBridgeError,
+    load_go_world_receipt,
+    project_world_signal_receipts,
+    summarize_go_world_receipts,
+    world_feed_row_from_signal_receipt,
+)
+
+FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures" / "go_world_signal_ingestor"
+GO_MODULE = Path(__file__).resolve().parents[1] / "tools" / "world_signal_ingestor_go"
+GO_OBSERVED_AT = "2026-05-12T00:00:00Z"
+
+
+def _run_ingestor(
+    event_type: str,
+    fixture_name: str,
+    output_path: Path,
+    *,
+    expect_rejected: bool = False,
+) -> None:
+    if shutil.which("go") is None:
+        pytest.skip("Go toolchain is not installed")
+    fixture_raw = json.loads((FIXTURE_DIR / fixture_name).read_text(encoding="utf-8"))
+    payload_path = output_path.parent / (fixture_name + ".payload")
+    payload_path.parent.mkdir(parents=True, exist_ok=True)
+    if "payload_text" in fixture_raw:
+        payload_path.write_text(str(fixture_raw["payload_text"]), encoding="utf-8")
+    else:
+        payload_path.write_text(json.dumps(fixture_raw["payload"]), encoding="utf-8")
+
+    env = dict(os.environ)
+    env["GOCACHE"] = "/tmp/dharma-swarm-go-build"
+    env["GOMODCACHE"] = "/tmp/dharma-swarm-go-mod"
+    completed = subprocess.run(
+        [
+            "go",
+            "run",
+            ".",
+            "--input",
+            str(payload_path),
+            "--output",
+            str(output_path),
+            "--event-type",
+            event_type,
+            "--source-url",
+            str(fixture_raw["source_url"]),
+            "--correlation-id",
+            str(fixture_raw["correlation_id"]),
+            "--observed-at",
+            GO_OBSERVED_AT,
+        ],
+        cwd=GO_MODULE,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if expect_rejected:
+        assert output_path.exists(), (
+            f"rejected receipt was not written: stderr={completed.stderr}"
+        )
+        assert "rejected" in completed.stderr
+    elif completed.returncode != 0:
+        pytest.fail(
+            f"world ingestor failed for {event_type}: "
+            f"stdout={completed.stdout} stderr={completed.stderr}"
+        )
+
+
+def test_world_signal_receipt_round_trips_to_world_feed_row(tmp_path: Path) -> None:
+    receipt_path = tmp_path / "world_signal.json"
+    _run_ingestor("world_signal", "world_signal.json", receipt_path)
+
+    receipt = load_go_world_receipt(receipt_path)
+    assert receipt.source == "world_signal"
+    assert receipt.status == "accepted"
+    assert receipt.schema_version == GO_EVIDENCE_SCHEMA_V0
+
+    row = world_feed_row_from_signal_receipt(receipt)
+    assert row["id"] == receipt.event_uid
+    assert row["source"] == "go_world_signal_receipt"
+    assert row["category"] == "model_release"
+    assert row["relevance_score"] == 0.91
+    assert row["metadata"]["receipt_id"] == receipt.receipt_id
+    assert "claim_verification" in row["metadata"]["strategic_moves"]
+
+
+def test_rejected_world_receipt_is_loaded_with_reason(tmp_path: Path) -> None:
+    receipt_path = tmp_path / "bad_score.json"
+    _run_ingestor(
+        "world_signal",
+        "bad_score.json",
+        receipt_path,
+        expect_rejected=True,
+    )
+
+    receipt = load_go_world_receipt(receipt_path)
+    assert receipt.status == "rejected"
+    assert receipt.rejected_reason == "invalid_field_type:relevance_score"
+    with pytest.raises(GoWorldBridgeError):
+        world_feed_row_from_signal_receipt(receipt)
+
+
+def test_summary_counts_world_receipts_and_projection(tmp_path: Path) -> None:
+    receipts_dir = tmp_path / "receipts"
+    _run_ingestor("world_raw_observation", "raw_observation.json", receipts_dir / "raw.json")
+    _run_ingestor("world_signal", "world_signal.json", receipts_dir / "signal.json")
+    _run_ingestor("world_scout_health", "scout_health.json", receipts_dir / "health.json")
+    _run_ingestor(
+        "world_signal",
+        "bad_score.json",
+        receipts_dir / "bad_score.json",
+        expect_rejected=True,
+    )
+
+    summary = summarize_go_world_receipts(receipts_dir)
+    assert summary["total"] == 4
+    assert summary["accepted"] == 3
+    assert summary["rejected"] == 1
+    assert summary["world_raw_observation"] == 1
+    assert summary["world_signal"] == 2
+    assert summary["world_scout_health"] == 1
+    assert summary["projected_world_signals"] == 1
+    assert summary["rejected_reasons"] == {
+        "invalid_field_type:relevance_score": 1,
+    }
+
+    rows = project_world_signal_receipts(tuple(receipts_dir.glob("*.json")))
+    assert len(rows) == 1
+    assert rows[0]["title"].startswith("SubQ claims")
+
+
+def test_control_surface_projects_world_receipt_summary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state_dir = tmp_path / ".dharma"
+    receipts_dir = state_dir / "go_receipts" / "world"
+    _run_ingestor("world_signal", "world_signal.json", receipts_dir / "signal.json")
+    monkeypatch.setenv("DHARMA_STATE_DIR", str(state_dir))
+
+    rows = _go_world_receipt_summary_rows()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.id == "go.world_signal_receipts"
+    assert row.observed_state == "receipts accepted"
+    assert row.coherence_state == "bound"
+    assert row.freshness == GO_OBSERVED_AT
+    assert row.raw["projected_world_signals"] == 1


### PR DESCRIPTION
## Why

PR #261 made world-radar Go evidence receipt-native. This PR connects that G14a foundation to the operator control surface without adding live network fetch, runtime `go run`, or a new ledger.

The manifest declares the desired world-radar receipt surface. The Python bridge reads canonical Go receipts as observed reality. The Control Surface grid shows receipt freshness, accepted/rejected counts, and whether world signals can be projected.

Closes part of #231.

## What Changed

- Adds `dharma_swarm/operator_core/world_radar/receipt_bridge.py`.
- Parses canonical `go_evidence_receipt.v0` receipts for:
  - `world_raw_observation`
  - `world_signal`
  - `world_scout_health`
- Projects accepted `world_signal` receipts into the existing world-feed row shape for Zeitgeist/Shakti follow-up.
- Adds Control Surface row `go.world_signal_receipts` with:
  - receipt directory
  - total/accepted/rejected counts
  - world signal count
  - projected signal count
  - freshest observed timestamp
  - rejected reason evidence
- Adds `go.world_signal_ingestor` to the Go receipt surface projection.
- Registers declared intent in `ACTIVE_SURFACE_MANIFEST.yaml`.
- Adds bridge/control-surface tests and refreshes DocOps counts.

## Boundaries

- No live source fetch.
- No runtime loop wiring.
- No `go run` from `orchestrate_live.py`.
- No runtime DB, ontology DB, dispatch, strategy, or Python policy writes.
- This is read-only projection from sidecar receipts into typed Python views and Control Surface rows.

## Coherence Delta

- **Organ touched:** Operator Core / Control Surface / Go sense-organ receipt projection.
- **Declared-vs-actual gap closed:** `ACTIVE_SURFACE_MANIFEST.yaml` now declares Go world-signal receipts, and the Control Surface observes real receipt files rather than file-presence-only Go infrastructure.
- **Proof that re-reads the map:** `tests/test_go_world_signal_bridge.py` drives `tools/world_signal_ingestor_go`, loads the resulting receipts through the Python bridge, projects a world-feed row, and verifies the Control Surface row from `DHARMA_STATE_DIR`.
- **New drift introduced:** None intentional. The PR adds no live network fetch, runtime execution hook, new database, or dashboard-owned truth; missing receipts show as declared-only until observed receipt files exist.

## Verification

- `pytest tests/test_go_world_signal_bridge.py tests/test_control_surface.py -q` passed.
- `make go-ci` passed.
- `python3 scripts/docops/check_docops_integrity.py --changed-from origin/main` passed.
- `git diff --check` passed.
- `pre-commit run --files ACTIVE_SURFACE_MANIFEST.yaml dharma_swarm/operator_core/control_surface.py dharma_swarm/operator_core/world_radar/__init__.py dharma_swarm/operator_core/world_radar/receipt_bridge.py tests/test_go_world_signal_bridge.py tests/test_control_surface.py docs/docops/AUTO_INVENTORY.md docs/governance/SOVEREIGN_MANIFEST.md` passed.
