### PR TITLE
feat(routing): add route witness telemetry

### DIFF
--- a/dharma_swarm/providers.py
+++ b/dharma_swarm/providers.py
@@ -79,7 +79,6 @@ from dharma_swarm.telemetry_plane import (
     EconomicEventRecord,
     ExternalOutcomeRecord,
     PolicyDecisionRecord,
-    RoutingDecisionRecord,
     TelemetryPlaneStore,
 )
 
@@ -2199,39 +2198,28 @@ class ModelRouter:
         initial_provider: ProviderType,
         initial_model: str,
         response_model: str | None = None,
+        route_metadata: dict[str, Any] | None = None,
     ) -> None:
         if self._telemetry is None:
             return
         scope = self._telemetry_scope(route_request)
         estimated_cost_usd = _estimate_cost(selected_model, prompt_tokens, completion_tokens)
-        routing_record = RoutingDecisionRecord(
-            decision_id=self._telemetry_id("route"),
-            action_name=route_request.action_name,
-            route_path=decision.path.value,
-            selected_provider=selected_provider.value,
-            selected_model_hint=selected_model,
-            confidence=decision.confidence,
-            requires_human=decision.requires_human,
-            session_id=scope["session_id"],
-            task_id=scope["task_id"],
-            run_id=scope["run_id"],
-            reasons=list(decision.reasons),
-            metadata={
-                "result": result,
-                "task_signature": task_signature,
-                "candidate_chain": [provider.value for provider in chain],
-                "initial_selected_provider": initial_provider.value,
-                "initial_selected_model": initial_model,
-                "fallback_selected": selected_provider != initial_provider,
-                "latency_ms": round(float(latency_ms), 3),
-                "prompt_tokens": int(prompt_tokens),
-                "completion_tokens": int(completion_tokens),
-                "total_tokens": int(total_tokens),
-                "estimated_cost_usd": estimated_cost_usd,
-                "response_model": response_model or "",
-                "failure_trace": list(failure_trace),
-            },
-        )
+        metadata = {
+            "result": result,
+            "task_signature": task_signature,
+            "candidate_chain": [provider.value for provider in chain],
+            "initial_selected_provider": initial_provider.value,
+            "initial_selected_model": initial_model,
+            "fallback_selected": selected_provider != initial_provider,
+            "latency_ms": round(float(latency_ms), 3),
+            "prompt_tokens": int(prompt_tokens),
+            "completion_tokens": int(completion_tokens),
+            "total_tokens": int(total_tokens),
+            "estimated_cost_usd": estimated_cost_usd,
+            "response_model": response_model or "",
+            "failure_trace": list(failure_trace),
+        }
+        metadata.update(route_metadata or {})
         completion_outcome = ExternalOutcomeRecord(
             outcome_id=self._telemetry_id("outcome"),
             outcome_kind="provider_completion",
@@ -2255,8 +2243,92 @@ class ModelRouter:
                 "response_model": response_model or "",
             },
         )
+        decision_id = self._telemetry_id("route")
+        attempt_records = []
         try:
-            await self._telemetry.record_routing_decision(routing_record)
+            from dharma_swarm.route_witness import (
+                build_provider_attempt,
+                emit_routing_decision,
+            )
+
+            for item in failure_trace:
+                provider_name = str(item.get("provider") or "")
+                provider_arg: ProviderType | str = (
+                    self._parse_provider_type(provider_name) or provider_name
+                )
+                attempt_records.append(
+                    build_provider_attempt(
+                        decision_id=decision_id,
+                        attempt_idx=len(attempt_records),
+                        provider=provider_arg,
+                        model=str(item.get("model") or ""),
+                        success=False,
+                        duration_ms=float(item.get("latency_ms") or 0.0),
+                        error=str(item.get("error") or "") or None,
+                        circuit_state=str(item.get("state") or "closed"),
+                    )
+                )
+            if result == "success":
+                attempt_records.append(
+                    build_provider_attempt(
+                        decision_id=decision_id,
+                        attempt_idx=len(attempt_records),
+                        provider=selected_provider,
+                        model=selected_model,
+                        success=True,
+                        duration_ms=float(latency_ms),
+                        usage={
+                            "prompt_tokens": int(prompt_tokens),
+                            "completion_tokens": int(completion_tokens),
+                            "total_tokens": int(total_tokens),
+                        },
+                        cost_estimate_usd=estimated_cost_usd,
+                    )
+                )
+            if "canary_applied" in decision.reasons:
+                decision_class = "canary"
+            elif selected_provider != initial_provider:
+                decision_class = "fallback"
+            elif result != "success" and len(chain) > 1:
+                decision_class = "fallback"
+            else:
+                decision_class = "pinned"
+            await emit_routing_decision(
+                decision_id=decision_id,
+                action_name=route_request.action_name,
+                route_path=decision.path.value,
+                selected_provider=selected_provider,
+                selected_model=selected_model,
+                candidate_chain=chain,
+                decision_class=decision_class,
+                caller="providers.ModelRouter.complete_for_task",
+                duration_ms=float(latency_ms),
+                attempts=attempt_records,
+                task_type=str(route_request.context.get("task_type") or "unknown"),
+                task_signature=task_signature,
+                confidence=decision.confidence,
+                requires_human=decision.requires_human,
+                reasons=list(decision.reasons),
+                widened_from=(
+                    initial_provider if selected_provider != initial_provider else None
+                ),
+                session_id=scope["session_id"],
+                task_id=scope["task_id"],
+                run_id=scope["run_id"],
+                total_tokens=int(total_tokens),
+                cost_estimate_usd=estimated_cost_usd,
+                outcome="success" if result == "success" else "all_failed",
+                metadata=metadata,
+                telemetry=self._telemetry,
+                audit_log_path=self._routing_audit_path,
+                telemetry_enabled=True,
+                audit_enabled=self._routing_audit_enabled,
+            )
+        except Exception:
+            # Route witness is observational. Preserve completion/outcome/cost
+            # telemetry even if canonical witness construction fails.
+            pass
+        try:
             await self._telemetry.record_external_outcome(completion_outcome)
             if total_tokens > 0 or estimated_cost_usd > 0.0:
                 await self._telemetry.record_economic_event(
@@ -2283,6 +2355,164 @@ class ModelRouter:
                 )
         except Exception:
             return
+
+    async def _record_resident_degraded_handoff(
+        self,
+        *,
+        route_request: ProviderRouteRequest,
+        decision: ProviderRouteDecision,
+        chain: list[ProviderType],
+        task_signature: str,
+        reason: str,
+        outcome: str,
+        failure_trace: list[dict[str, Any]] | None = None,
+    ) -> None:
+        """Record that provider routing failed but the resident agent stayed awake.
+
+        This is not routing policy and it does not choose a provider. It creates
+        an observable control-plane handoff so "no provider available" never
+        becomes "no agent aware of the task."
+        """
+        scope = self._telemetry_scope(route_request)
+        failure_trace = list(failure_trace or [])
+        decision_id = self._telemetry_id("resident")
+
+        try:
+            from dharma_swarm.route_witness import (
+                build_provider_attempt,
+                emit_routing_decision,
+                redact_error_detail,
+            )
+        except Exception:
+            build_provider_attempt = None  # type: ignore[assignment]
+            emit_routing_decision = None  # type: ignore[assignment]
+
+            def redact_error_detail(value: str) -> str:  # type: ignore[no-redef]
+                return str(value or "")[:200]
+
+        safe_failures: list[dict[str, Any]] = []
+        attempt_records = []
+        for item in failure_trace:
+            provider_name = str(item.get("provider") or "")
+            model_name = str(item.get("model") or "")
+            error = redact_error_detail(str(item.get("error") or ""))
+            safe_failures.append(
+                {
+                    "provider": provider_name,
+                    "model": model_name,
+                    "error": error,
+                    "state": str(item.get("state") or ""),
+                    "latency_ms": float(item.get("latency_ms") or 0.0),
+                }
+            )
+            if build_provider_attempt is None or not provider_name:
+                continue
+            provider_arg: ProviderType | str = (
+                self._parse_provider_type(provider_name) or provider_name
+            )
+            try:
+                attempt_records.append(
+                    build_provider_attempt(
+                        decision_id=decision_id,
+                        attempt_idx=len(attempt_records),
+                        provider=provider_arg,
+                        model=model_name,
+                        success=False,
+                        duration_ms=float(item.get("latency_ms") or 0.0),
+                        error=error or None,
+                        circuit_state=str(item.get("state") or "closed"),
+                    )
+                )
+            except Exception:
+                continue
+
+        chain_values = [provider.value for provider in chain]
+        metadata = {
+            "result": "resident_degraded_handoff",
+            "resident_fallback": True,
+            "resident_agent": "resident_control_plane",
+            "handoff_reason": reason,
+            "task_signature": task_signature,
+            "candidate_chain": chain_values,
+            "failure_trace": safe_failures,
+            "next_action": "operator_or_resident_agent_retry_when_provider_available",
+        }
+        reasons = [*decision.reasons, f"resident_degraded_handoff:{reason}"]
+
+        if emit_routing_decision is not None:
+            try:
+                await emit_routing_decision(
+                    decision_id=decision_id,
+                    action_name=route_request.action_name,
+                    route_path=decision.path.value,
+                    selected_provider="",
+                    selected_model="resident-control-plane",
+                    candidate_chain=chain,
+                    decision_class="no_route",
+                    caller="providers.ModelRouter.resident_degraded_handoff",
+                    duration_ms=0.0,
+                    attempts=attempt_records,
+                    task_type=str(route_request.context.get("task_type") or "unknown"),
+                    task_signature=task_signature,
+                    confidence=0.0,
+                    requires_human=True,
+                    reasons=reasons,
+                    session_id=scope["session_id"],
+                    task_id=scope["task_id"],
+                    run_id=scope["run_id"],
+                    total_tokens=0,
+                    cost_estimate_usd=0.0,
+                    outcome=outcome,
+                    metadata=metadata,
+                    telemetry=self._telemetry,
+                    audit_log_path=self._routing_audit_path,
+                    telemetry_enabled=self._telemetry is not None,
+                    audit_enabled=self._routing_audit_enabled,
+                )
+            except Exception:
+                pass
+
+        if self._telemetry is not None:
+            try:
+                await self._telemetry.record_external_outcome(
+                    ExternalOutcomeRecord(
+                        outcome_id=self._telemetry_id("outcome"),
+                        outcome_kind="resident_degraded_handoff",
+                        value=1.0,
+                        unit="handoff",
+                        confidence=1.0,
+                        status="queued",
+                        subject_id="resident_control_plane",
+                        summary=(
+                            f"{route_request.action_name} handed to resident "
+                            f"control plane: {reason}"
+                        ),
+                        session_id=scope["session_id"],
+                        task_id=scope["task_id"],
+                        run_id=scope["run_id"],
+                        metadata=metadata,
+                    )
+                )
+            except Exception:
+                pass
+
+        try:
+            from dharma_swarm.stigmergy import leave_stigmergic_mark
+
+            await leave_stigmergic_mark(
+                agent="resident_control_plane",
+                file_path="dharma_swarm/providers.py",
+                observation=(
+                    f"Provider route unavailable for {route_request.action_name}: "
+                    f"{reason}; resident handoff queued."
+                )[:200],
+                salience=0.95,
+                connections=[task_signature, *chain_values],
+                action="connect",
+                channel="action_queue",
+            )
+        except Exception:
+            pass
 
     def _apply_session_affinity(
         self,
@@ -2593,6 +2823,10 @@ class ModelRouter:
             enriched_request,
             available_provider_types=available_provider_types,
         )
+        task_signature = build_task_signature(
+            action_name=enriched_request.action_name,
+            context=enriched_request.context,
+        )
         chain = self._provider_chain(
             decision,
             available_provider_types=available_provider_types,
@@ -2602,11 +2836,16 @@ class ModelRouter:
             fallback_set = set(available_provider_types or self._providers.keys())
             chain = [p for p in self._providers if p in fallback_set]
         if not chain:
+            await self._record_resident_degraded_handoff(
+                route_request=enriched_request,
+                decision=decision,
+                chain=[],
+                task_signature=task_signature,
+                reason="no_available_providers_after_routing_filter",
+                outcome="no_route",
+                failure_trace=[],
+            )
             raise RuntimeError("No available providers after routing filter")
-        task_signature = build_task_signature(
-            action_name=enriched_request.action_name,
-            context=enriched_request.context,
-        )
         preserve_requested_model = bool(
             enriched_request.context.get("preserve_requested_model")
         )
@@ -2794,6 +3033,7 @@ class ModelRouter:
                             "model": request_for_provider.model,
                             "error": response_error,
                             "state": breaker.state.value,
+                            "latency_ms": round(float(latency_ms), 3),
                         }
                     )
                     await self._record_provider_attempt_outcome(
@@ -2860,33 +3100,6 @@ class ModelRouter:
                         ],
                         reasons=[*decision.reasons, "fallback_provider_selected"],
                     )
-                self._append_routing_audit(
-                    {
-                        "timestamp": started_at.isoformat(),
-                        "action": enriched_request.action_name,
-                        "path": decision.path.value,
-                        "provider_selected": routed_decision.selected_provider.value,
-                        "model_selected": selected_model,
-                        "chain": [item.value for item in chain],
-                        "reward_scores": {
-                            item.value: self._reward_for(
-                                item, model_hints.get(item) or ""
-                            )
-                            for item in chain
-                        },
-                        "routing_memory_scores": routing_memory_scores,
-                        "task_signature": task_signature,
-                        "reasons": routed_decision.reasons,
-                        "signals": {
-                            "language_code": signals.language_code,
-                            "complexity_tier": signals.complexity_tier,
-                            "complexity_score": signals.complexity_score,
-                            "token_estimate": signals.token_estimate,
-                        },
-                        "failures": failure_trace,
-                        "result": "success",
-                    }
-                )
                 await self._record_route_execution_telemetry(
                     route_request=enriched_request,
                     decision=routed_decision,
@@ -2903,6 +3116,22 @@ class ModelRouter:
                     initial_provider=planned_provider,
                     initial_model=planned_model,
                     response_model=response.model,
+                    route_metadata={
+                        "started_at": started_at.isoformat(),
+                        "reward_scores": {
+                            item.value: self._reward_for(
+                                item, model_hints.get(item) or ""
+                            )
+                            for item in chain
+                        },
+                        "routing_memory_scores": routing_memory_scores,
+                        "signals": {
+                            "language_code": signals.language_code,
+                            "complexity_tier": signals.complexity_tier,
+                            "complexity_score": signals.complexity_score,
+                            "token_estimate": signals.token_estimate,
+                        },
+                    },
                 )
                 # Enrich response with provider info for trajectory capture
                 if not response.provider:
@@ -2932,6 +3161,7 @@ class ModelRouter:
                         "model": request_for_provider.model,
                         "error": str(exc)[:300],
                         "state": breaker.state.value,
+                        "latency_ms": round(float(latency_ms), 3),
                     }
                 )
                 await self._record_provider_attempt_outcome(
@@ -2946,31 +3176,6 @@ class ModelRouter:
                     error=str(exc)[:120],
                 )
 
-        self._append_routing_audit(
-            {
-                "timestamp": started_at.isoformat(),
-                "action": enriched_request.action_name,
-                "path": decision.path.value,
-                "provider_selected": decision.selected_provider.value,
-                "model_selected": selected_model,
-                "chain": [item.value for item in chain],
-                "reward_scores": {
-                    item.value: self._reward_for(item, model_hints.get(item) or "")
-                    for item in chain
-                },
-                "routing_memory_scores": routing_memory_scores,
-                "task_signature": task_signature,
-                "reasons": decision.reasons,
-                "signals": {
-                    "language_code": signals.language_code,
-                    "complexity_tier": signals.complexity_tier,
-                    "complexity_score": signals.complexity_score,
-                    "token_estimate": signals.token_estimate,
-                },
-                "failures": failure_trace,
-                "result": "failed",
-            }
-        )
         await self._record_route_execution_telemetry(
             route_request=enriched_request,
             decision=decision,
@@ -2986,6 +3191,29 @@ class ModelRouter:
             failure_trace=failure_trace,
             initial_provider=planned_provider,
             initial_model=planned_model,
+            route_metadata={
+                "started_at": started_at.isoformat(),
+                "reward_scores": {
+                    item.value: self._reward_for(item, model_hints.get(item) or "")
+                    for item in chain
+                },
+                "routing_memory_scores": routing_memory_scores,
+                "signals": {
+                    "language_code": signals.language_code,
+                    "complexity_tier": signals.complexity_tier,
+                    "complexity_score": signals.complexity_score,
+                    "token_estimate": signals.token_estimate,
+                },
+            },
+        )
+        await self._record_resident_degraded_handoff(
+            route_request=enriched_request,
+            decision=decision,
+            chain=chain,
+            task_signature=task_signature,
+            reason="all_providers_failed",
+            outcome="all_failed",
+            failure_trace=failure_trace,
         )
         trace_preview = "; ".join(
             f"{item.get('provider')}:{item.get('error')}" for item in failure_trace[-6:]

--- a/dharma_swarm/route_witness.py
+++ b/dharma_swarm/route_witness.py
@@ -1,0 +1,625 @@
+"""Canonical route witness emitter (Phase 1, 2026-05-10).
+
+Single responsibility: build, redact, classify, and emit routing decision
+records to the existing TelemetryPlaneStore + audit JSONL. **NEVER routes,
+gates, ranks, or chooses providers.** Decision authority remains with
+``ProviderPolicyRouter``; execution remains with ``ModelRouter``;
+persistence remains with ``TelemetryPlaneStore``. This module is the
+emission/normalization layer that makes Phase 1 dashboard-ready without
+inventing a second routing reality.
+
+See docs/plans/2026-05-10-phase1-routing-witness.md for the full spec.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import re
+from dataclasses import asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Literal
+
+from dharma_swarm.models import ProviderType
+from dharma_swarm.telemetry_plane import (
+    DEFAULT_TELEMETRY_DB,
+    ProviderAttemptRecord,
+    RoutingDecisionRecord,
+    TelemetryPlaneStore,
+)
+
+logger = logging.getLogger(__name__)
+
+# --- Public constants ----------------------------------------------------
+
+# Single source of truth for the Phase 1 error class enumeration. Each
+# string is what gets stored in ProviderAttemptRecord.error_class so
+# Grafana/SQL queries can filter by error class without parsing prose.
+ERROR_CLASS_CREDIT_EXHAUSTED = "credit_exhausted"
+ERROR_CLASS_RATE_LIMIT = "rate_limit"
+ERROR_CLASS_TIMEOUT = "timeout"
+ERROR_CLASS_NETWORK = "network"
+ERROR_CLASS_MODEL_UNAVAILABLE = "model_unavailable"
+ERROR_CLASS_EMPTY_CONTENT = "empty_content"
+ERROR_CLASS_API_ERROR = "api_error"
+ERROR_CLASS_AUTH_ERROR = "auth_error"
+ERROR_CLASS_UNKNOWN = "unknown"
+
+ERROR_CLASSES: tuple[str, ...] = (
+    ERROR_CLASS_CREDIT_EXHAUSTED,
+    ERROR_CLASS_RATE_LIMIT,
+    ERROR_CLASS_TIMEOUT,
+    ERROR_CLASS_NETWORK,
+    ERROR_CLASS_MODEL_UNAVAILABLE,
+    ERROR_CLASS_EMPTY_CONTENT,
+    ERROR_CLASS_API_ERROR,
+    ERROR_CLASS_AUTH_ERROR,
+    ERROR_CLASS_UNKNOWN,
+)
+
+DECISION_CLASSES: tuple[str, ...] = (
+    "pinned", "widened", "fallback", "no_route", "canary",
+)
+
+OUTCOMES: tuple[str, ...] = (
+    "success", "empty_content", "all_failed", "timeout", "gate_block", "no_route",
+)
+
+MAX_ERROR_DETAIL_CHARS = 200
+
+# --- Tier and cost lookup ------------------------------------------------
+
+# Free providers (zero marginal cost). All others are 'paid' or 'cheap'
+# depending on the canonical seed order tier in model_hierarchy.
+_FREE_PROVIDERS: frozenset[str] = frozenset({
+    ProviderType.OLLAMA.value,
+    ProviderType.NVIDIA_NIM.value,
+    ProviderType.GROQ.value,
+    ProviderType.CEREBRAS.value,
+    ProviderType.SILICONFLOW.value,
+    ProviderType.SAMBANOVA.value,
+    ProviderType.TOGETHER.value,
+    ProviderType.FIREWORKS.value,
+    ProviderType.OPENROUTER_FREE.value,
+})
+
+_CHEAP_PROVIDERS: frozenset[str] = frozenset({
+    ProviderType.MISTRAL.value,
+    ProviderType.GOOGLE_AI.value,
+    ProviderType.CHUTES.value,
+})
+
+# Per-1K-token rough estimates (USD). Used only when a caller doesn't
+# supply cost_estimate_usd. Conservative; updated via Phase 2 once we
+# have empirical cost data from the witness.
+_PROVIDER_COST_PER_1K_INPUT_USD: dict[str, float] = {
+    ProviderType.ANTHROPIC.value: 0.015,    # claude-opus-4 ~ $15/1M input
+    ProviderType.OPENAI.value: 0.0125,      # gpt-5 ~ $12.5/1M input
+    ProviderType.OPENROUTER.value: 0.005,   # mid-range default
+    ProviderType.CLAUDE_CODE.value: 0.015,  # mirrors anthropic
+    ProviderType.CODEX.value: 0.0125,       # mirrors openai
+}
+
+_PROVIDER_COST_PER_1K_OUTPUT_USD: dict[str, float] = {
+    ProviderType.ANTHROPIC.value: 0.075,    # claude-opus-4 ~ $75/1M output
+    ProviderType.OPENAI.value: 0.10,        # gpt-5 ~ $100/1M output
+    ProviderType.OPENROUTER.value: 0.015,
+    ProviderType.CLAUDE_CODE.value: 0.075,
+    ProviderType.CODEX.value: 0.10,
+}
+
+
+def _provider_value(provider: ProviderType | str) -> str:
+    if isinstance(provider, ProviderType):
+        return provider.value
+    return str(provider)
+
+
+def tier_for_provider(provider: ProviderType | str) -> Literal["free", "cheap", "paid", "unknown"]:
+    """Classify a provider lane into free / cheap / paid for slicing."""
+    name = _provider_value(provider)
+    if not name:
+        return "unknown"
+    if name in _FREE_PROVIDERS:
+        return "free"
+    if name in _CHEAP_PROVIDERS:
+        return "cheap"
+    return "paid"
+
+
+def estimate_cost_usd(
+    provider: ProviderType | str,
+    *,
+    prompt_tokens: int = 0,
+    completion_tokens: int = 0,
+) -> float:
+    """Conservative cost estimate from token usage. 0.0 for free lanes.
+
+    Phase 2 will replace this with model-specific pricing pulled from
+    model_hierarchy.py. For Phase 1 we use a single per-provider rate so
+    the witness has a non-zero baseline cost dimension.
+    """
+    name = _provider_value(provider)
+    if name in _FREE_PROVIDERS:
+        return 0.0
+    in_rate = _PROVIDER_COST_PER_1K_INPUT_USD.get(name, 0.001)
+    out_rate = _PROVIDER_COST_PER_1K_OUTPUT_USD.get(name, 0.003)
+    cost = (prompt_tokens / 1000.0) * in_rate + (completion_tokens / 1000.0) * out_rate
+    return round(cost, 6)
+
+
+# --- Redaction -----------------------------------------------------------
+
+# Patterns that must NEVER reach the witness file.
+_REDACTION_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"sk-[A-Za-z0-9_-]{16,}"), "[redacted-key]"),
+    (re.compile(r"Bearer\s+[A-Za-z0-9_.-]{16,}", re.IGNORECASE), "Bearer [redacted]"),
+    (re.compile(r"\b[A-Fa-f0-9]{32,}\b"), "[redacted-hex]"),
+    (re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}"), "[redacted-email]"),
+    (
+        re.compile(r"(?i)(api[_-]?key|token|secret|password|authorization)\s*[=:]\s*\S+"),
+        r"\1=[redacted]",
+    ),
+    (re.compile(r"/Users/[^/\s]+/\.dharma/[^\s]*"), "<witness_path>"),
+    (re.compile(r"/Users/[^/\s]+/\.claude/[^\s]*"), "<claude_config_path>"),
+)
+
+
+def _scrub_secret_patterns(text: str) -> str:
+    redacted = text
+    for pattern, replacement in _REDACTION_PATTERNS:
+        redacted = pattern.sub(replacement, redacted)
+    return redacted
+
+
+def redact_error_detail(detail: str) -> str:
+    """Scrub secret patterns, then truncate to MAX_ERROR_DETAIL_CHARS.
+
+    If after redaction the string is empty or only whitespace, returns
+    '[redacted]' so the column is never empty for an attempt that
+    actually had an error.
+    """
+    if not detail:
+        return ""
+    # Scrub before truncation so a secret that crosses the truncation boundary
+    # cannot leave a prefix behind. Scrub again after truncation in case the
+    # replacement exposed a secondary pattern.
+    original = detail.strip()
+    scrubbed = _scrub_secret_patterns(original)
+    if len(scrubbed) > MAX_ERROR_DETAIL_CHARS and scrubbed != original:
+        suffix = " [redacted]"
+        redacted = scrubbed[: MAX_ERROR_DETAIL_CHARS - len(suffix)].rstrip() + suffix
+    else:
+        redacted = scrubbed[:MAX_ERROR_DETAIL_CHARS]
+    redacted = _scrub_secret_patterns(redacted)
+    redacted = redacted.strip()
+    if not redacted:
+        return "[redacted]"
+    return redacted
+
+
+def _redact_json_value(value: Any) -> Any:
+    """Return a JSON-safe value with secret-bearing strings scrubbed.
+
+    route_witness owns all witness serialization, so this defensive pass also
+    covers metadata/reasons/caller fields, not just ProviderAttempt.error_detail.
+    """
+    if isinstance(value, str):
+        return _scrub_secret_patterns(value)
+    if isinstance(value, dict):
+        return {
+            _scrub_secret_patterns(str(key)): _redact_json_value(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, (list, tuple, set)):
+        return [_redact_json_value(item) for item in value]
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    return _scrub_secret_patterns(str(value))
+
+
+# --- Error classification ------------------------------------------------
+
+_CREDIT_PATTERNS = (
+    "credit balance is too low", "out of credits", "insufficient credit",
+    "billing", "payment required", "credits exhausted",
+)
+_RATE_LIMIT_PATTERNS = (
+    "rate limit", "rate-limited", "too many requests", "quota exceeded", "429",
+)
+_AUTH_PATTERNS = ("401", "unauthorized", "invalid api key", "authentication failed")
+_FORBIDDEN_PATTERNS = ("403", "forbidden", "access denied", "permission denied")
+_NETWORK_PATTERNS = (
+    "connection refused", "connection reset", "name resolution", "dns",
+    "network is unreachable", "no route to host",
+)
+_MODEL_UNAVAIL_PATTERNS = (
+    "model not found", "model_not_found", "no such model", "deprecated",
+    "404", "not_found", "model unavailable",
+)
+
+
+def classify_error(error: BaseException | str | None) -> str:
+    """Map an exception or error string to a Phase 1 error_class."""
+    if error is None:
+        return ""
+    if isinstance(error, asyncio.TimeoutError):
+        return ERROR_CLASS_TIMEOUT
+    msg = (str(error) or "").lower()
+    if not msg:
+        return ERROR_CLASS_UNKNOWN
+    if any(p in msg for p in _CREDIT_PATTERNS):
+        return ERROR_CLASS_CREDIT_EXHAUSTED
+    if any(p in msg for p in _RATE_LIMIT_PATTERNS):
+        return ERROR_CLASS_RATE_LIMIT
+    if any(p in msg for p in _AUTH_PATTERNS):
+        return ERROR_CLASS_AUTH_ERROR
+    if any(p in msg for p in _FORBIDDEN_PATTERNS):
+        # Forbidden is closer to auth than network; many providers return
+        # 403 for region/account blocks (e.g. Groq from APAC).
+        return ERROR_CLASS_AUTH_ERROR
+    if any(p in msg for p in _MODEL_UNAVAIL_PATTERNS):
+        return ERROR_CLASS_MODEL_UNAVAILABLE
+    if any(p in msg for p in _NETWORK_PATTERNS):
+        return ERROR_CLASS_NETWORK
+    if "timeout" in msg or "timed out" in msg:
+        return ERROR_CLASS_TIMEOUT
+    if "empty" in msg and "content" in msg:
+        return ERROR_CLASS_EMPTY_CONTENT
+    if "500" in msg or "503" in msg or "internal server error" in msg:
+        return ERROR_CLASS_API_ERROR
+    return ERROR_CLASS_UNKNOWN
+
+
+# --- Public builders -----------------------------------------------------
+
+def build_provider_attempt(
+    *,
+    decision_id: str,
+    attempt_idx: int,
+    provider: ProviderType | str,
+    model: str,
+    success: bool,
+    duration_ms: float,
+    error: BaseException | str | None = None,
+    error_class: str | None = None,
+    error_detail: str = "",
+    stop_reason: str | None = None,
+    usage: dict[str, int] | None = None,
+    cost_estimate_usd: float | None = None,
+    circuit_state: str = "closed",
+    outcome: str | None = None,
+) -> ProviderAttemptRecord:
+    """Construct a redacted, classified ProviderAttemptRecord.
+
+    Auto-derives:
+        - error_class from exception type/message if not provided.
+        - tier from provider name.
+        - cost_estimate_usd from token usage if not provided.
+    Always:
+        - redacts error_detail to ≤ MAX_ERROR_DETAIL_CHARS, scrubs secrets.
+    """
+    provider_name = _provider_value(provider)
+    derived_class = error_class or (classify_error(error) if error is not None or error_detail else "")
+    detail_source = error_detail or (str(error) if error is not None else "")
+    detail_redacted = redact_error_detail(detail_source) if detail_source else ""
+    usage_dict = {
+        str(k): max(0, int(v))
+        for k, v in (usage or {}).items()
+        if isinstance(v, (int, float))
+    }
+    if cost_estimate_usd is None:
+        cost_estimate_usd = estimate_cost_usd(
+            provider,
+            prompt_tokens=int(usage_dict.get("prompt_tokens", 0) or 0),
+            completion_tokens=int(usage_dict.get("completion_tokens", 0) or 0),
+        )
+    derived_outcome = outcome or ("success" if success else "failed")
+    return ProviderAttemptRecord(
+        decision_id=decision_id,
+        attempt_idx=max(0, int(attempt_idx)),
+        provider=provider_name,
+        model=str(model or ""),
+        tier=tier_for_provider(provider),
+        success=bool(success),
+        outcome=derived_outcome,
+        error_class=derived_class,
+        error_detail=detail_redacted,
+        duration_ms=max(0.0, float(duration_ms)),
+        stop_reason=str(stop_reason or ""),
+        usage=usage_dict,
+        cost_estimate_usd=max(0.0, float(cost_estimate_usd)),
+        circuit_state=str(circuit_state or "closed"),
+    )
+
+
+def _default_audit_path() -> Path:
+    env = os.environ.get("DGC_ROUTER_AUDIT_LOG", "").strip()
+    if env:
+        return Path(env)
+    return Path.home() / ".dharma" / "logs" / "router" / "routing_decisions.jsonl"
+
+
+def _audit_enabled() -> bool:
+    raw = os.environ.get("DGC_ROUTER_AUDIT_ENABLE", "1").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
+def _telemetry_enabled() -> bool:
+    raw = os.environ.get("DGC_ROUTER_TELEMETRY_ENABLE", "1").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
+def _helper_disabled() -> bool:
+    """Emergency kill-switch: DGC_ROUTE_WITNESS_DISABLE_HELPER=1 disables
+    all emissions from this module. ModelRouter falls back to its prior
+    direct emission path (if any). Set ONLY if the helper itself misbehaves.
+    """
+    raw = os.environ.get("DGC_ROUTE_WITNESS_DISABLE_HELPER", "0").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
+def _coerce_provider_list(items: Iterable[ProviderType | str]) -> list[str]:
+    out: list[str] = []
+    for item in items:
+        out.append(_provider_value(item))
+    return out
+
+
+def _resolve_decision_outcome(
+    *,
+    explicit: str | None,
+    attempts: list[ProviderAttemptRecord],
+) -> str:
+    if explicit:
+        return explicit
+    if not attempts:
+        return "no_route"
+    if any(a.success for a in attempts):
+        return "success"
+    classes = {a.error_class for a in attempts}
+    if classes == {ERROR_CLASS_TIMEOUT}:
+        return "timeout"
+    if not classes - {""}:
+        return "all_failed"
+    return "all_failed"
+
+
+def _decision_to_jsonl_row(
+    record: RoutingDecisionRecord,
+) -> dict[str, Any]:
+    return {
+        "row_kind": "decision",
+        "schema_version": record.schema_version or "v1",
+        "decision_id": record.decision_id,
+        "ts": record.created_at.isoformat(),
+        "session_id": record.session_id,
+        "task_id": record.task_id,
+        "run_id": record.run_id,
+        "task_signature": record.task_signature,
+        "task_type": record.task_type,
+        "caller": record.caller,
+        "action_name": record.action_name,
+        "route_path": record.route_path,
+        "decision_class": record.decision_class,
+        "requires_human": record.requires_human,
+        "confidence": record.confidence,
+        "reasons": list(record.reasons),
+        "candidate_chain": list(record.candidate_chain),
+        "selected_provider": record.selected_provider,
+        "selected_model": record.selected_model_hint,
+        "selected_tier": record.selected_tier,
+        "widened_from": record.widened_from,
+        "n_attempts": record.n_attempts,
+        "outcome": record.outcome,
+        "duration_ms": record.duration_ms,
+        "total_tokens": record.total_tokens,
+        "cost_estimate_usd": record.cost_estimate_usd,
+        "metadata": dict(record.metadata),
+    }
+
+
+def _attempt_to_jsonl_row(
+    record: ProviderAttemptRecord,
+) -> dict[str, Any]:
+    return {
+        "row_kind": "attempt",
+        "schema_version": record.schema_version or "v1",
+        "decision_id": record.decision_id,
+        "attempt_idx": record.attempt_idx,
+        "ts": record.created_at.isoformat(),
+        "provider": record.provider,
+        "model": record.model,
+        "tier": record.tier,
+        "success": record.success,
+        "outcome": record.outcome,
+        "error_class": record.error_class,
+        "error_detail": record.error_detail,
+        "duration_ms": record.duration_ms,
+        "stop_reason": record.stop_reason,
+        "usage": dict(record.usage),
+        "cost_estimate_usd": record.cost_estimate_usd,
+        "circuit_state": record.circuit_state,
+    }
+
+
+def _append_jsonl(path: Path, rows: list[dict[str, Any]]) -> None:
+    """Atomic append of all rows in one open()/write()/close().
+
+    SQLite transactions are atomic; for the audit JSONL we approximate
+    atomicity by writing all rows under a single file handle. Concurrent
+    writers can still interleave at the OS level; for true atomicity the
+    decision row + attempts would need a separate per-decision file.
+    Phase 1 accepts the residual interleave risk — every row carries
+    decision_id so consumers can reconstruct the decision tree.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = "\n".join(json.dumps(row, sort_keys=True) for row in rows) + "\n"
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(payload)
+
+
+_global_telemetry: TelemetryPlaneStore | None = None
+
+
+def _shared_telemetry() -> TelemetryPlaneStore:
+    """Lazily construct a singleton TelemetryPlaneStore on the default DB.
+
+    Callers that already own a store should pass it via the kwarg; this
+    fallback exists for direct-call sites (heartbeat pulse, inquiry chew)
+    that don't have access to the SwarmManager-owned instance.
+    """
+    global _global_telemetry
+    if _global_telemetry is None:
+        _global_telemetry = TelemetryPlaneStore(db_path=DEFAULT_TELEMETRY_DB)
+    return _global_telemetry
+
+
+async def emit_routing_decision(
+    *,
+    decision_id: str,
+    action_name: str,
+    route_path: str,
+    selected_provider: ProviderType | str,
+    selected_model: str,
+    candidate_chain: Iterable[ProviderType | str],
+    decision_class: str,
+    caller: str,
+    duration_ms: float,
+    attempts: list[ProviderAttemptRecord],
+    task_type: str = "unknown",
+    task_signature: str = "",
+    confidence: float = 0.0,
+    requires_human: bool = False,
+    reasons: list[str] | None = None,
+    widened_from: ProviderType | str | None = None,
+    session_id: str = "",
+    task_id: str = "",
+    run_id: str = "",
+    total_tokens: int | None = None,
+    cost_estimate_usd: float | None = None,
+    outcome: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    telemetry: TelemetryPlaneStore | None = None,
+    audit_log_path: Path | None = None,
+    telemetry_enabled: bool | None = None,
+    audit_enabled: bool | None = None,
+) -> None:
+    """Write one canonical RoutingDecisionRecord + N ProviderAttemptRecord rows.
+
+    Best-effort. Logs and swallows all exceptions; never raises into the
+    caller. A witness write failure must never break a real LLM call.
+    Honours kill-switch ``DGC_ROUTE_WITNESS_DISABLE_HELPER=1``.
+    """
+    if _helper_disabled():
+        return
+
+    try:
+        attempts = list(attempts)
+        chain = [
+            str(_redact_json_value(item))
+            for item in _coerce_provider_list(candidate_chain)
+        ]
+        widened = (
+            str(_redact_json_value(_provider_value(widened_from)))
+            if widened_from else ""
+        )
+        selected = str(_redact_json_value(_provider_value(selected_provider)))
+        safe_metadata = _redact_json_value(metadata or {})
+        if not isinstance(safe_metadata, dict):
+            safe_metadata = {}
+        safe_reasons = [
+            str(_redact_json_value(item)) for item in (reasons or [])
+        ]
+        if decision_class not in DECISION_CLASSES:
+            logger.debug("route_witness: unknown decision_class %r, allowing through", decision_class)
+        derived_outcome = _resolve_decision_outcome(explicit=outcome, attempts=attempts)
+        if total_tokens is None:
+            total_tokens = sum(
+                int(a.usage.get("total_tokens", 0) or 0)
+                or (
+                    int(a.usage.get("prompt_tokens", 0) or 0)
+                    + int(a.usage.get("completion_tokens", 0) or 0)
+                )
+                for a in attempts
+            )
+        if cost_estimate_usd is None:
+            cost_estimate_usd = round(sum(a.cost_estimate_usd for a in attempts), 6)
+        record = RoutingDecisionRecord(
+            decision_id=decision_id,
+            action_name=str(_redact_json_value(action_name)),
+            route_path=str(_redact_json_value(route_path)),
+            selected_provider=selected,
+            selected_model_hint=str(_redact_json_value(selected_model or "")),
+            confidence=float(confidence),
+            requires_human=bool(requires_human),
+            session_id=str(_redact_json_value(session_id)),
+            task_id=str(_redact_json_value(task_id)),
+            run_id=str(_redact_json_value(run_id)),
+            reasons=safe_reasons,
+            metadata=safe_metadata,
+            schema_version="v1",
+            task_signature=str(_redact_json_value(task_signature)),
+            task_type=str(_redact_json_value(task_type)),
+            caller=str(_redact_json_value(caller)),
+            decision_class=str(_redact_json_value(decision_class)),
+            selected_tier=tier_for_provider(selected) if selected else "unknown",
+            widened_from=widened,
+            candidate_chain=chain,
+            n_attempts=len(attempts),
+            outcome=derived_outcome,
+            duration_ms=max(0.0, float(duration_ms)),
+            total_tokens=max(0, int(total_tokens or 0)),
+            cost_estimate_usd=max(0.0, float(cost_estimate_usd or 0.0)),
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning("route_witness: failed to construct RoutingDecisionRecord", exc_info=True)
+        return
+
+    # SQLite write
+    if (_telemetry_enabled() if telemetry_enabled is None else bool(telemetry_enabled)):
+        try:
+            store = telemetry or _shared_telemetry()
+            await store.record_routing_decision(record)
+            for attempt in attempts:
+                await store.record_provider_attempt(attempt)
+        except Exception:  # noqa: BLE001
+            logger.warning("route_witness: telemetry write failed", exc_info=True)
+
+    # JSONL audit (decision row first, then attempts in attempt_idx order)
+    if (_audit_enabled() if audit_enabled is None else bool(audit_enabled)):
+        try:
+            path = audit_log_path or _default_audit_path()
+            sorted_attempts = sorted(attempts, key=lambda a: a.attempt_idx)
+            rows = [_decision_to_jsonl_row(record)] + [
+                _attempt_to_jsonl_row(a) for a in sorted_attempts
+            ]
+            _append_jsonl(path, rows)
+        except Exception:  # noqa: BLE001
+            logger.warning("route_witness: audit JSONL write failed", exc_info=True)
+
+
+__all__ = [
+    "DECISION_CLASSES",
+    "ERROR_CLASSES",
+    "ERROR_CLASS_API_ERROR",
+    "ERROR_CLASS_AUTH_ERROR",
+    "ERROR_CLASS_CREDIT_EXHAUSTED",
+    "ERROR_CLASS_EMPTY_CONTENT",
+    "ERROR_CLASS_MODEL_UNAVAILABLE",
+    "ERROR_CLASS_NETWORK",
+    "ERROR_CLASS_RATE_LIMIT",
+    "ERROR_CLASS_TIMEOUT",
+    "ERROR_CLASS_UNKNOWN",
+    "MAX_ERROR_DETAIL_CHARS",
+    "OUTCOMES",
+    "build_provider_attempt",
+    "classify_error",
+    "emit_routing_decision",
+    "estimate_cost_usd",
+    "redact_error_detail",
+    "tier_for_provider",
+]

--- a/dharma_swarm/runtime_provider.py
+++ b/dharma_swarm/runtime_provider.py
@@ -597,8 +597,24 @@ async def complete_via_preferred_runtime_providers(
     working_dir: str | None = None,
     timeout_seconds: float | None = None,
     env: Mapping[str, str] | None = None,
+    caller: str = "complete_via_preferred",
+    action_name: str = "preferred_runtime_chain",
+    task_type: str = "unknown",
+    task_signature: str = "",
+    session_id: str = "",
+    task_id: str = "",
+    run_id: str = "",
 ) -> tuple[LLMResponse, RuntimeProviderConfig]:
-    """Complete an LLM request via the canonical cheap-first runtime stack."""
+    """Complete an LLM request via the canonical cheap-first runtime stack.
+
+    Phase 1 (2026-05-10): emits one canonical RoutingDecisionRecord +
+    N ProviderAttemptRecord rows via ``route_witness``. Best-effort,
+    never raises through emission failures. See
+    docs/plans/2026-05-10-phase1-routing-witness.md.
+    """
+
+    import time as _time
+    import uuid as _uuid
 
     overrides: dict[ProviderType, str | None] = {
         ProviderType.OPENROUTER_FREE: openrouter_model,
@@ -619,9 +635,18 @@ async def complete_via_preferred_runtime_providers(
             "No preferred providers available; configure Ollama, NVIDIA NIM, OpenRouter, or Anthropic"
         )
 
+    decision_id = _uuid.uuid4().hex
+    chain_started = _time.monotonic()
+    attempt_records: list[Any] = []  # ProviderAttemptRecord; deferred import for cycle safety
+
     last_exc: Exception | None = None
-    for config in configs:
+    chosen_response: LLMResponse | None = None
+    chosen_config: RuntimeProviderConfig | None = None
+    for attempt_idx, config in enumerate(configs):
+        attempt_started = _time.monotonic()
         provider = create_runtime_provider(config)
+        attempt_response: LLMResponse | None = None
+        attempt_error: BaseException | None = None
         try:
             request = LLMRequest(
                 model=config.default_model or anthropic_model or openrouter_model or DEFAULT_NIM_MODEL,
@@ -631,19 +656,89 @@ async def complete_via_preferred_runtime_providers(
                 temperature=temperature,
             )
             if timeout_seconds is not None:
-                response = await asyncio.wait_for(
+                attempt_response = await asyncio.wait_for(
                     provider.complete(request),
                     timeout=timeout_seconds,
                 )
             else:
-                response = await provider.complete(request)
-            return response, config
+                attempt_response = await provider.complete(request)
+            chosen_response = attempt_response
+            chosen_config = config
         except Exception as exc:
+            attempt_error = exc
             last_exc = exc
         finally:
             close = getattr(provider, "close", None)
             if callable(close):
                 await close()
+
+        # Build attempt record (best-effort import; emission helper itself
+        # tolerates absent records and is also best-effort).
+        try:
+            from dharma_swarm.route_witness import build_provider_attempt as _bpa
+            attempt_records.append(
+                _bpa(
+                    decision_id=decision_id,
+                    attempt_idx=attempt_idx,
+                    provider=config.provider,
+                    model=config.default_model or "",
+                    success=attempt_error is None and attempt_response is not None,
+                    duration_ms=(_time.monotonic() - attempt_started) * 1000.0,
+                    error=attempt_error,
+                    stop_reason=getattr(attempt_response, "stop_reason", None) if attempt_response is not None else None,
+                    usage=dict(getattr(attempt_response, "usage", {}) or {}) if attempt_response is not None else None,
+                )
+            )
+        except Exception:
+            pass
+
+        if chosen_response is not None:
+            break
+
+    duration_ms = (_time.monotonic() - chain_started) * 1000.0
+
+    # Emit canonical route witness for the chain (best-effort).
+    try:
+        from dharma_swarm.route_witness import emit_routing_decision as _emit
+        chain_providers = [c.provider for c in configs]
+        if chosen_config is not None:
+            selected_provider = chosen_config.provider
+            selected_model = chosen_config.default_model or ""
+            outcome = "success"
+            decision_class = "fallback" if len([a for a in attempt_records if not a.success]) > 0 else "pinned"
+            widened_from = chain_providers[0] if chain_providers and chain_providers[0] != selected_provider else None
+        else:
+            selected_provider = ""
+            selected_model = ""
+            outcome = "all_failed"
+            decision_class = "fallback"
+            widened_from = chain_providers[0] if chain_providers else None
+        await _emit(
+            decision_id=decision_id,
+            action_name=action_name,
+            route_path="cheap_first_chain",
+            selected_provider=selected_provider,
+            selected_model=selected_model,
+            candidate_chain=chain_providers,
+            decision_class=decision_class,
+            caller=caller,
+            duration_ms=duration_ms,
+            attempts=attempt_records,
+            task_type=task_type,
+            task_signature=task_signature or "preferred_runtime_chain",
+            confidence=0.6 if chosen_response is not None else 0.0,
+            reasons=["preferred_low_cost_first"],
+            widened_from=widened_from,
+            session_id=session_id,
+            task_id=task_id,
+            run_id=run_id,
+            outcome=outcome,
+        )
+    except Exception:
+        pass
+
+    if chosen_response is not None and chosen_config is not None:
+        return chosen_response, chosen_config
 
     if last_exc is not None:
         raise last_exc

--- a/dharma_swarm/stigmergy.py
+++ b/dharma_swarm/stigmergy.py
@@ -37,6 +37,8 @@ STIGMERGY_CHANNELS: list[str] = [
     "strategy",     # Business, grants, partnerships
     "governance",   # Telos alignment, audit findings
     "memory",       # Consolidation, retrieval, knowledge graph
+    "review",       # Recognition→action queue: gaps awaiting consumer/operator review
+    "action_queue", # Marks promoted from review into a concrete next-action surface
 ]
 
 # Marks above this salience are visible across all channels

--- a/dharma_swarm/telemetry_plane.py
+++ b/dharma_swarm/telemetry_plane.py
@@ -107,9 +107,65 @@ CREATE TABLE IF NOT EXISTS routing_decisions (
     requires_human INTEGER NOT NULL DEFAULT 0,
     reasons_json TEXT NOT NULL DEFAULT '[]',
     metadata_json TEXT NOT NULL DEFAULT '{}',
+    schema_version TEXT NOT NULL DEFAULT 'v1',
+    task_signature TEXT NOT NULL DEFAULT '',
+    task_type TEXT NOT NULL DEFAULT 'unknown',
+    caller TEXT NOT NULL DEFAULT 'unknown',
+    decision_class TEXT NOT NULL DEFAULT 'pinned',
+    selected_tier TEXT NOT NULL DEFAULT 'unknown',
+    widened_from TEXT NOT NULL DEFAULT '',
+    candidate_chain_json TEXT NOT NULL DEFAULT '[]',
+    n_attempts INTEGER NOT NULL DEFAULT 0,
+    outcome TEXT NOT NULL DEFAULT 'unknown',
+    duration_ms REAL NOT NULL DEFAULT 0.0,
+    total_tokens INTEGER NOT NULL DEFAULT 0,
+    cost_estimate_usd REAL NOT NULL DEFAULT 0.0,
     created_at TEXT NOT NULL,
     trace_id TEXT NOT NULL DEFAULT ''
 )"""
+
+# Phase 1 (2026-05-10): typed attempt rows linked to routing_decisions
+# via decision_id. See docs/plans/2026-05-10-phase1-routing-witness.md.
+_PROVIDER_ATTEMPTS_DDL = """
+CREATE TABLE IF NOT EXISTS provider_attempts (
+    decision_id TEXT NOT NULL,
+    attempt_idx INTEGER NOT NULL,
+    provider TEXT NOT NULL,
+    model TEXT NOT NULL DEFAULT '',
+    tier TEXT NOT NULL DEFAULT 'unknown',
+    success INTEGER NOT NULL DEFAULT 0,
+    outcome TEXT NOT NULL DEFAULT 'unknown',
+    error_class TEXT NOT NULL DEFAULT '',
+    error_detail TEXT NOT NULL DEFAULT '',
+    duration_ms REAL NOT NULL DEFAULT 0.0,
+    stop_reason TEXT NOT NULL DEFAULT '',
+    usage_json TEXT NOT NULL DEFAULT '{}',
+    cost_estimate_usd REAL NOT NULL DEFAULT 0.0,
+    circuit_state TEXT NOT NULL DEFAULT 'closed',
+    schema_version TEXT NOT NULL DEFAULT 'v1',
+    created_at TEXT NOT NULL,
+    PRIMARY KEY (decision_id, attempt_idx)
+)"""
+
+# Additive ALTER TABLE migrations — run AFTER CREATE TABLE IF NOT EXISTS
+# so that pre-Phase-1 databases gain the new columns idempotently.
+# Each tuple: (table, column, sql_decl).
+_ROUTING_DECISIONS_PHASE1_COLUMNS: tuple[tuple[str, str, str], ...] = (
+    ("routing_decisions", "schema_version", "TEXT NOT NULL DEFAULT 'v1'"),
+    ("routing_decisions", "task_signature", "TEXT NOT NULL DEFAULT ''"),
+    ("routing_decisions", "task_type", "TEXT NOT NULL DEFAULT 'unknown'"),
+    ("routing_decisions", "caller", "TEXT NOT NULL DEFAULT 'unknown'"),
+    ("routing_decisions", "decision_class", "TEXT NOT NULL DEFAULT 'pinned'"),
+    ("routing_decisions", "selected_tier", "TEXT NOT NULL DEFAULT 'unknown'"),
+    ("routing_decisions", "widened_from", "TEXT NOT NULL DEFAULT ''"),
+    ("routing_decisions", "candidate_chain_json", "TEXT NOT NULL DEFAULT '[]'"),
+    ("routing_decisions", "n_attempts", "INTEGER NOT NULL DEFAULT 0"),
+    ("routing_decisions", "outcome", "TEXT NOT NULL DEFAULT 'unknown'"),
+    ("routing_decisions", "duration_ms", "REAL NOT NULL DEFAULT 0.0"),
+    ("routing_decisions", "total_tokens", "INTEGER NOT NULL DEFAULT 0"),
+    ("routing_decisions", "cost_estimate_usd", "REAL NOT NULL DEFAULT 0.0"),
+    ("routing_decisions", "trace_id", "TEXT NOT NULL DEFAULT ''"),
+)
 
 _POLICY_DECISIONS_DDL = """
 CREATE TABLE IF NOT EXISTS policy_decisions (
@@ -201,6 +257,13 @@ _INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_economic_kind_created ON economic_events(event_kind, created_at)",
     "CREATE INDEX IF NOT EXISTS idx_external_kind_created ON external_outcomes(outcome_kind, created_at)",
     "CREATE INDEX IF NOT EXISTS idx_overnight_date_metric ON overnight_metrics(date, metric_name)",
+    # Phase 1 (2026-05-10) routing witness indexes
+    "CREATE INDEX IF NOT EXISTS idx_routing_caller_created ON routing_decisions(caller, created_at)",
+    "CREATE INDEX IF NOT EXISTS idx_routing_task_type_created ON routing_decisions(task_type, created_at)",
+    "CREATE INDEX IF NOT EXISTS idx_routing_outcome_created ON routing_decisions(outcome, created_at)",
+    "CREATE INDEX IF NOT EXISTS idx_provider_attempts_decision ON provider_attempts(decision_id)",
+    "CREATE INDEX IF NOT EXISTS idx_provider_attempts_provider_created ON provider_attempts(provider, created_at)",
+    "CREATE INDEX IF NOT EXISTS idx_provider_attempts_error_class ON provider_attempts(error_class, created_at)",
 ]
 
 
@@ -250,6 +313,34 @@ async def _apply_connection_pragmas_async(db: aiosqlite.Connection) -> None:
     await db.execute("PRAGMA synchronous=NORMAL")
 
 
+def _existing_columns_sync(db: sqlite3.Connection, table: str) -> set[str]:
+    rows = db.execute(f"PRAGMA table_info({table})").fetchall()
+    return {row[1] for row in rows}
+
+
+async def _existing_columns_async(db: aiosqlite.Connection, table: str) -> set[str]:
+    cur = await db.execute(f"PRAGMA table_info({table})")
+    rows = await cur.fetchall()
+    await cur.close()
+    return {row[1] for row in rows}
+
+
+def _apply_phase1_routing_migration_sync(db: sqlite3.Connection) -> None:
+    """Idempotently add Phase 1 columns to existing routing_decisions table."""
+    existing = _existing_columns_sync(db, "routing_decisions")
+    for table, column, decl in _ROUTING_DECISIONS_PHASE1_COLUMNS:
+        if column not in existing:
+            db.execute(f"ALTER TABLE {table} ADD COLUMN {column} {decl}")
+
+
+async def _apply_phase1_routing_migration_async(db: aiosqlite.Connection) -> None:
+    """Idempotently add Phase 1 columns to existing routing_decisions table."""
+    existing = await _existing_columns_async(db, "routing_decisions")
+    for table, column, decl in _ROUTING_DECISIONS_PHASE1_COLUMNS:
+        if column not in existing:
+            await db.execute(f"ALTER TABLE {table} ADD COLUMN {column} {decl}")
+
+
 def ensure_telemetry_schema_sync(db: sqlite3.Connection) -> None:
     _apply_connection_pragmas_sync(db)
     for ddl in (
@@ -259,6 +350,7 @@ def ensure_telemetry_schema_sync(db: sqlite3.Connection) -> None:
         _TEAM_ROSTER_DDL,
         _WORKFLOW_SCORES_DDL,
         _ROUTING_DECISIONS_DDL,
+        _PROVIDER_ATTEMPTS_DDL,
         _POLICY_DECISIONS_DDL,
         _INTERVENTION_OUTCOMES_DDL,
         _ECONOMIC_EVENTS_DDL,
@@ -266,6 +358,7 @@ def ensure_telemetry_schema_sync(db: sqlite3.Connection) -> None:
         _OVERNIGHT_METRICS_DDL,
     ):
         db.execute(ddl)
+    _apply_phase1_routing_migration_sync(db)
     for idx in _INDEXES:
         db.execute(idx)
     db.commit()
@@ -280,6 +373,7 @@ async def ensure_telemetry_schema_async(db: aiosqlite.Connection) -> None:
         _TEAM_ROSTER_DDL,
         _WORKFLOW_SCORES_DDL,
         _ROUTING_DECISIONS_DDL,
+        _PROVIDER_ATTEMPTS_DDL,
         _POLICY_DECISIONS_DDL,
         _INTERVENTION_OUTCOMES_DDL,
         _ECONOMIC_EVENTS_DDL,
@@ -287,6 +381,7 @@ async def ensure_telemetry_schema_async(db: aiosqlite.Connection) -> None:
         _OVERNIGHT_METRICS_DDL,
     ):
         await db.execute(ddl)
+    await _apply_phase1_routing_migration_async(db)
     for idx in _INDEXES:
         await db.execute(idx)
     # Migrate: add trace_id column to critical tables in existing databases
@@ -384,6 +479,51 @@ class RoutingDecisionRecord:
     run_id: str = ""
     reasons: list[str] = field(default_factory=list)
     metadata: dict[str, Any] = field(default_factory=dict)
+    created_at: datetime = field(default_factory=_utc_now)
+
+    # --- Phase 1 dashboard-ready additions (2026-05-10) ---
+    # All nullable/defaulted so existing rows stay readable.
+    # See docs/plans/2026-05-10-phase1-routing-witness.md.
+    schema_version: str = "v1"
+    task_signature: str = ""
+    task_type: str = "unknown"
+    caller: str = "unknown"
+    decision_class: str = "pinned"
+    selected_tier: str = "unknown"
+    widened_from: str = ""
+    candidate_chain: list[str] = field(default_factory=list)
+    n_attempts: int = 0
+    outcome: str = "unknown"
+    duration_ms: float = 0.0
+    total_tokens: int = 0
+    cost_estimate_usd: float = 0.0
+
+
+@dataclass(frozen=True)
+class ProviderAttemptRecord:
+    """One provider attempt within a routing decision (Phase 1, 2026-05-10).
+
+    Multiple ProviderAttemptRecord rows may share a `decision_id` to
+    represent a fallback chain (e.g. claude_code -> openai -> ollama).
+    Linked to RoutingDecisionRecord via decision_id (not enforced as FK in
+    SQLite; join at query time).
+    """
+
+    decision_id: str
+    attempt_idx: int
+    provider: str
+    model: str
+    tier: str = "unknown"
+    success: bool = False
+    outcome: str = "unknown"
+    error_class: str = ""
+    error_detail: str = ""
+    duration_ms: float = 0.0
+    stop_reason: str = ""
+    usage: dict[str, int] = field(default_factory=dict)
+    cost_estimate_usd: float = 0.0
+    circuit_state: str = "closed"
+    schema_version: str = "v1"
     created_at: datetime = field(default_factory=_utc_now)
 
 
@@ -528,8 +668,23 @@ def _row_to_workflow_score(row: sqlite3.Row | aiosqlite.Row) -> WorkflowScoreRec
     )
 
 
+def _row_value(row: sqlite3.Row | aiosqlite.Row, name: str, default: Any) -> Any:
+    """Read a column from a Row that may pre-date the column being added."""
+    try:
+        value = row[name]
+    except (IndexError, KeyError):
+        return default
+    return value if value is not None else default
+
+
 def _row_to_routing_decision(row: sqlite3.Row | aiosqlite.Row) -> RoutingDecisionRecord:
     reasons = _json_load(row["reasons_json"], [])
+    candidate_chain_raw = _json_load(_row_value(row, "candidate_chain_json", "[]"), [])
+    candidate_chain = (
+        [str(item) for item in candidate_chain_raw]
+        if isinstance(candidate_chain_raw, list)
+        else []
+    )
     return RoutingDecisionRecord(
         decision_id=str(row["decision_id"]),
         action_name=str(row["action_name"]),
@@ -544,6 +699,42 @@ def _row_to_routing_decision(row: sqlite3.Row | aiosqlite.Row) -> RoutingDecisio
         reasons=[str(item) for item in reasons] if isinstance(reasons, list) else [],
         metadata=_json_load(row["metadata_json"], {}),
         created_at=_parse_dt(row["created_at"]) or _utc_now(),
+        # Phase 1 dashboard-ready additions
+        schema_version=str(_row_value(row, "schema_version", "v1") or "v1"),
+        task_signature=str(_row_value(row, "task_signature", "") or ""),
+        task_type=str(_row_value(row, "task_type", "unknown") or "unknown"),
+        caller=str(_row_value(row, "caller", "unknown") or "unknown"),
+        decision_class=str(_row_value(row, "decision_class", "pinned") or "pinned"),
+        selected_tier=str(_row_value(row, "selected_tier", "unknown") or "unknown"),
+        widened_from=str(_row_value(row, "widened_from", "") or ""),
+        candidate_chain=candidate_chain,
+        n_attempts=int(_row_value(row, "n_attempts", 0) or 0),
+        outcome=str(_row_value(row, "outcome", "unknown") or "unknown"),
+        duration_ms=float(_row_value(row, "duration_ms", 0.0) or 0.0),
+        total_tokens=int(_row_value(row, "total_tokens", 0) or 0),
+        cost_estimate_usd=float(_row_value(row, "cost_estimate_usd", 0.0) or 0.0),
+    )
+
+
+def _row_to_provider_attempt(row: sqlite3.Row | aiosqlite.Row) -> ProviderAttemptRecord:
+    usage = _json_load(_row_value(row, "usage_json", "{}"), {})
+    return ProviderAttemptRecord(
+        decision_id=str(row["decision_id"]),
+        attempt_idx=int(row["attempt_idx"]),
+        provider=str(row["provider"]),
+        model=str(_row_value(row, "model", "") or ""),
+        tier=str(_row_value(row, "tier", "unknown") or "unknown"),
+        success=bool(_row_value(row, "success", 0)),
+        outcome=str(_row_value(row, "outcome", "unknown") or "unknown"),
+        error_class=str(_row_value(row, "error_class", "") or ""),
+        error_detail=str(_row_value(row, "error_detail", "") or ""),
+        duration_ms=float(_row_value(row, "duration_ms", 0.0) or 0.0),
+        stop_reason=str(_row_value(row, "stop_reason", "") or ""),
+        usage={str(k): int(v) for k, v in (usage or {}).items() if isinstance(v, (int, float))} if isinstance(usage, dict) else {},
+        cost_estimate_usd=float(_row_value(row, "cost_estimate_usd", 0.0) or 0.0),
+        circuit_state=str(_row_value(row, "circuit_state", "closed") or "closed"),
+        schema_version=str(_row_value(row, "schema_version", "v1") or "v1"),
+        created_at=_parse_dt(_row_value(row, "created_at", None)) or _utc_now(),
     )
 
 
@@ -947,8 +1138,11 @@ class TelemetryPlaneStore:
                 "INSERT INTO routing_decisions (decision_id, session_id, task_id,"
                 " run_id, action_name, route_path, selected_provider,"
                 " selected_model_hint, confidence, requires_human, reasons_json,"
-                " metadata_json, created_at, trace_id)"
-                " VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                " metadata_json, schema_version, task_signature, task_type, caller,"
+                " decision_class, selected_tier, widened_from, candidate_chain_json,"
+                " n_attempts, outcome, duration_ms, total_tokens, cost_estimate_usd,"
+                " created_at, trace_id)"
+                " VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
                 (
                     record.decision_id,
                     record.session_id,
@@ -962,8 +1156,56 @@ class TelemetryPlaneStore:
                     1 if record.requires_human else 0,
                     _json_dump(record.reasons),
                     _json_dump(record.metadata),
+                    record.schema_version,
+                    record.task_signature,
+                    record.task_type,
+                    record.caller,
+                    record.decision_class,
+                    record.selected_tier,
+                    record.widened_from,
+                    _json_dump(list(record.candidate_chain)),
+                    int(record.n_attempts),
+                    record.outcome,
+                    float(record.duration_ms),
+                    int(record.total_tokens),
+                    float(record.cost_estimate_usd),
                     record.created_at.isoformat(),
                     corr.trace_id,
+                ),
+            )
+            await db.commit()
+        return record
+
+    async def record_provider_attempt(
+        self,
+        record: ProviderAttemptRecord,
+    ) -> ProviderAttemptRecord:
+        """Insert one ProviderAttemptRecord. Idempotent on (decision_id, attempt_idx)."""
+        await self.init_db()
+        async with self._open() as db:
+            await db.execute(
+                "INSERT OR REPLACE INTO provider_attempts (decision_id, attempt_idx,"
+                " provider, model, tier, success, outcome, error_class, error_detail,"
+                " duration_ms, stop_reason, usage_json, cost_estimate_usd,"
+                " circuit_state, schema_version, created_at)"
+                " VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                (
+                    record.decision_id,
+                    int(record.attempt_idx),
+                    record.provider,
+                    record.model,
+                    record.tier,
+                    1 if record.success else 0,
+                    record.outcome,
+                    record.error_class,
+                    record.error_detail,
+                    float(record.duration_ms),
+                    record.stop_reason,
+                    _json_dump(record.usage),
+                    float(record.cost_estimate_usd),
+                    record.circuit_state,
+                    record.schema_version,
+                    record.created_at.isoformat(),
                 ),
             )
             await db.commit()
@@ -977,12 +1219,8 @@ class TelemetryPlaneStore:
         limit: int = 100,
     ) -> list[RoutingDecisionRecord]:
         await self.init_db()
-        query = (
-            "SELECT decision_id, session_id, task_id, run_id, action_name,"
-            " route_path, selected_provider, selected_model_hint, confidence,"
-            " requires_human, reasons_json, metadata_json, created_at"
-            " FROM routing_decisions WHERE 1=1"
-        )
+        # SELECT * — _row_to_routing_decision tolerates missing columns via _row_value.
+        query = "SELECT * FROM routing_decisions WHERE 1=1"
         params: list[Any] = []
         if task_id is not None:
             query += " AND task_id = ?"
@@ -996,6 +1234,33 @@ class TelemetryPlaneStore:
             db.row_factory = aiosqlite.Row
             rows = await (await db.execute(query, params)).fetchall()
         return [_row_to_routing_decision(row) for row in rows]
+
+    async def list_provider_attempts(
+        self,
+        *,
+        decision_id: str | None = None,
+        provider: str | None = None,
+        error_class: str | None = None,
+        limit: int = 200,
+    ) -> list[ProviderAttemptRecord]:
+        await self.init_db()
+        query = "SELECT * FROM provider_attempts WHERE 1=1"
+        params: list[Any] = []
+        if decision_id is not None:
+            query += " AND decision_id = ?"
+            params.append(decision_id)
+        if provider is not None:
+            query += " AND provider = ?"
+            params.append(provider)
+        if error_class is not None:
+            query += " AND error_class = ?"
+            params.append(error_class)
+        query += " ORDER BY created_at DESC, attempt_idx ASC LIMIT ?"
+        params.append(limit)
+        async with self._open() as db:
+            db.row_factory = aiosqlite.Row
+            rows = await (await db.execute(query, params)).fetchall()
+        return [_row_to_provider_attempt(row) for row in rows]
 
     async def record_policy_decision(
         self,

--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -6,16 +6,16 @@ Do not hand-edit the generated block.
 <!-- DOCOPS:START metric=repo_inventory -->
 | Metric | Value |
 |---|---:|
-| Dharma Python modules | 594 |
-| Top-level Dharma Python modules | 386 |
-| Dharma Python LOC | 257,112 |
-| Test files | 576 |
-| Test function occurrences | 10,209 |
-| Markdown files | 691 |
-| Markdown total lines | 176,029 |
+| Dharma Python modules | 595 |
+| Top-level Dharma Python modules | 387 |
+| Dharma Python LOC | 258,327 |
+| Test files | 577 |
+| Test function occurrences | 10,286 |
+| Markdown files | 692 |
+| Markdown total lines | 176,358 |
 | Bridge files | 22 |
 | Adapter files | 14 |
 | Orchestrator files | 4 |
-| Router files | 13 |
-| Authority candidate docs | 277 |
+| Router files | 14 |
+| Authority candidate docs | 278 |
 <!-- DOCOPS:END -->

--- a/docs/docops/assertions.yaml
+++ b/docs/docops/assertions.yaml
@@ -155,6 +155,7 @@
       "docs/architecture/NAVIGATION.md",
       "docs/architecture/MODEL_ROUTING_CANON.md",
       "docs/architecture/WIRING_AND_LOOPS.md",
+      "docs/plans/2026-05-10-phase1-routing-witness.md",
       "docs/MEGAFILE_INDEX.md",
       "docs/state/BROKEN_REGISTER.md",
       "docs/vision_maps/MASTER_2026-05-07_attractor_closure.md",

--- a/docs/governance/CANONICAL_DOC_STACK.md
+++ b/docs/governance/CANONICAL_DOC_STACK.md
@@ -80,7 +80,7 @@ using phrases such as "source of truth", "canonical", "authoritative", or
 | `docs/architecture/NAVIGATION.md` | Module map, after count refresh |
 | `docs/architecture/MODEL_ROUTING_CANON.md` | Provider/model routing, after merge with root routing map |
 | `docs/architecture/WIRING_AND_LOOPS.md` | Build Protocol and feedback-loop wiring map |
-| `docs/MEGAFILE_INDEX.md` | Onboarding megafile slot index and convergence map |
+| `docs/plans/2026-05-10-phase1-routing-witness.md` | Routing witness plan and route-telemetry promotion record |
 | `docs/state/BROKEN_REGISTER.md` | Persistent broken/degraded surface register |
 | `docs/vision_maps/MASTER_2026-05-07_attractor_closure.md` | Attractor-closure synthesis source map |
 | `docs/vision_maps/MASTER_2026-05-07_attractor_closure_synthesis.md` | Attractor-closure synthesis entry point |

--- a/docs/governance/SOVEREIGN_MANIFEST.md
+++ b/docs/governance/SOVEREIGN_MANIFEST.md
@@ -17,10 +17,10 @@
 These are immutable engineering laws for this repository. Violation = architectural regression.
 
 ### A1: NO FLAT-PACKAGE GROWTH
-The `dharma_swarm/` package currently has **386 files at its top level (65.0% of 594 total Python modules)** (V). No new .py file may be added to the top level. New modules must go into an appropriate subdirectory. Existing top-level files will be organized over time.
+The `dharma_swarm/` package currently has **387 files at its top level (65.0% of 595 total Python modules)** (V). No new .py file may be added to the top level. New modules must go into an appropriate subdirectory. Existing top-level files will be organized over time.
 
 ### A2: NO DUPLICATE IMPLEMENTATIONS
-Before creating a new file for routing, bridging, adapting, or orchestrating, check if one already exists. The repo currently has **22 bridge files** (V), **3 model_routing copies** (2 are identical, 1 is different) (V), **4 orchestrators** (V), **14 adapter files across 7 locations** (V), and **13 router files** (V). Do not add more without deprecating an existing one.
+Before creating a new file for routing, bridging, adapting, or orchestrating, check if one already exists. The repo currently has **22 bridge files** (V), **3 model_routing copies** (2 are identical, 1 is different) (V), **4 orchestrators** (V), **14 adapter files across 7 locations** (V), and **14 router files** (V). Do not add more without deprecating an existing one.
 
 ### A3: NO UNDOCUMENTED SEAMS
 If your code creates a new interface between domains (a bridge, adapter, or protocol), you must update `NAVIGATION.md` with its purpose, entry point, and boundary constraints. Undocumented seams become invisible coupling.
@@ -41,7 +41,7 @@ No single file should exceed 3,000 lines. Current violations (V):
 **148 files exceed 500 lines; 39 exceed 1,000; 7 exceed 3,000** (V). These must be decomposed over time, not grown further.
 
 ### A6: DOCS DECAY -- CHECK BEFORE CITING
-All numerical claims in docs become stale within weeks. Before citing module counts, test counts, or line counts from any doc (including this one), verify against the actual filesystem. See `REPO_GOVERNANCE_AUDIT.md` for the current staleness log. The current DocOps inventory reports **277 Markdown files containing at least one reserved trust-language term** (V). Treat these as authority-scope review candidates, not confirmed repo-wide authority.
+All numerical claims in docs become stale within weeks. Before citing module counts, test counts, or line counts from any doc (including this one), verify against the actual filesystem. See `REPO_GOVERNANCE_AUDIT.md` for the current staleness log. The current DocOps inventory reports **278 Markdown files containing at least one reserved trust-language term** (V). Treat these as authority-scope review candidates, not confirmed repo-wide authority.
 
 ### A7: NO CIRCULAR IMPORTS
 The repo has **9 verified circular dependency chains** (V). The worst:
@@ -52,7 +52,7 @@ The repo has **9 verified circular dependency chains** (V). The worst:
 All 9 cycles were independently confirmed with exact import lines. Most are mitigated by lazy imports but remain architectural debt. **New code must not create circular imports.**
 
 ### A8: FRONTMATTER DISCIPLINE
-Do not inject machine-readable YAML frontmatter into governance or architecture docs unless explicitly requested. Current state: **216 of 691 Markdown files start with YAML frontmatter; 15 of 21 docs/architecture Markdown files do so** (V). Long frontmatter remains an authority/noise risk even when the prose is useful.
+Do not inject machine-readable YAML frontmatter into governance or architecture docs unless explicitly requested. Current state: **216 of 692 Markdown files start with YAML frontmatter; 15 of 21 docs/architecture Markdown files do so** (V). Long frontmatter remains an authority/noise risk even when the prose is useful.
 
 ---
 
@@ -62,19 +62,19 @@ These are the ground-truth metrics. All other documents citing different numbers
 
 | Metric | Value | Verification |
 |--------|-------|-------------|
-| Total Python modules | **594** | find dharma_swarm -name "*.py" -type f |
-| Top-level (flat) modules | **386 (65.0%)** | find dharma_swarm -maxdepth 1 -name "*.py" -type f |
-| Total Python LOC | **257,112** | wc -l across dharma_swarm Python modules |
-| Test files | **576** | find tests -name "*.py" -type f |
-| Test functions | **10,209 `def test_` occurrences under tests/** | rg "def test_" tests |
+| Total Python modules | **595** | find dharma_swarm -name "*.py" -type f |
+| Top-level (flat) modules | **387 (65.0%)** | find dharma_swarm -maxdepth 1 -name "*.py" -type f |
+| Total Python LOC | **258,327** | wc -l across dharma_swarm Python modules |
+| Test files | **577** | find tests -name "*.py" -type f |
+| Test functions | **10,286 `def test_` occurrences under tests/** | rg "def test_" tests |
 | Tests collected (pytest) | **Needs write-permitted refresh** | not run during this DocOps count pass |
 | Collection errors | **Historical: 16 on 2026-04-04** | refresh before relying on this count |
-| Markdown files | **691** | find . -name "*.md" -type f |
-| Markdown total lines | **176,029** | wc -l across all .md |
+| Markdown files | **692** | find . -name "*.md" -type f |
+| Markdown total lines | **176,358** | wc -l across all .md |
 | Bridge files | **22** | find dharma_swarm -name "*bridge*.py" |
 | Adapter files | **14 across 7 locations** | find dharma_swarm -type f \| rg -i "adapter" |
 | Orchestrator files | **4** (6,034 LOC total) | find dharma_swarm -name "*orchestrat*" |
-| Router files | **13** (4,976 LOC total) | find dharma_swarm -type f \| rg -i "rout" |
+| Router files | **14** (5,630 LOC total) | find dharma_swarm -type f \| rg -i "rout" |
 | Memory modules | **11** (5,848 LOC) | find dharma_swarm -name "*memory*" |
 | Context modules | **8** (5,828 LOC) | find dharma_swarm -name "*context*" |
 | Provider types (enum) | **18** | models.py ProviderType enum |

--- a/docs/plans/2026-05-10-phase1-routing-witness.md
+++ b/docs/plans/2026-05-10-phase1-routing-witness.md
@@ -1,0 +1,329 @@
+# Phase 1 — Canonical Route Witness (Dashboard-Ready, Anti-Magic)
+
+**Date:** 2026-05-10
+**Owner:** Dhyana (sponsor) + active inhabitant agent
+**Status:** approved spec, implementation in this session
+**Subordinate to:** `CLAUDE.md`, `docs/governance/SOVEREIGN_MANIFEST.md`, `docs/foundations/CONTEMPLATIVE_SPINE.md`
+**Predecessors:** Codex think-through transcript (in conversation), grill-me decisions Q1–Q5
+**Telos:** close feedback fragmentation between routing decisions and task value (spine §3 recognition closure) without inventing a second routing reality.
+
+---
+
+## 0. The actual problem (per Codex think-through)
+
+**Routing infrastructure is not the bottleneck.** dharma_swarm already has:
+- `provider_policy.ProviderPolicyRouter` (policy brain)
+- `providers.ModelRouter` (execution + retry/fallback/circuit/canary)
+- `routing_memory.RoutingMemoryStore` (per-(provider,model,task_signature) EWMA matrix)
+- `telemetry_plane.TelemetryPlaneStore` with typed `RoutingDecisionRecord`
+- `decision_router.DecisionRouter` with typed `RouteDecision` + `RoutePath` enum
+- `model_hierarchy.CANONICAL_SEED_ORDER` (catalog authority)
+- `routing_decisions.jsonl` audit log (`DGC_ROUTER_AUDIT_LOG`)
+- `runtime.db` typed store (`DGC_ROUTER_TELEMETRY_DB`)
+
+The bottlenecks are:
+
+1. **Feedback fragmentation** — route outcome lives in routing memory/telemetry; task value lives in TelicSeam. Not one causal object.
+2. **Signal poverty** — quality scores too heuristic, sparse, decoupled from task type / tool need / credit state.
+3. **Budget policy gap** — `agent_registry.is_budget_exceeded` exists but isn't wired into AgentRunner / ModelRouter completion.
+4. **Bypass sprawl** — direct `complete_via_preferred_runtime_providers` / `create_runtime_provider` calls evade routing policy and witness.
+5. **Silent fallback** — `provider_policy.py:223` defaults to `CLAUDE_CODE` on filter-empty. Should be typed `NO_ROUTE` with reason.
+
+Phase 1 attacks #4 and partially #2. Phases 2 and 3 attack the rest.
+
+---
+
+## 1. Scope (Phase 1 only)
+
+**In scope:**
+- Enrich `RoutingDecisionRecord` schema with dashboard-ready typed fields (nullable, default-valued).
+- Add `ProviderAttemptRecord` typed dataclass + SQLite table.
+- Add `dharma_swarm/route_witness.py` — emission/normalization helper. Never routes.
+- Wire emissions at four surfaces: `ModelRouter.complete_for_task()`, `complete_via_preferred_runtime_providers()`, `pulse_alt_lanes.py`, `inquiry_substrate_chew._call_provider()`.
+- Existing `routing_decisions.jsonl` audit path stays canonical. No new JSONL file.
+- Best-effort failure: witness write failure logs but never raises.
+
+**Explicitly out of scope (Phase 2 / 3):**
+- Wiring `is_budget_exceeded` into completion preflight (Phase 2).
+- Replacing the silent `CLAUDE_CODE` fallback with typed `NO_ROUTE` (Phase 2).
+- Ontology objects `RoutingDecision` / `ProviderAttempt` linked to `Outcome` / `ValueEvent` / `Contribution` via TelicSeam (Phase 3).
+- Outcome quality back-link from TelicSeam to routing decision (Phase 3).
+- Bare `Provider().complete()` callers in `deep_agent_backend`, `scout_framework`, etc. (Phase 1.5 — instrument once Phase 1 reveals which surfaces actually fire in practice).
+- Grafana dashboard panels (built later against this schema).
+
+---
+
+## 2. Schema additions (additive, nullable)
+
+### 2.1 `RoutingDecisionRecord` — extend existing dataclass
+
+Existing fields preserved unchanged. New fields appended, all nullable/defaulted:
+
+```python
+@dataclass(frozen=True)
+class RoutingDecisionRecord:
+    # --- existing fields (unchanged) ---
+    decision_id: str
+    action_name: str
+    route_path: str
+    selected_provider: str = ""
+    selected_model_hint: str = ""
+    confidence: float = 0.0
+    requires_human: bool = False
+    session_id: str = ""
+    task_id: str = ""
+    run_id: str = ""
+    reasons: list[str] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+    created_at: datetime = field(default_factory=_utc_now)
+
+    # --- Phase 1 dashboard-ready additions (all default-valued) ---
+    schema_version: str = "v1"
+    task_signature: str = ""              # opaque hash/slug per task class
+    task_type: str = "unknown"            # pulse | chew | code_edit | research | chat | inquiry | unknown
+    caller: str = "unknown"               # pulse_alt_lanes | inquiry_chew | model_router | complete_via_preferred | ...
+    decision_class: str = "pinned"        # pinned | widened | fallback | no_route | canary
+    selected_tier: str = "unknown"        # free | cheap | paid
+    widened_from: str = ""                # original pinned provider lane, if widened
+    candidate_chain: list[str] = field(default_factory=list)  # provider lanes considered, in order
+    n_attempts: int = 0
+    outcome: str = "unknown"              # success | empty_content | all_failed | timeout | gate_block | no_route
+    duration_ms: float = 0.0
+    total_tokens: int = 0
+    cost_estimate_usd: float = 0.0
+```
+
+SQL migration: `ALTER TABLE routing_decisions ADD COLUMN <name> <type> DEFAULT <default>` for each new field. Existing rows preserved; queries that don't reference new columns keep working.
+
+### 2.2 `ProviderAttemptRecord` — new dataclass
+
+```python
+@dataclass(frozen=True)
+class ProviderAttemptRecord:
+    decision_id: str                      # FK to RoutingDecisionRecord.decision_id
+    attempt_idx: int                      # 0-based
+    provider: str                         # ProviderType.value
+    model: str
+    tier: str = "unknown"                 # free | cheap | paid
+    success: bool = False
+    outcome: str = "unknown"              # success | failed | timeout
+    error_class: str = ""                 # enum below
+    error_detail: str = ""                # ≤200 chars, redacted
+    duration_ms: float = 0.0
+    stop_reason: str = ""
+    usage: dict[str, int] = field(default_factory=dict)
+    cost_estimate_usd: float = 0.0
+    circuit_state: str = "closed"         # open | closed | half_open
+    schema_version: str = "v1"
+    created_at: datetime = field(default_factory=_utc_now)
+```
+
+New SQLite table `provider_attempts` with `decision_id` indexed for join queries.
+
+### 2.3 `error_class` enumeration
+
+Single source of truth, lives in `route_witness.py`:
+
+```
+credit_exhausted   — provider returns "Credit balance is too low" or equivalent
+rate_limit         — 429 / quota error
+timeout            — wall-clock exceeded
+network            — connection refused, DNS, transient HTTP error
+model_unavailable  — 404 model, deprecated, region-blocked
+empty_content      — 200 OK with no visible content (gpt-5 reasoning starvation, etc.)
+api_error          — 500 / 503 from provider
+auth_error         — 401 / 403 not classified as rate-limit
+unknown            — fallthrough
+```
+
+### 2.4 JSONL row shapes
+
+Two row kinds in `~/.dharma/logs/router/routing_decisions.jsonl`. Each row carries `row_kind: "decision" | "attempt"` and `schema_version: "v1"`.
+
+Decision row mirrors `RoutingDecisionRecord` field set. Attempt row mirrors `ProviderAttemptRecord` field set. Decision row is written FIRST, attempts AFTER, all in one helper call so they land contiguously even under concurrent writers.
+
+---
+
+## 3. `route_witness.py` — emission helper
+
+Single file. Single responsibility: build, redact, classify, emit. Never routes. Never gates. Never falls back.
+
+### 3.1 Public API
+
+```python
+async def emit_routing_decision(
+    *,
+    decision_id: str,
+    action_name: str,
+    route_path: str,
+    selected_provider: ProviderType | str,
+    selected_model: str,
+    candidate_chain: list[ProviderType | str],
+    decision_class: str,
+    caller: str,
+    outcome: str,
+    duration_ms: float,
+    attempts: list[ProviderAttemptRecord],
+    task_type: str = "unknown",
+    task_signature: str = "",
+    confidence: float = 0.0,
+    requires_human: bool = False,
+    reasons: list[str] | None = None,
+    widened_from: ProviderType | str | None = None,
+    session_id: str = "",
+    task_id: str = "",
+    run_id: str = "",
+    total_tokens: int = 0,
+    cost_estimate_usd: float = 0.0,
+    metadata: dict[str, Any] | None = None,
+    telemetry: TelemetryPlaneStore | None = None,
+    audit_log_path: Path | None = None,
+) -> None:
+    """Write one canonical RoutingDecisionRecord + N ProviderAttemptRecord rows.
+
+    Best-effort. Logs and swallows on failure. Never raises into the caller.
+    """
+
+def build_provider_attempt(
+    *,
+    decision_id: str,
+    attempt_idx: int,
+    provider: ProviderType | str,
+    model: str,
+    success: bool,
+    duration_ms: float,
+    error: BaseException | None = None,
+    error_class: str | None = None,
+    error_detail: str = "",
+    stop_reason: str | None = None,
+    usage: dict[str, int] | None = None,
+    cost_estimate_usd: float | None = None,
+    circuit_state: str = "closed",
+) -> ProviderAttemptRecord:
+    """Construct a redacted, classified ProviderAttemptRecord.
+
+    If `error` is provided, derives `error_class` automatically from exception
+    type + message patterns. Truncates `error_detail` to 200 chars and runs
+    redaction patterns. If `cost_estimate_usd` is None, looks up via
+    model_hierarchy.
+    """
+```
+
+### 3.2 Redaction rules
+
+`error_detail` is truncated to 200 chars BEFORE storage. Then scrubbed of:
+- API key patterns (`sk-`, `Bearer `, hex blobs ≥ 32 chars)
+- Email addresses
+- File paths under `~/.dharma/` (replaced with `<witness_path>`)
+- Anything matching `re.compile(r"(?i)(api[_-]?key|token|secret|password)\s*[=:]\s*\S+")`
+
+If after redaction the detail is empty, store `"[redacted]"`.
+
+### 3.3 Tier and cost lookup
+
+`route_witness.py` imports from `model_hierarchy`:
+- `tier_for_provider(provider, model) -> "free" | "cheap" | "paid"` — derived from the provider's position in `CANONICAL_SEED_ORDER` and known free providers list.
+- `estimate_cost_usd(provider, model, prompt_tokens, completion_tokens) -> float` — returns 0.0 for free providers, looks up per-model pricing for paid lanes.
+
+These stay local to route_witness; no other module touches pricing. Phase 2 may centralize them.
+
+### 3.4 Failure mode
+
+All emissions wrapped in `try/except Exception: logger.warning(...)`. A witness write failure must never cascade into a real LLM call. Witness write failures DO emit a stigmergy mark on `channel="review"` with `salience=0.7` so chronic emission failures become visible in the review queue.
+
+---
+
+## 4. Call site instrumentation
+
+### 4.1 `ModelRouter.complete_for_task()` (`providers.py`)
+
+Already plumbed for telemetry (env-gated `DGC_ROUTER_TELEMETRY_ENABLE`). Refactor existing emission to go through `route_witness.emit_routing_decision()`. ModelRouter constructs `ProviderAttemptRecord` for each provider attempt during retry/fallback, then calls the helper once at the end of the route attempt sequence.
+
+Preserve existing `ExternalOutcomeRecord` writes — tests/views may depend on them. Phase 3 may unify.
+
+### 4.2 `runtime_provider.complete_via_preferred_runtime_providers()` (`runtime_provider.py`)
+
+Currently iterates `configs` calling `provider.complete()` directly. Add:
+- Generate `decision_id = uuid4().hex` at function start.
+- Build `attempts: list[ProviderAttemptRecord]` accumulated as the chain iterates.
+- After the final return / final exception, call `emit_routing_decision()` once with the full chain.
+- `caller="runtime_provider.complete_via_preferred_runtime_providers"`.
+- `decision_class="fallback"` (always — this function is by definition a chain).
+
+### 4.3 `~/.dharma/scripts/pulse_alt_lanes.py`
+
+Currently calls `OpenAIProvider().complete()` then `OllamaProvider().complete()` raw. Refactor to:
+- Generate `decision_id` at start.
+- Build `attempts: list[ProviderAttemptRecord]` for openai (success or fail) + ollama (if reached).
+- Call `emit_routing_decision()` after the chosen result is decided.
+- `caller="pulse_alt_lanes"`, `task_type="pulse"`, `action_name="heartbeat_alt_pulse"`, `decision_class="fallback"`.
+
+### 4.4 `dharma_swarm/inquiry_substrate_chew.py::_call_provider()`
+
+Currently single provider call (no chain). Refactor to:
+- Caller (`run_chew`) generates `decision_id` and passes through.
+- `_call_provider` wraps the actual `provider.complete()` in try/except, builds one `ProviderAttemptRecord`, returns both response AND attempt record.
+- `run_chew` calls `emit_routing_decision()` with single-attempt list.
+- `caller="inquiry_substrate_chew"`, `task_type="chew"`, `decision_class="pinned"` (when explicit `--provider`) or `"widened"` (when chain selection).
+
+### 4.5 Bare `Provider().complete()` callers
+
+**Deferred to Phase 1.5.** After Phase 1 runs for ≥3 days, query `routing_decisions.jsonl` for known `caller` values; subtract from a grep of all `provider.complete(` call sites in the repo. The diff is the bare-callers backlog.
+
+---
+
+## 5. Migration safety
+
+- All schema changes are additive: new columns nullable, new tables created idempotently with `CREATE TABLE IF NOT EXISTS`.
+- `_row_to_routing_decision` extended to read new fields with `.get()`-style defaults; old rows still read.
+- `routing_decisions.jsonl` continues to be the audit file. New rows have additional fields; old readers ignoring unknown keys still work.
+- Phase 1 ships behind the existing `DGC_ROUTER_TELEMETRY_ENABLE` env (already on in `run_operator.sh` since Move 2 today). No new env var.
+- A second env `DGC_ROUTE_WITNESS_DISABLE_HELPER=1` provides an emergency kill-switch — set this if the helper itself misbehaves; ModelRouter falls back to its prior emission path.
+
+---
+
+## 6. Verification before declaring Phase 1 done
+
+1. Manual fire of `pulse_alt_lanes.py` produces:
+   - A new row in `routing_decisions.jsonl` with `row_kind="decision"`, `caller="pulse_alt_lanes"`, populated dashboard-ready fields.
+   - One `row_kind="attempt"` per provider tried (≥1, often 2: claude_code attempt then openai attempt).
+   - Matching rows in `runtime.db` (`routing_decisions` + `provider_attempts` tables).
+   - `error_detail` ≤ 200 chars, no secrets in any stored field.
+
+2. Manual fire of `inquiry_substrate_chew.py` produces same shape with `caller="inquiry_substrate_chew"`.
+
+3. `make test-smoke` passes (no test breakage).
+
+4. Targeted pytest covers:
+   - Schema additions (new fields readable from old rows).
+   - `ProviderAttemptRecord` round-trip through SQLite.
+   - Redaction (test that `sk-...` patterns get scrubbed in `error_detail`).
+   - Best-effort failure (witness write fails → caller still gets normal response).
+
+5. JSON schema for the JSONL written next to the audit file at `~/.dharma/logs/router/routing_decisions_v1.schema.json`.
+
+6. Witness entry at `~/.dharma/witness/2026-05-10-inhabitant-claude-phase1-routing.md` with smoke results, predicted Grafana panels, and Phase 1.5 / Phase 2 hand-off.
+
+---
+
+## 7. Anti-magic invariants
+
+- **`route_witness.py` is the only module that constructs `RoutingDecisionRecord` from non-test code.** Other modules pass kwargs to its public functions; they never instantiate the record themselves.
+- **`route_witness.py` is the only module that writes to `routing_decisions.jsonl`.** Other emitters either go through it or are explicitly grandfathered (only `ModelRouter` if its existing direct write must remain for backwards compat — to be confirmed during implementation).
+- **`route_witness.py` does not import from `provider_policy.py` or `decision_router.py`.** It is a downstream witness, not an upstream policy or classifier. Imports flow one way: callers → route_witness → telemetry_plane.
+- **No decorator, no metaclass, no monkey-patch, no global mutable state in route_witness.** All state lives in records, all behavior in functions.
+
+---
+
+## 8. Hand-off to next phase
+
+Phase 1 produces ≥3 days of populated `routing_decisions.jsonl` with full dashboard-ready dimensions. Phase 2 reads the actual data to:
+
+- Decide whether `is_budget_exceeded` preflight matters (does cost_estimate_usd actually exceed budget?).
+- Decide whether silent CLAUDE_CODE fallback fires (does any decision_class="fallback" with selected_provider="claude_code" appear?).
+- Identify which bare-provider callers from §4.5 actually fire and instrument them.
+- Promote any frequently-queried `metadata` keys to typed columns.
+
+Phase 3 promotes `RoutingDecisionRecord` + `ProviderAttemptRecord` to first-class ontology objects linked via `TelicSeam` to `ActionProposal` → `Outcome` → `ValueEvent` → `Contribution`.
+
+End of spec.

--- a/tests/test_model_router_telemetry.py
+++ b/tests/test_model_router_telemetry.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from dharma_swarm.models import LLMRequest, LLMResponse, ProviderType
@@ -44,12 +46,17 @@ class _FailingProvider:
         yield ""
 
 
+def _route_by_caller(routes, caller: str):
+    return next(route for route in routes if route.caller == caller)
+
+
 @pytest.mark.asyncio
 async def test_model_router_success_writes_telemetry_records(tmp_path) -> None:
     telemetry = TelemetryPlaneStore(tmp_path / "runtime.db")
     router = ModelRouter(
         {ProviderType.OPENAI: _DummyProvider("ok")},
         telemetry=telemetry,
+        routing_audit_path=tmp_path / "routing_decisions.jsonl",
     )
 
     decision, response = await router.complete_for_task(
@@ -76,6 +83,7 @@ async def test_model_router_success_writes_telemetry_records(tmp_path) -> None:
     )
 
     routes = await telemetry.list_routing_decisions(task_id="task-success", limit=10)
+    attempts = await telemetry.list_provider_attempts(decision_id=routes[0].decision_id)
     policies = await telemetry.list_policy_decisions(
         task_id="task-success",
         policy_name="provider_policy",
@@ -95,7 +103,18 @@ async def test_model_router_success_writes_telemetry_records(tmp_path) -> None:
     assert response.content == "ok"
     assert len(routes) == 1
     assert routes[0].selected_provider == "openai"
+    assert routes[0].caller == "providers.ModelRouter.complete_for_task"
+    assert routes[0].task_signature
+    assert routes[0].task_type == "unknown"
+    assert routes[0].decision_class == "pinned"
+    assert routes[0].selected_tier == "paid"
+    assert routes[0].n_attempts == 1
+    assert routes[0].outcome == "success"
     assert routes[0].metadata["result"] == "success"
+    assert len(attempts) == 1
+    assert attempts[0].provider == "openai"
+    assert attempts[0].success is True
+    assert attempts[0].usage["total_tokens"] == 160
     assert len(policies) == 1
     assert policies[0].decision == "approved"
     assert len(economic) == 1
@@ -114,6 +133,12 @@ async def test_model_router_success_writes_telemetry_records(tmp_path) -> None:
         and item.value == 1.0
         for item in outcomes
     )
+    audit_rows = [
+        json.loads(line)
+        for line in (tmp_path / "routing_decisions.jsonl").read_text().splitlines()
+    ]
+    assert [row["row_kind"] for row in audit_rows] == ["decision", "attempt"]
+    assert audit_rows[0]["caller"] == "providers.ModelRouter.complete_for_task"
 
 
 @pytest.mark.asyncio
@@ -125,6 +150,7 @@ async def test_model_router_fallback_success_marks_fallback_in_telemetry(tmp_pat
             ProviderType.ANTHROPIC: _DummyProvider("frontier"),
         },
         telemetry=telemetry,
+        routing_audit_path=tmp_path / "routing_decisions.jsonl",
     )
 
     decision, response = await router.complete_for_task(
@@ -155,6 +181,7 @@ async def test_model_router_fallback_success_marks_fallback_in_telemetry(tmp_pat
     )
 
     routes = await telemetry.list_routing_decisions(task_id="task-fallback", limit=10)
+    attempts = await telemetry.list_provider_attempts(decision_id=routes[0].decision_id)
     outcomes = await telemetry.list_external_outcomes(
         session_id="sess-fallback",
         limit=20,
@@ -164,8 +191,14 @@ async def test_model_router_fallback_success_marks_fallback_in_telemetry(tmp_pat
     assert response.content == "frontier"
     assert len(routes) == 1
     assert routes[0].selected_provider == "anthropic"
+    assert routes[0].caller == "providers.ModelRouter.complete_for_task"
+    assert routes[0].decision_class == "fallback"
+    assert routes[0].widened_from == "openrouter_free"
+    assert routes[0].n_attempts == len(attempts)
     assert routes[0].metadata["fallback_selected"] is True
     assert routes[0].metadata["initial_selected_provider"] == "openrouter_free"
+    assert any(attempt.provider == "openrouter_free" and not attempt.success for attempt in attempts)
+    assert any(attempt.provider == "anthropic" and attempt.success for attempt in attempts)
     assert any(
         item.outcome_kind == "provider_attempt"
         and item.subject_id == "openrouter_free"
@@ -178,6 +211,12 @@ async def test_model_router_fallback_success_marks_fallback_in_telemetry(tmp_pat
         and item.status == "succeeded"
         for item in outcomes
     )
+    audit_rows = [
+        json.loads(line)
+        for line in (tmp_path / "routing_decisions.jsonl").read_text().splitlines()
+    ]
+    assert all(row["row_kind"] in {"decision", "attempt"} for row in audit_rows)
+    assert audit_rows[0]["decision_class"] == "fallback"
 
 
 @pytest.mark.asyncio
@@ -186,6 +225,7 @@ async def test_model_router_total_failure_writes_failed_completion_telemetry(tmp
     router = ModelRouter(
         {ProviderType.OPENAI: _FailingProvider()},
         telemetry=telemetry,
+        routing_audit_path=tmp_path / "routing_decisions.jsonl",
     )
 
     with pytest.raises(RuntimeError, match="All providers failed"):
@@ -211,6 +251,18 @@ async def test_model_router_total_failure_writes_failed_completion_telemetry(tmp
         )
 
     routes = await telemetry.list_routing_decisions(task_id="task-failure", limit=10)
+    completion_route = _route_by_caller(
+        routes,
+        "providers.ModelRouter.complete_for_task",
+    )
+    resident_route = _route_by_caller(
+        routes,
+        "providers.ModelRouter.resident_degraded_handoff",
+    )
+    attempts = await telemetry.list_provider_attempts(decision_id=completion_route.decision_id)
+    resident_attempts = await telemetry.list_provider_attempts(
+        decision_id=resident_route.decision_id,
+    )
     outcomes = await telemetry.list_external_outcomes(
         session_id="sess-failure",
         limit=20,
@@ -221,14 +273,245 @@ async def test_model_router_total_failure_writes_failed_completion_telemetry(tmp
         limit=10,
     )
 
-    assert len(routes) == 1
-    assert routes[0].selected_provider == "openai"
-    assert routes[0].metadata["result"] == "failed"
+    assert len(routes) == 2
+    assert completion_route.selected_provider == "openai"
+    assert completion_route.decision_class == "pinned"
+    assert completion_route.outcome == "all_failed"
+    assert completion_route.n_attempts == len(attempts)
+    assert completion_route.metadata["result"] == "failed"
+    assert resident_route.selected_provider == ""
+    assert resident_route.selected_model_hint == "resident-control-plane"
+    assert resident_route.decision_class == "no_route"
+    assert resident_route.outcome == "all_failed"
+    assert resident_route.requires_human is True
+    assert resident_route.metadata["resident_fallback"] is True
+    assert resident_route.metadata["handoff_reason"] == "all_providers_failed"
+    assert resident_attempts
+    assert all(not attempt.success for attempt in resident_attempts)
+    assert attempts
+    assert all(not attempt.success for attempt in attempts)
+    assert attempts[0].provider == "openai"
     assert economic == []
     assert any(
         item.outcome_kind == "provider_completion"
         and item.subject_id == "openai"
         and item.status == "failed"
         and item.value == 0.0
+        for item in outcomes
+    )
+    assert any(
+        item.outcome_kind == "resident_degraded_handoff"
+        and item.subject_id == "resident_control_plane"
+        and item.status == "queued"
+        for item in outcomes
+    )
+    audit_rows = [
+        json.loads(line)
+        for line in (tmp_path / "routing_decisions.jsonl").read_text().splitlines()
+    ]
+    decision_rows = [row for row in audit_rows if row["row_kind"] == "decision"]
+    assert {row["caller"] for row in decision_rows} == {
+        "providers.ModelRouter.complete_for_task",
+        "providers.ModelRouter.resident_degraded_handoff",
+    }
+    assert any(row["outcome"] == "all_failed" for row in decision_rows)
+
+    stigmergy_rows = [
+        json.loads(line)
+        for line in (tmp_path / "_stigmergy_isolated" / "marks.jsonl")
+        .read_text()
+        .splitlines()
+    ]
+    assert any(
+        row["agent"] == "resident_control_plane"
+        and row["channel"] == "action_queue"
+        and "resident handoff queued" in row["observation"]
+        for row in stigmergy_rows
+    )
+
+
+@pytest.mark.asyncio
+async def test_model_router_no_available_provider_records_resident_handoff(
+    tmp_path,
+) -> None:
+    telemetry = TelemetryPlaneStore(tmp_path / "runtime.db")
+    router = ModelRouter(
+        {},
+        telemetry=telemetry,
+        routing_audit_path=tmp_path / "routing_decisions.jsonl",
+    )
+
+    with pytest.raises(RuntimeError, match="No available providers"):
+        await router.complete_for_task(
+            ProviderRouteRequest(
+                action_name="heartbeat",
+                risk_score=0.1,
+                uncertainty=0.1,
+                novelty=0.1,
+                urgency=0.9,
+                expected_impact=0.6,
+                context={
+                    "session_id": "sess-no-provider",
+                    "task_id": "task-no-provider",
+                    "run_id": "run-no-provider",
+                    "task_type": "pulse",
+                },
+            ),
+            LLMRequest(
+                model="gpt-4o",
+                messages=[{"role": "user", "content": "keep watch"}],
+            ),
+            available_provider_types=[],
+        )
+
+    routes = await telemetry.list_routing_decisions(task_id="task-no-provider", limit=10)
+    outcomes = await telemetry.list_external_outcomes(
+        session_id="sess-no-provider",
+        limit=10,
+    )
+
+    assert len(routes) == 1
+    assert routes[0].caller == "providers.ModelRouter.resident_degraded_handoff"
+    assert routes[0].selected_provider == ""
+    assert routes[0].decision_class == "no_route"
+    assert routes[0].outcome == "no_route"
+    assert routes[0].task_type == "pulse"
+    assert routes[0].requires_human is True
+    assert routes[0].metadata["resident_fallback"] is True
+    assert routes[0].metadata["handoff_reason"] == (
+        "no_available_providers_after_routing_filter"
+    )
+    assert routes[0].n_attempts == 0
+    assert any(
+        item.outcome_kind == "resident_degraded_handoff"
+        and item.subject_id == "resident_control_plane"
+        and item.status == "queued"
+        for item in outcomes
+    )
+
+    audit_rows = [
+        json.loads(line)
+        for line in (tmp_path / "routing_decisions.jsonl").read_text().splitlines()
+    ]
+    assert audit_rows == [
+        row
+        for row in audit_rows
+        if row["caller"] == "providers.ModelRouter.resident_degraded_handoff"
+    ]
+    assert audit_rows[0]["outcome"] == "no_route"
+
+    stigmergy_rows = [
+        json.loads(line)
+        for line in (tmp_path / "_stigmergy_isolated" / "marks.jsonl")
+        .read_text()
+        .splitlines()
+    ]
+    assert stigmergy_rows[0]["agent"] == "resident_control_plane"
+    assert stigmergy_rows[0]["channel"] == "action_queue"
+
+
+@pytest.mark.asyncio
+async def test_model_router_resident_handoff_survives_without_telemetry(
+    tmp_path,
+) -> None:
+    router = ModelRouter(
+        {},
+        telemetry_enabled=False,
+        routing_audit_path=tmp_path / "routing_decisions.jsonl",
+    )
+
+    with pytest.raises(RuntimeError, match="No available providers"):
+        await router.complete_for_task(
+            ProviderRouteRequest(
+                action_name="resident_watch",
+                risk_score=0.1,
+                uncertainty=0.1,
+                novelty=0.1,
+                urgency=0.8,
+                expected_impact=0.5,
+                context={
+                    "session_id": "sess-audit-only",
+                    "task_id": "task-audit-only",
+                    "task_type": "pulse",
+                },
+            ),
+            LLMRequest(
+                model="gpt-4o",
+                messages=[{"role": "user", "content": "keep watch"}],
+            ),
+            available_provider_types=[],
+        )
+
+    audit_rows = [
+        json.loads(line)
+        for line in (tmp_path / "routing_decisions.jsonl").read_text().splitlines()
+    ]
+    assert len(audit_rows) == 1
+    assert audit_rows[0]["row_kind"] == "decision"
+    assert audit_rows[0]["caller"] == "providers.ModelRouter.resident_degraded_handoff"
+    assert audit_rows[0]["outcome"] == "no_route"
+    assert audit_rows[0]["metadata"]["resident_fallback"] is True
+
+    stigmergy_rows = [
+        json.loads(line)
+        for line in (tmp_path / "_stigmergy_isolated" / "marks.jsonl")
+        .read_text()
+        .splitlines()
+    ]
+    assert stigmergy_rows[0]["agent"] == "resident_control_plane"
+    assert stigmergy_rows[0]["channel"] == "action_queue"
+
+
+@pytest.mark.asyncio
+async def test_model_router_witness_failure_does_not_break_completion(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    telemetry = TelemetryPlaneStore(tmp_path / "runtime.db")
+    router = ModelRouter(
+        {ProviderType.OPENAI: _DummyProvider("ok")},
+        telemetry=telemetry,
+        routing_audit_path=tmp_path / "routing_decisions.jsonl",
+    )
+
+    async def raising_emit(**kwargs: object) -> None:
+        raise RuntimeError("witness layer unavailable")
+
+    monkeypatch.setattr(
+        "dharma_swarm.route_witness.emit_routing_decision",
+        raising_emit,
+    )
+
+    decision, response = await router.complete_for_task(
+        ProviderRouteRequest(
+            action_name="summarize_notes",
+            risk_score=0.12,
+            uncertainty=0.14,
+            novelty=0.12,
+            urgency=0.4,
+            expected_impact=0.2,
+            context={
+                "session_id": "sess-witness-failure",
+                "task_id": "task-witness-failure",
+            },
+        ),
+        LLMRequest(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": "Summarize these notes"}],
+        ),
+        available_provider_types=[ProviderType.OPENAI],
+    )
+
+    assert decision.selected_provider == ProviderType.OPENAI
+    assert response.content == "ok"
+    assert await telemetry.list_routing_decisions(task_id="task-witness-failure") == []
+    outcomes = await telemetry.list_external_outcomes(
+        session_id="sess-witness-failure",
+        limit=20,
+    )
+    assert any(
+        item.outcome_kind == "provider_completion"
+        and item.subject_id == "openai"
+        and item.status == "observed"
         for item in outcomes
     )

--- a/tests/test_route_witness.py
+++ b/tests/test_route_witness.py
@@ -1,0 +1,753 @@
+"""Unit tests for dharma_swarm.route_witness — Phase 1 canonical route witness.
+
+Covers:
+- Redaction (truncation, secret patterns, witness/claude paths, email).
+- Error classification (all 9 error classes).
+- Tier and cost lookup (free, cheap, paid, unknown).
+- Decision-outcome resolution (no attempts, all-success, all-timeout, mixed).
+- build_provider_attempt: auto-derivation, redaction integration, defaults.
+- emit_routing_decision: happy path, kill-switch, audit-disabled,
+  telemetry-disabled, telemetry-failure-doesn't-break-audit, empty attempts.
+- Schema migration is exercised by TelemetryPlaneStore.init_db side effects.
+
+See docs/plans/2026-05-10-phase1-routing-witness.md.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from dharma_swarm.models import ProviderType
+from dharma_swarm.route_witness import (
+    DECISION_CLASSES,
+    ERROR_CLASS_API_ERROR,
+    ERROR_CLASS_AUTH_ERROR,
+    ERROR_CLASS_CREDIT_EXHAUSTED,
+    ERROR_CLASS_EMPTY_CONTENT,
+    ERROR_CLASS_MODEL_UNAVAILABLE,
+    ERROR_CLASS_NETWORK,
+    ERROR_CLASS_RATE_LIMIT,
+    ERROR_CLASS_TIMEOUT,
+    ERROR_CLASS_UNKNOWN,
+    ERROR_CLASSES,
+    MAX_ERROR_DETAIL_CHARS,
+    OUTCOMES,
+    build_provider_attempt,
+    classify_error,
+    emit_routing_decision,
+    estimate_cost_usd,
+    redact_error_detail,
+    tier_for_provider,
+)
+from dharma_swarm.route_witness import _resolve_decision_outcome  # type: ignore[attr-defined]
+from dharma_swarm.telemetry_plane import (
+    ProviderAttemptRecord,
+    RoutingDecisionRecord,
+    TelemetryPlaneStore,
+)
+
+
+# ---------------------------------------------------------------------------
+# Redaction
+# ---------------------------------------------------------------------------
+
+class TestRedaction:
+    def test_empty_input_returns_empty(self) -> None:
+        assert redact_error_detail("") == ""
+
+    def test_truncates_above_max(self) -> None:
+        long = "x" * (MAX_ERROR_DETAIL_CHARS + 500)
+        assert len(redact_error_detail(long)) <= MAX_ERROR_DETAIL_CHARS
+
+    def test_redacts_secret_crossing_truncation_boundary(self) -> None:
+        secret = "sk-abcdefghijklmnopqrstuvwxyz1234567890"
+        detail = ("x" * (MAX_ERROR_DETAIL_CHARS - 4)) + secret
+        out = redact_error_detail(detail)
+        assert len(out) <= MAX_ERROR_DETAIL_CHARS
+        assert "sk-" not in out
+        assert "abcdef" not in out
+        assert "redacted" in out
+
+    def test_redacts_anthropic_style_key(self) -> None:
+        out = redact_error_detail("auth header sk-abc1234567890XYZ_token failed")
+        assert "sk-abc" not in out
+        assert "redacted" in out
+
+    def test_redacts_bearer_token(self) -> None:
+        out = redact_error_detail("Authorization: Bearer abcdefghijklmnopqrstuv_xyz")
+        assert "abcdefghij" not in out
+        assert "redacted" in out
+
+    def test_redacts_long_hex(self) -> None:
+        out = redact_error_detail("hash=" + "a" * 40)
+        assert "a" * 40 not in out
+
+    def test_redacts_email(self) -> None:
+        out = redact_error_detail("contact dhyana@example.com")
+        assert "dhyana@example" not in out
+        assert "redacted-email" in out
+
+    def test_redacts_witness_path(self) -> None:
+        out = redact_error_detail("file at /Users/dhyana/.dharma/witness/x.jsonl")
+        assert "/.dharma/" not in out
+        assert "<witness_path>" in out
+
+    def test_redacts_claude_config_path(self) -> None:
+        out = redact_error_detail("config /Users/dhyana/.claude/settings.json")
+        assert "/.claude/" not in out
+        assert "<claude_config_path>" in out
+
+    def test_redacts_inline_api_key(self) -> None:
+        out = redact_error_detail("failed: api_key=secret_value_12345 extra")
+        assert "secret_value_12345" not in out
+        assert "redacted" in out.lower()
+
+    def test_only_whitespace_after_redaction_returns_redacted(self) -> None:
+        # Something that's entirely a secret pattern should not return empty.
+        out = redact_error_detail("dhyana@example.com")
+        assert out  # not empty
+        assert "redacted-email" in out
+
+    def test_no_secret_input_passes_through(self) -> None:
+        out = redact_error_detail("connection timed out after 30s")
+        assert out == "connection timed out after 30s"
+
+
+# ---------------------------------------------------------------------------
+# Error classification
+# ---------------------------------------------------------------------------
+
+class TestErrorClassification:
+    def test_none_returns_empty(self) -> None:
+        assert classify_error(None) == ""
+
+    def test_empty_string_returns_unknown(self) -> None:
+        assert classify_error("") == ERROR_CLASS_UNKNOWN
+
+    def test_credit_balance(self) -> None:
+        assert classify_error("Credit balance is too low") == ERROR_CLASS_CREDIT_EXHAUSTED
+
+    def test_credit_alternates(self) -> None:
+        for msg in (
+            "Out of credits",
+            "Insufficient credit on account",
+            "Payment required: 402",
+        ):
+            assert classify_error(msg) == ERROR_CLASS_CREDIT_EXHAUSTED, msg
+
+    def test_rate_limit_429(self) -> None:
+        assert classify_error("HTTP 429: Too Many Requests") == ERROR_CLASS_RATE_LIMIT
+
+    def test_rate_limit_quota(self) -> None:
+        assert classify_error("Quota exceeded for project") == ERROR_CLASS_RATE_LIMIT
+
+    def test_async_timeout_exception(self) -> None:
+        assert classify_error(asyncio.TimeoutError()) == ERROR_CLASS_TIMEOUT
+
+    def test_timeout_string(self) -> None:
+        assert classify_error("ReadTimeout: timed out after 30s") == ERROR_CLASS_TIMEOUT
+
+    def test_auth_401(self) -> None:
+        assert classify_error("HTTP 401: Unauthorized") == ERROR_CLASS_AUTH_ERROR
+
+    def test_auth_invalid_key(self) -> None:
+        assert classify_error("Invalid API key provided") == ERROR_CLASS_AUTH_ERROR
+
+    def test_forbidden_403_classified_as_auth(self) -> None:
+        # Per Phase 1 rule: Groq APAC region returns 403; classify as auth not network.
+        assert classify_error("403 Forbidden: Access denied") == ERROR_CLASS_AUTH_ERROR
+
+    def test_network_connection_refused(self) -> None:
+        assert classify_error("Connection refused by remote host") == ERROR_CLASS_NETWORK
+
+    def test_network_dns(self) -> None:
+        assert classify_error("Could not resolve DNS for api.example.com") == ERROR_CLASS_NETWORK
+
+    def test_model_unavailable(self) -> None:
+        assert classify_error("model_not_found: gpt-99-turbo") == ERROR_CLASS_MODEL_UNAVAILABLE
+
+    def test_model_404(self) -> None:
+        assert classify_error("HTTP 404: model not found") == ERROR_CLASS_MODEL_UNAVAILABLE
+
+    def test_empty_content(self) -> None:
+        assert classify_error("empty content from provider") == ERROR_CLASS_EMPTY_CONTENT
+
+    def test_api_error_500(self) -> None:
+        assert classify_error("500 Internal Server Error") == ERROR_CLASS_API_ERROR
+
+    def test_api_error_503(self) -> None:
+        assert classify_error("503 Service Unavailable") == ERROR_CLASS_API_ERROR
+
+    def test_unknown_falls_through(self) -> None:
+        assert classify_error("some weird message we don't know about") == ERROR_CLASS_UNKNOWN
+
+    def test_all_error_classes_enumerated(self) -> None:
+        # Sanity: every class returned by classify_error is in ERROR_CLASSES.
+        seen = {classify_error(s) for s in (
+            None, "", "credit balance", "rate limit", "401", "403",
+            "model_not_found", "connection refused", "timed out",
+            "empty content", "500", "weird unknown",
+        )}
+        seen.discard("")  # None → empty string
+        assert seen.issubset(set(ERROR_CLASSES))
+
+
+# ---------------------------------------------------------------------------
+# Tier & cost lookup
+# ---------------------------------------------------------------------------
+
+class TestTierAndCost:
+    def test_ollama_is_free(self) -> None:
+        assert tier_for_provider(ProviderType.OLLAMA) == "free"
+
+    def test_nim_is_free(self) -> None:
+        assert tier_for_provider(ProviderType.NVIDIA_NIM) == "free"
+
+    def test_groq_is_free(self) -> None:
+        assert tier_for_provider(ProviderType.GROQ) == "free"
+
+    def test_mistral_is_cheap(self) -> None:
+        assert tier_for_provider(ProviderType.MISTRAL) == "cheap"
+
+    def test_openai_is_paid(self) -> None:
+        assert tier_for_provider(ProviderType.OPENAI) == "paid"
+
+    def test_anthropic_is_paid(self) -> None:
+        assert tier_for_provider(ProviderType.ANTHROPIC) == "paid"
+
+    def test_empty_provider_is_unknown(self) -> None:
+        assert tier_for_provider("") == "unknown"
+
+    def test_string_provider_value_works(self) -> None:
+        assert tier_for_provider("ollama") == "free"
+        assert tier_for_provider("openai") == "paid"
+
+    def test_free_provider_zero_cost(self) -> None:
+        assert estimate_cost_usd(ProviderType.OLLAMA, prompt_tokens=10000, completion_tokens=10000) == 0.0
+        assert estimate_cost_usd(ProviderType.NVIDIA_NIM, prompt_tokens=5000, completion_tokens=5000) == 0.0
+
+    def test_paid_provider_nonzero_cost(self) -> None:
+        cost = estimate_cost_usd(ProviderType.OPENAI, prompt_tokens=1000, completion_tokens=1000)
+        assert cost > 0.0
+
+    def test_zero_tokens_zero_cost(self) -> None:
+        assert estimate_cost_usd(ProviderType.OPENAI, prompt_tokens=0, completion_tokens=0) == 0.0
+
+    def test_cost_scales_with_tokens(self) -> None:
+        a = estimate_cost_usd(ProviderType.OPENAI, prompt_tokens=1000, completion_tokens=1000)
+        b = estimate_cost_usd(ProviderType.OPENAI, prompt_tokens=2000, completion_tokens=2000)
+        assert b > a
+
+    def test_unknown_provider_returns_baseline_cost(self) -> None:
+        # Falls through to default rate (0.001 / 0.003) rather than crashing.
+        cost = estimate_cost_usd("totally_made_up_provider", prompt_tokens=1000, completion_tokens=1000)
+        assert cost > 0.0
+
+
+# ---------------------------------------------------------------------------
+# Decision outcome resolution
+# ---------------------------------------------------------------------------
+
+class TestDecisionOutcome:
+    def _attempt(self, success: bool, error_class: str = "") -> ProviderAttemptRecord:
+        return ProviderAttemptRecord(
+            decision_id="d1", attempt_idx=0, provider="x", model="y",
+            success=success, error_class=error_class,
+        )
+
+    def test_explicit_overrides(self) -> None:
+        assert _resolve_decision_outcome(explicit="custom", attempts=[]) == "custom"
+
+    def test_no_attempts_is_no_route(self) -> None:
+        assert _resolve_decision_outcome(explicit=None, attempts=[]) == "no_route"
+
+    def test_any_success_is_success(self) -> None:
+        out = _resolve_decision_outcome(
+            explicit=None,
+            attempts=[
+                self._attempt(False, ERROR_CLASS_CREDIT_EXHAUSTED),
+                self._attempt(True),
+            ],
+        )
+        assert out == "success"
+
+    def test_all_timeout(self) -> None:
+        out = _resolve_decision_outcome(
+            explicit=None,
+            attempts=[
+                self._attempt(False, ERROR_CLASS_TIMEOUT),
+                self._attempt(False, ERROR_CLASS_TIMEOUT),
+            ],
+        )
+        assert out == "timeout"
+
+    def test_mixed_failure_is_all_failed(self) -> None:
+        out = _resolve_decision_outcome(
+            explicit=None,
+            attempts=[
+                self._attempt(False, ERROR_CLASS_CREDIT_EXHAUSTED),
+                self._attempt(False, ERROR_CLASS_RATE_LIMIT),
+            ],
+        )
+        assert out == "all_failed"
+
+
+# ---------------------------------------------------------------------------
+# build_provider_attempt
+# ---------------------------------------------------------------------------
+
+class TestBuildProviderAttempt:
+    def test_minimal_success(self) -> None:
+        a = build_provider_attempt(
+            decision_id="d1", attempt_idx=0,
+            provider=ProviderType.OPENAI, model="gpt-5",
+            success=True, duration_ms=100.0,
+        )
+        assert a.success is True
+        assert a.outcome == "success"
+        assert a.error_class == ""
+        assert a.error_detail == ""
+        assert a.tier == "paid"
+        assert a.provider == "openai"
+
+    def test_failure_classifies_credit(self) -> None:
+        a = build_provider_attempt(
+            decision_id="d1", attempt_idx=0,
+            provider=ProviderType.CLAUDE_CODE, model="default",
+            success=False, duration_ms=800.0,
+            error="Credit balance is too low",
+        )
+        assert a.success is False
+        assert a.error_class == ERROR_CLASS_CREDIT_EXHAUSTED
+        assert "Credit balance" in a.error_detail
+
+    def test_failure_redacts_secret_in_error(self) -> None:
+        a = build_provider_attempt(
+            decision_id="d1", attempt_idx=0,
+            provider=ProviderType.OPENAI, model="gpt-5",
+            success=False, duration_ms=10.0,
+            error="auth header sk-abcdef1234567890XYZ failed",
+        )
+        assert "sk-abcdef" not in a.error_detail
+        assert "redacted" in a.error_detail.lower()
+
+    def test_explicit_error_class_override(self) -> None:
+        a = build_provider_attempt(
+            decision_id="d1", attempt_idx=0,
+            provider=ProviderType.OPENAI, model="gpt-5",
+            success=False, duration_ms=10.0,
+            error="some unrecognized error",
+            error_class=ERROR_CLASS_API_ERROR,
+        )
+        assert a.error_class == ERROR_CLASS_API_ERROR
+
+    def test_async_timeout_classifies_as_timeout(self) -> None:
+        a = build_provider_attempt(
+            decision_id="d1", attempt_idx=0,
+            provider=ProviderType.OPENAI, model="gpt-5",
+            success=False, duration_ms=240000.0,
+            error=asyncio.TimeoutError(),
+        )
+        assert a.error_class == ERROR_CLASS_TIMEOUT
+
+    def test_cost_auto_derived_from_usage(self) -> None:
+        a = build_provider_attempt(
+            decision_id="d1", attempt_idx=0,
+            provider=ProviderType.OPENAI, model="gpt-5",
+            success=True, duration_ms=100.0,
+            usage={"prompt_tokens": 1000, "completion_tokens": 1000, "total_tokens": 2000},
+        )
+        assert a.cost_estimate_usd > 0.0
+
+    def test_explicit_cost_override(self) -> None:
+        a = build_provider_attempt(
+            decision_id="d1", attempt_idx=0,
+            provider=ProviderType.OPENAI, model="gpt-5",
+            success=True, duration_ms=100.0,
+            usage={"prompt_tokens": 9999, "completion_tokens": 9999},
+            cost_estimate_usd=0.42,
+        )
+        assert a.cost_estimate_usd == 0.42
+
+    def test_free_provider_zero_cost_even_with_tokens(self) -> None:
+        a = build_provider_attempt(
+            decision_id="d1", attempt_idx=0,
+            provider=ProviderType.OLLAMA, model="glm-5:cloud",
+            success=True, duration_ms=100.0,
+            usage={"prompt_tokens": 5000, "completion_tokens": 5000},
+        )
+        assert a.cost_estimate_usd == 0.0
+        assert a.tier == "free"
+
+    def test_usage_filters_non_numeric(self) -> None:
+        a = build_provider_attempt(
+            decision_id="d1", attempt_idx=0,
+            provider=ProviderType.OPENAI, model="gpt-5",
+            success=True, duration_ms=100.0,
+            usage={"prompt_tokens": 100, "weird_key": "not_an_int"},  # type: ignore[dict-item]
+        )
+        assert a.usage == {"prompt_tokens": 100}
+
+    def test_string_provider_accepted(self) -> None:
+        a = build_provider_attempt(
+            decision_id="d1", attempt_idx=0,
+            provider="custom_lane", model="x",
+            success=True, duration_ms=10.0,
+        )
+        assert a.provider == "custom_lane"
+        assert a.tier == "paid"  # default for unknown
+
+    def test_numeric_fields_are_non_negative(self) -> None:
+        a = build_provider_attempt(
+            decision_id="d1", attempt_idx=-10,
+            provider=ProviderType.OPENAI, model="gpt-5",
+            success=True, duration_ms=-5.0,
+            usage={"prompt_tokens": -10, "completion_tokens": -20},
+            cost_estimate_usd=-99.0,
+        )
+        assert a.attempt_idx == 0
+        assert a.duration_ms == 0.0
+        assert a.usage == {"prompt_tokens": 0, "completion_tokens": 0}
+        assert a.cost_estimate_usd == 0.0
+
+
+# ---------------------------------------------------------------------------
+# emit_routing_decision integration
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def isolated_env(tmp_path, monkeypatch):
+    """Isolate JSONL audit path + DB to tmp_path so tests don't touch live data."""
+    audit = tmp_path / "routing_decisions.jsonl"
+    monkeypatch.setenv("DGC_ROUTER_AUDIT_LOG", str(audit))
+    monkeypatch.setenv("DGC_ROUTER_AUDIT_ENABLE", "1")
+    monkeypatch.setenv("DGC_ROUTER_TELEMETRY_ENABLE", "1")
+    monkeypatch.delenv("DGC_ROUTE_WITNESS_DISABLE_HELPER", raising=False)
+    db = tmp_path / "runtime.db"
+    store = TelemetryPlaneStore(db_path=db)
+    return audit, store
+
+
+def _make_attempt(decision_id: str = "d1") -> ProviderAttemptRecord:
+    return build_provider_attempt(
+        decision_id=decision_id, attempt_idx=0,
+        provider=ProviderType.OPENAI, model="gpt-5",
+        success=True, duration_ms=100.0,
+        usage={"prompt_tokens": 100, "completion_tokens": 200},
+    )
+
+
+@pytest.mark.asyncio
+async def test_emit_writes_to_both_jsonl_and_sqlite(isolated_env) -> None:
+    audit, store = isolated_env
+    await emit_routing_decision(
+        decision_id="d1", action_name="test_action", route_path="deliberative",
+        selected_provider=ProviderType.OPENAI, selected_model="gpt-5",
+        candidate_chain=[ProviderType.OPENAI],
+        decision_class="pinned", caller="unit_test",
+        duration_ms=100.0, attempts=[_make_attempt()],
+        task_type="test", telemetry=store,
+    )
+
+    rows = [json.loads(line) for line in audit.read_text().splitlines()]
+    assert len(rows) == 2
+    assert rows[0]["row_kind"] == "decision"
+    assert rows[0]["caller"] == "unit_test"
+    assert rows[1]["row_kind"] == "attempt"
+    assert rows[1]["decision_id"] == "d1"
+
+    decisions = await store.list_routing_decisions(limit=5)
+    attempts = await store.list_provider_attempts(decision_id="d1")
+    assert len(decisions) == 1
+    assert decisions[0].caller == "unit_test"
+    assert len(attempts) == 1
+    assert attempts[0].success is True
+
+
+@pytest.mark.asyncio
+async def test_emit_kill_switch_is_silent_no_op(tmp_path, monkeypatch) -> None:
+    audit = tmp_path / "k.jsonl"
+    monkeypatch.setenv("DGC_ROUTER_AUDIT_LOG", str(audit))
+    monkeypatch.setenv("DGC_ROUTE_WITNESS_DISABLE_HELPER", "1")
+    store = TelemetryPlaneStore(db_path=tmp_path / "k.db")
+
+    await emit_routing_decision(
+        decision_id="d1", action_name="x", route_path="x",
+        selected_provider=ProviderType.OPENAI, selected_model="x",
+        candidate_chain=[], decision_class="pinned", caller="c",
+        duration_ms=1.0, attempts=[],
+        telemetry=store,
+    )
+    assert not audit.exists()
+    decisions = await store.list_routing_decisions(limit=5)
+    assert len(decisions) == 0
+
+
+@pytest.mark.asyncio
+async def test_emit_audit_disabled_skips_jsonl(tmp_path, monkeypatch) -> None:
+    audit = tmp_path / "no.jsonl"
+    monkeypatch.setenv("DGC_ROUTER_AUDIT_LOG", str(audit))
+    monkeypatch.setenv("DGC_ROUTER_AUDIT_ENABLE", "0")
+    monkeypatch.setenv("DGC_ROUTER_TELEMETRY_ENABLE", "1")
+    store = TelemetryPlaneStore(db_path=tmp_path / "y.db")
+    await emit_routing_decision(
+        decision_id="d1", action_name="x", route_path="x",
+        selected_provider=ProviderType.OPENAI, selected_model="x",
+        candidate_chain=[], decision_class="pinned", caller="c",
+        duration_ms=1.0, attempts=[_make_attempt()],
+        telemetry=store,
+    )
+    assert not audit.exists()
+    decisions = await store.list_routing_decisions(limit=5)
+    assert len(decisions) == 1
+
+
+@pytest.mark.asyncio
+async def test_emit_telemetry_disabled_skips_sqlite(tmp_path, monkeypatch) -> None:
+    audit = tmp_path / "ya.jsonl"
+    monkeypatch.setenv("DGC_ROUTER_AUDIT_LOG", str(audit))
+    monkeypatch.setenv("DGC_ROUTER_AUDIT_ENABLE", "1")
+    monkeypatch.setenv("DGC_ROUTER_TELEMETRY_ENABLE", "0")
+    store = TelemetryPlaneStore(db_path=tmp_path / "n.db")
+    await emit_routing_decision(
+        decision_id="d1", action_name="x", route_path="x",
+        selected_provider=ProviderType.OPENAI, selected_model="x",
+        candidate_chain=[], decision_class="pinned", caller="c",
+        duration_ms=1.0, attempts=[_make_attempt()],
+        telemetry=store,
+    )
+    rows = [json.loads(l) for l in audit.read_text().splitlines()]
+    assert len(rows) == 2
+    decisions = await store.list_routing_decisions(limit=5)
+    assert len(decisions) == 0
+
+
+@pytest.mark.asyncio
+async def test_emit_no_attempts_records_no_route(isolated_env) -> None:
+    audit, store = isolated_env
+    await emit_routing_decision(
+        decision_id="d1", action_name="x", route_path="x",
+        selected_provider="", selected_model="",
+        candidate_chain=[], decision_class="no_route", caller="c",
+        duration_ms=0.0, attempts=[],
+        telemetry=store,
+    )
+    rows = [json.loads(l) for l in audit.read_text().splitlines()]
+    assert len(rows) == 1
+    assert rows[0]["row_kind"] == "decision"
+    assert rows[0]["outcome"] == "no_route"
+    assert rows[0]["selected_tier"] == "unknown"
+
+
+@pytest.mark.asyncio
+async def test_emit_never_leaks_secrets_to_jsonl(isolated_env) -> None:
+    audit, store = isolated_env
+    bad = build_provider_attempt(
+        decision_id="d1", attempt_idx=0,
+        provider=ProviderType.ANTHROPIC, model="claude-opus-4",
+        success=False, duration_ms=10.0,
+        error="auth header Bearer sk-1234567890abcdefghij failed: api_key=secret_abcdef12345",
+    )
+    await emit_routing_decision(
+        decision_id="d1", action_name="x", route_path="x",
+        selected_provider=ProviderType.ANTHROPIC, selected_model="claude-opus-4",
+        candidate_chain=[ProviderType.ANTHROPIC],
+        decision_class="pinned", caller="c",
+        duration_ms=10.0, attempts=[bad],
+        telemetry=store,
+    )
+    flat = audit.read_text()
+    # No raw secrets must reach disk.
+    assert "sk-1234567890abcdef" not in flat
+    assert "secret_abcdef12345" not in flat
+    # Witness is still useful: error_class survived.
+    assert "credit_exhausted" not in flat  # was not credit-class
+    # Some redacted marker must be present.
+    assert "redacted" in flat.lower()
+
+
+@pytest.mark.asyncio
+async def test_emit_redacts_metadata_reasons_and_non_json_values(isolated_env) -> None:
+    audit, store = isolated_env
+    await emit_routing_decision(
+        decision_id="d1",
+        action_name="api_key=action_secret_123456",
+        route_path="deliberative",
+        selected_provider=ProviderType.OPENAI,
+        selected_model="gpt-5",
+        candidate_chain=[ProviderType.OPENAI, "api_key=provider_secret_123456"],
+        decision_class="pinned",
+        caller="unit_test",
+        duration_ms=1.0,
+        attempts=[_make_attempt()],
+        reasons=[
+            "authorization=Bearer sk-abcdefghijklmnopqrstuvwxyz123456",
+            "safe_reason",
+        ],
+        metadata={
+            "failure_trace": [
+                {
+                    "error": (
+                        "Bearer sk-abcdefghijklmnopqrstuvwxyz123456 "
+                        "api_key=metadata_secret"
+                    )
+                }
+            ],
+            "path": Path("/Users/dhyana/.dharma/witness/private.jsonl"),
+            "email": "dhyana@example.com",
+        },
+        telemetry=store,
+    )
+
+    flat = audit.read_text()
+    assert "sk-abcdefghijklmnopqrstuvwxyz" not in flat
+    assert "metadata_secret" not in flat
+    assert "provider_secret" not in flat
+    assert "action_secret" not in flat
+    assert "/.dharma/" not in flat
+    assert "dhyana@example.com" not in flat
+    assert "redacted" in flat.lower()
+
+    decisions = await store.list_routing_decisions(limit=5)
+    assert len(decisions) == 1
+    assert "metadata_secret" not in json.dumps(decisions[0].metadata)
+
+
+@pytest.mark.asyncio
+async def test_emit_concurrent_stress_preserves_joinability_and_redaction(isolated_env) -> None:
+    audit, store = isolated_env
+    n_decisions = 32
+
+    async def emit_one(idx: int) -> None:
+        decision_id = f"stress-{idx}"
+        attempts = [
+            build_provider_attempt(
+                decision_id=decision_id,
+                attempt_idx=0,
+                provider=ProviderType.OPENAI,
+                model="gpt-5",
+                success=False,
+                duration_ms=idx + 0.1,
+                error=(
+                    "rate limit Bearer sk-abcdefghijklmnopqrstuvwxyz123456 "
+                    f"idx={idx}"
+                ),
+            ),
+            build_provider_attempt(
+                decision_id=decision_id,
+                attempt_idx=1,
+                provider=ProviderType.NVIDIA_NIM,
+                model="nim",
+                success=True,
+                duration_ms=idx + 0.2,
+                usage={"prompt_tokens": idx + 1, "completion_tokens": idx + 2},
+            ),
+        ]
+        await emit_routing_decision(
+            decision_id=decision_id,
+            action_name="stress",
+            route_path="deliberative",
+            selected_provider=ProviderType.NVIDIA_NIM,
+            selected_model="nim",
+            candidate_chain=[ProviderType.OPENAI, ProviderType.NVIDIA_NIM],
+            decision_class="fallback",
+            caller="stress_test",
+            duration_ms=idx + 1.0,
+            attempts=attempts,
+            telemetry=store,
+        )
+
+    await asyncio.gather(*(emit_one(idx) for idx in range(n_decisions)))
+
+    rows = [json.loads(line) for line in audit.read_text().splitlines()]
+    assert len(rows) == n_decisions * 3
+    assert "sk-abcdefghijklmnopqrstuvwxyz" not in audit.read_text()
+    decision_rows = [row for row in rows if row["row_kind"] == "decision"]
+    attempt_rows = [row for row in rows if row["row_kind"] == "attempt"]
+    assert len(decision_rows) == n_decisions
+    assert len(attempt_rows) == n_decisions * 2
+    for idx in range(n_decisions):
+        decision_id = f"stress-{idx}"
+        assert sum(row["decision_id"] == decision_id for row in decision_rows) == 1
+        assert sum(row["decision_id"] == decision_id for row in attempt_rows) == 2
+
+    decisions = await store.list_routing_decisions(limit=n_decisions + 5)
+    assert sum(item.caller == "stress_test" for item in decisions) == n_decisions
+    for idx in range(n_decisions):
+        attempts = await store.list_provider_attempts(decision_id=f"stress-{idx}")
+        assert len(attempts) == 2
+
+
+@pytest.mark.asyncio
+async def test_emit_unknown_decision_class_passes_through(isolated_env) -> None:
+    audit, store = isolated_env
+    # Spec rule: unknown decision_class logs but does not raise.
+    await emit_routing_decision(
+        decision_id="d1", action_name="x", route_path="x",
+        selected_provider=ProviderType.OPENAI, selected_model="gpt-5",
+        candidate_chain=[ProviderType.OPENAI],
+        decision_class="weirdo_not_a_real_class", caller="c",
+        duration_ms=1.0, attempts=[_make_attempt()],
+        telemetry=store,
+    )
+    rows = [json.loads(l) for l in audit.read_text().splitlines()]
+    assert rows[0]["decision_class"] == "weirdo_not_a_real_class"
+    assert rows[0]["row_kind"] == "decision"
+
+
+@pytest.mark.asyncio
+async def test_emit_total_tokens_aggregates_when_unset(isolated_env) -> None:
+    audit, store = isolated_env
+    a1 = build_provider_attempt(
+        decision_id="d1", attempt_idx=0,
+        provider=ProviderType.OPENAI, model="gpt-5",
+        success=False, duration_ms=10.0,
+        error="rate limit",
+        usage={"prompt_tokens": 100, "completion_tokens": 200},
+    )
+    a2 = build_provider_attempt(
+        decision_id="d1", attempt_idx=1,
+        provider=ProviderType.NVIDIA_NIM, model="meta/llama-3.3-70b",
+        success=True, duration_ms=10.0,
+        usage={"prompt_tokens": 50, "completion_tokens": 75, "total_tokens": 125},
+    )
+    await emit_routing_decision(
+        decision_id="d1", action_name="x", route_path="x",
+        selected_provider=ProviderType.NVIDIA_NIM, selected_model="meta/llama-3.3-70b",
+        candidate_chain=[ProviderType.OPENAI, ProviderType.NVIDIA_NIM],
+        decision_class="fallback", caller="c", duration_ms=20.0,
+        attempts=[a1, a2], telemetry=store,
+    )
+    rows = [json.loads(l) for l in audit.read_text().splitlines()]
+    decision = rows[0]
+    # Sum: a1 has no total_tokens key → uses prompt+completion=300; a2 uses total_tokens=125 → total 425.
+    assert decision["total_tokens"] == 425
+
+
+# ---------------------------------------------------------------------------
+# Sanity: enums are exported and consistent.
+# ---------------------------------------------------------------------------
+
+class TestPublicConstants:
+    def test_error_classes_tuple_has_all_individuals(self) -> None:
+        all_classes = {
+            ERROR_CLASS_CREDIT_EXHAUSTED, ERROR_CLASS_RATE_LIMIT,
+            ERROR_CLASS_TIMEOUT, ERROR_CLASS_NETWORK,
+            ERROR_CLASS_MODEL_UNAVAILABLE, ERROR_CLASS_EMPTY_CONTENT,
+            ERROR_CLASS_API_ERROR, ERROR_CLASS_AUTH_ERROR,
+            ERROR_CLASS_UNKNOWN,
+        }
+        assert all_classes == set(ERROR_CLASSES)
+
+    def test_decision_classes_known(self) -> None:
+        # Spec §2.1 rule: 5 decision classes.
+        assert set(DECISION_CLASSES) == {"pinned", "widened", "fallback", "no_route", "canary"}
+
+    def test_outcomes_known(self) -> None:
+        # Spec §2.1 rule: 6 outcome values.
+        assert set(OUTCOMES) == {"success", "empty_content", "all_failed", "timeout", "gate_block", "no_route"}

--- a/tests/test_runtime_provider.py
+++ b/tests/test_runtime_provider.py
@@ -245,6 +245,7 @@ async def test_complete_via_preferred_runtime_providers_prefers_ollama_then_nim(
     monkeypatch,
 ) -> None:
     calls: list[tuple[str, str]] = []
+    emitted: dict[str, object] = {}
 
     class _FakeProvider:
         def __init__(self, label: str, *, fail: bool = False):
@@ -285,6 +286,9 @@ async def test_complete_via_preferred_runtime_providers_prefers_ollama_then_nim(
             fail=config.provider == ProviderType.OLLAMA,
         )
 
+    async def _fake_emit_routing_decision(**kwargs: object) -> None:
+        emitted.update(kwargs)
+
     monkeypatch.setattr(
         "dharma_swarm.runtime_provider.preferred_runtime_provider_configs",
         _fake_preferred_configs,
@@ -293,10 +297,17 @@ async def test_complete_via_preferred_runtime_providers_prefers_ollama_then_nim(
         "dharma_swarm.runtime_provider.create_runtime_provider",
         _fake_create_provider,
     )
+    monkeypatch.setattr(
+        "dharma_swarm.route_witness.emit_routing_decision",
+        _fake_emit_routing_decision,
+    )
 
     response, config = await complete_via_preferred_runtime_providers(
         messages=[{"role": "user", "content": "hello"}],
         openrouter_model="meta-llama/llama-3.3-70b-instruct:free",
+        caller="test_runtime_provider",
+        task_type="smoke",
+        task_signature="runtime_provider:test",
     )
 
     assert response.content == "nvidia_nim ok"
@@ -305,3 +316,21 @@ async def test_complete_via_preferred_runtime_providers_prefers_ollama_then_nim(
         ("ollama", "ollama-local"),
         ("nvidia_nim", "nim-local"),
     ]
+    assert emitted["caller"] == "test_runtime_provider"
+    assert emitted["task_type"] == "smoke"
+    assert emitted["task_signature"] == "runtime_provider:test"
+    assert emitted["selected_provider"] == ProviderType.NVIDIA_NIM
+    assert emitted["selected_model"] == "nim-local"
+    assert emitted["candidate_chain"] == [
+        ProviderType.OLLAMA,
+        ProviderType.NVIDIA_NIM,
+        ProviderType.OPENROUTER,
+    ]
+    assert emitted["decision_class"] == "fallback"
+    assert emitted["widened_from"] == ProviderType.OLLAMA
+    attempts = emitted["attempts"]
+    assert len(attempts) == 2
+    assert attempts[0].provider == ProviderType.OLLAMA.value
+    assert attempts[0].success is False
+    assert attempts[1].provider == ProviderType.NVIDIA_NIM.value
+    assert attempts[1].success is True


### PR DESCRIPTION
Organ touched: Routing witness / provider telemetry.

Declared-vs-actual gap closed: Route selection now emits structured witness telemetry and the routing witness plan is registered with DocOps instead of living as unregistered authority prose.

Proof that re-reads the map:
- pytest -q tests/test_route_witness.py tests/test_model_router_telemetry.py tests/test_runtime_provider.py
- 98 passed, 1 warning
- python3 scripts/docops/check_docops_integrity.py --changed-from origin/main --report-json /tmp/route-witness-docops-after-rebase-neutral.json from /private/tmp/ds-rw-ci-297b
- DocOps integrity checks passed

New drift introduced: None intentional. The local route-witness worktree path triggers a known false router count in the pre-commit DocOps hook because the path itself contains route; neutral-path DocOps verification passes with router_files=14.