### PR TITLE
feat(recursive): add discovery shadow receipts

### DIFF
--- a/ACTIVE_SURFACE_MANIFEST.yaml
+++ b/ACTIVE_SURFACE_MANIFEST.yaml
@@ -166,6 +166,9 @@ health_check_registry:
   go_world_receipts_present:
     description: "Verify canonical Go world-radar receipts exist under ~/.dharma/go_receipts/world"
     type: file_exists
+  recursive_discovery_module_exists:
+    description: "Verify the recursive discovery shadow receipt module exists"
+    type: file_exists
 
 # ── Dashboard Surfaces ────────────────────────────────────────────
 # Every dashboard page: desired state, observed-state checks, gap info.
@@ -427,6 +430,15 @@ agents:
     priority: p0
     next_action: null
 
+  - id: recursive_discovery_shadow
+    label: "Recursive Discovery Shadow"
+    module: dharma_swarm/recursive_discovery.py
+    status: shadow
+    health_check_ids: [recursive_discovery_module_exists, test_file_exists]
+    wired_to: [control_surface, eval_harness, audit, lineage, evolution]
+    priority: p0
+    next_action: "Keep shadow-only: record receipts and recommend PRs without autonomous apply"
+
 # ── Integrations ──────────────────────────────────────────────────
 # External services and APIs the system depends on.
 
@@ -469,6 +481,67 @@ integrations:
     health_check_ids: [go_world_receipts_present]
     used_by: [control_surface, world_radar_receipt_projection]
 
+  - id: recursive_discovery_receipts
+    label: "Recursive Discovery Receipts"
+    type: evidence_receipts
+    path: "~/.dharma/events/recursive_discovery.jsonl"
+    status: shadow
+    health_check_ids: [recursive_discovery_module_exists]
+    used_by: [control_surface, eval_harness, audit, lineage, darwin_engine]
+
+# ── Recursive Discovery Shadow Surfaces ──────────────────────────
+# Fixture-backed control-surface rows only. These declare the minimum
+# self-improvement loop without allowing autonomous apply.
+
+recursive_discovery_surfaces:
+  - id: limitations
+    label: "Recursive Limitations"
+    receipt_type: limitation
+    status: shadow
+    owner_module: dharma_swarm/recursive_discovery.py
+    priority: p0
+    next_action: "Record one bounded limitation before generating evals"
+
+  - id: generated_evals
+    label: "Recursive Generated Evals"
+    receipt_type: generated_eval
+    status: shadow
+    owner_module: dharma_swarm/recursive_discovery.py
+    priority: p0
+    next_action: "Bind generated eval receipts into EventLog and eval registry"
+
+  - id: candidate_diffs
+    label: "Recursive Candidate Diffs"
+    receipt_type: candidate_diff
+    status: shadow
+    owner_module: dharma_swarm/recursive_discovery.py
+    priority: p0
+    next_action: "Keep candidate diffs in sandbox artifacts until human promotion"
+
+  - id: experiment_receipts
+    label: "Recursive Experiment Receipts"
+    receipt_type: experiment_result
+    status: shadow
+    owner_module: dharma_swarm/recursive_discovery.py
+    priority: p0
+    next_action: "Attach command exits, eval ids, sandbox path, cost, and rollback pointer"
+
+  - id: archive
+    label: "Recursive Archive"
+    receipt_type: witness_verdict
+    status: shadow
+    owner_module: dharma_swarm/recursive_discovery.py
+    priority: p1
+    next_action: "Archive only after witness phases are recorded"
+
+  - id: promotion_queue
+    label: "Recursive Promotion Queue"
+    receipt_type: promotion_decision
+    status: shadow
+    owner_module: dharma_swarm/recursive_discovery.py
+    priority: p0
+    next_action: "Human PR review is required before promotion"
+
 # ── Feedback Loops ────────────────────────────────────────────────
 # The cybernetic loops declared in CYBERNETIC_LOOP_MAP.md.
 
@@ -496,6 +569,18 @@ loops:
     health_check_ids: [module_file_exists, test_file_exists]
     priority: p1
     next_action: "Apply diffs to running code in sandbox and benchmark"
+
+  - id: recursive_discovery_shadow
+    label: "Recursive Discovery Shadow"
+    sense: "bounded limitation receipt"
+    act: "generate eval and candidate diff receipts"
+    evaluate: "sandbox command receipts and witness verdicts"
+    adapt: "archive lineage or hold for human PR promotion"
+    module: dharma_swarm/recursive_discovery.py
+    status: shadow
+    health_check_ids: [recursive_discovery_module_exists, test_file_exists]
+    priority: p0
+    next_action: "Wire receipts through EventLog and Control Surface before any autonomous apply"
 
   - id: shakti_perception
     label: "Shakti Perception"

--- a/dharma_swarm/evaluation_registry.py
+++ b/dharma_swarm/evaluation_registry.py
@@ -587,6 +587,172 @@ class EvaluationRegistry:
             },
         )
 
+    async def record_recursive_discovery_receipt(
+        self,
+        receipt_payload: dict[str, Any],
+        *,
+        run_id: str = "",
+        session_id: str = "",
+        task_id: str = "",
+        trace_id: str | None = None,
+        created_by: str = "evaluation.registry",
+        promotion_state: str = "candidate",
+    ) -> EvaluationRegistrationResult:
+        """Record a recursive discovery shadow receipt into canonical eval truth."""
+        from dharma_swarm.recursive_discovery import EVENT_STREAM, RecursiveReceipt
+
+        await self.runtime_state.init_db()
+        await self.memory_lattice.init_db()
+
+        resolved_run = await self._resolve_run(run_id)
+        resolved_session_id = session_id or (resolved_run.session_id if resolved_run else "")
+        resolved_task_id = task_id or (resolved_run.task_id if resolved_run else "")
+        if not resolved_session_id:
+            raise ValueError("session_id or run_id is required to record evaluation outputs canonically")
+
+        receipt = RecursiveReceipt.model_validate(receipt_payload)
+        raw_payload = receipt.model_dump(mode="json")
+        resolved_trace_id = trace_id or self._resolve_trace_id(raw_payload, resolved_run)
+        if not resolved_trace_id:
+            resolved_trace_id = receipt.parent_id or receipt.receipt_id
+
+        stored = await self.artifact_store.create_text_artifact_async(
+            session_id=resolved_session_id,
+            artifact_type="evaluations",
+            artifact_kind="recursive_discovery_receipt",
+            content=self._render_job_payload(raw_payload),
+            created_by=created_by,
+            extension="json",
+            task_id=resolved_task_id,
+            run_id=run_id,
+            trace_id=resolved_trace_id,
+            promotion_state=promotion_state,
+            provenance={
+                "source": "recursive_discovery_shadow",
+                "receipt_id": receipt.receipt_id,
+                "receipt_type": receipt.receipt_type,
+                "parent_id": receipt.parent_id or "",
+                "candidate_id": receipt.candidate_id or "",
+            },
+            metadata={
+                "source": "recursive_discovery_shadow",
+                "receipt_id": receipt.receipt_id,
+                "receipt_type": receipt.receipt_type,
+                "parent_id": receipt.parent_id or "",
+                "candidate_id": receipt.candidate_id or "",
+                "eval_ids": list(receipt.eval_ids),
+                "status": receipt.status,
+            },
+        )
+        artifact = stored.record
+
+        facts: list[MemoryFact] = []
+        facts.append(
+            await self.memory_lattice.record_fact(
+                (
+                    f"Recursive discovery receipt {receipt.receipt_id} "
+                    f"recorded {receipt.receipt_type}: {receipt.summary}"
+                ).strip(),
+                fact_kind="recursive_discovery_receipt",
+                truth_state="candidate",
+                confidence=1.0,
+                session_id=resolved_session_id,
+                task_id=resolved_task_id,
+                source_artifact_id=artifact.artifact_id,
+                metadata={
+                    "receipt_id": receipt.receipt_id,
+                    "receipt_type": receipt.receipt_type,
+                    "status": receipt.status,
+                },
+                provenance={
+                    "artifact_id": artifact.artifact_id,
+                    "source": "recursive_discovery_shadow",
+                },
+            )
+        )
+        if receipt.receipt_type in {"generated_eval", "candidate_diff", "experiment_result"}:
+            facts.append(
+                await self.memory_lattice.record_fact(
+                    (
+                        f"Recursive discovery {receipt.receipt_type} "
+                        f"binds evals {', '.join(receipt.eval_ids) or 'none'} "
+                        f"to candidate {receipt.candidate_id or 'none'}."
+                    ),
+                    fact_kind=f"recursive_{receipt.receipt_type}",
+                    truth_state="candidate",
+                    confidence=0.9,
+                    session_id=resolved_session_id,
+                    task_id=resolved_task_id,
+                    source_artifact_id=artifact.artifact_id,
+                    metadata={
+                        "receipt_id": receipt.receipt_id,
+                        "eval_ids": list(receipt.eval_ids),
+                        "candidate_id": receipt.candidate_id or "",
+                    },
+                    provenance={
+                        "artifact_id": artifact.artifact_id,
+                        "source": "recursive_discovery_shadow",
+                    },
+                )
+            )
+
+        self.provenance.append(
+            ProvenanceEntry(
+                event="recursive_discovery_receipt_recorded",
+                artifact_id=artifact.artifact_id,
+                agent=created_by,
+                session_id=resolved_session_id,
+                inputs=[receipt.parent_id or receipt.receipt_id],
+                outputs=[artifact.artifact_id, *[fact.fact_id for fact in facts]],
+                confidence=1.0,
+                metadata={
+                    "receipt_id": receipt.receipt_id,
+                    "receipt_type": receipt.receipt_type,
+                    "run_id": run_id,
+                    "task_id": resolved_task_id,
+                    "candidate_id": receipt.candidate_id or "",
+                },
+            )
+        )
+
+        event = self.event_log.append_envelope(
+            RuntimeEnvelope.create(
+                event_type=RuntimeEventType.ACTION_EVENT,
+                source="evaluation.registry",
+                agent_id=created_by,
+                session_id=resolved_session_id,
+                trace_id=resolved_trace_id,
+                payload={
+                    "action_name": "record_recursive_discovery_receipt",
+                    "decision": "recorded",
+                    "confidence": 1.0,
+                    "receipt_id": receipt.receipt_id,
+                    "receipt_type": receipt.receipt_type,
+                    "artifact_id": artifact.artifact_id,
+                    "candidate_id": receipt.candidate_id or "",
+                    "eval_ids": list(receipt.eval_ids),
+                    "status": receipt.status,
+                },
+            ),
+            stream=EVENT_STREAM,
+        )
+        return EvaluationRegistrationResult(
+            artifact=artifact,
+            manifest_path=stored.manifest_path,
+            facts=facts,
+            receipt=event,
+            summary={
+                "receipt_id": receipt.receipt_id,
+                "receipt_type": receipt.receipt_type,
+                "artifact_id": artifact.artifact_id,
+                "fact_ids": [fact.fact_id for fact in facts],
+                "receipt_event_id": str(event.get("event_id", "")),
+                "candidate_id": receipt.candidate_id or "",
+                "eval_ids": list(receipt.eval_ids),
+                "status": receipt.status,
+            },
+        )
+
     async def record_ouroboros_observation(
         self,
         observation_payload: dict[str, Any],

--- a/dharma_swarm/operator_core/control_surface.py
+++ b/dharma_swarm/operator_core/control_surface.py
@@ -269,6 +269,29 @@ def _manifest_state_writer_rows(manifest: dict[str, Any]) -> list[ControlSurface
     return rows
 
 
+def _manifest_recursive_discovery_rows(manifest: dict[str, Any]) -> list[ControlSurfaceRow]:
+    rows: list[ControlSurfaceRow] = []
+    for entry in manifest.get("recursive_discovery_surfaces", []):
+        rid = f"recursive.{entry['id']}"
+        row = ControlSurfaceRow(
+            id=rid,
+            kind="recursive_discovery",
+            label=entry.get("label", entry["id"]),
+            authority_role="incubating",
+            declared_state=entry.get("status", "unknown"),
+            desired_state="shadow",
+            priority=entry.get("priority", "p1"),
+            next_action=entry.get("next_action", "") or "",
+            owner_module=entry.get("owner_module", "dharma_swarm/recursive_discovery.py"),
+            truth_owner="ACTIVE_SURFACE_MANIFEST.yaml",
+            raw=entry,
+        )
+        row.source_refs.append(_manifest_source_ref())
+        row.source_ref_labels.append("ACTIVE_SURFACE_MANIFEST.yaml")
+        rows.append(row)
+    return rows
+
+
 # ---------------------------------------------------------------------------
 # B) API / router reality adapter
 # ---------------------------------------------------------------------------
@@ -517,7 +540,54 @@ def _observe_feedback_loop(row: ControlSurfaceRow, repo_root: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# G) Operating facts adapter
+# G) Recursive discovery shadow adapter
+# ---------------------------------------------------------------------------
+
+def _observe_recursive_discovery_shadow(row: ControlSurfaceRow, repo_root: Path) -> None:
+    try:
+        from dharma_swarm.recursive_discovery import (
+            receipt_counts_by_type,
+            shadow_fixture_receipts,
+        )
+    except Exception as exc:
+        row.observed_state = "adapter_error"
+        row.coherence_state = "drifted"
+        row.gap_codes.append("recursive_discovery_adapter_error")
+        row.add_evidence(
+            "process",
+            f"recursive discovery adapter failed: {exc}",
+            status="error",
+            provenance_chain=["recursive_discovery", "adapter_import"],
+        )
+        return
+
+    receipts = shadow_fixture_receipts()
+    counts = receipt_counts_by_type(receipts)
+    receipt_type = row.raw.get("receipt_type", "")
+    count = counts.get(receipt_type, 0)
+    row.add_source_ref("file", "dharma_swarm/recursive_discovery.py", exists=True)
+    row.add_evidence(
+        "recursive_receipt",
+        f"{receipt_type}: fixture_count={count}",
+        status="present" if count else "missing",
+        provenance_chain=["recursive_discovery", "shadow_fixture"],
+    )
+    row.freshness = _file_freshness(repo_root / "dharma_swarm" / "recursive_discovery.py")
+
+    if count:
+        row.observed_state = f"shadow_fixture:{count}"
+        row.coherence_state = "partial"
+        row.gap_codes.append("shadow_only")
+        if receipt_type in {"candidate_diff", "promotion_decision"}:
+            row.gap_codes.append("human_promotion_required")
+    else:
+        row.observed_state = "missing_fixture"
+        row.coherence_state = "declared_only"
+        row.gap_codes.append("fixture_missing")
+
+
+# ---------------------------------------------------------------------------
+# H) Operating facts adapter
 # ---------------------------------------------------------------------------
 
 def _operating_facts_rows() -> list[ControlSurfaceRow]:
@@ -562,7 +632,7 @@ def _operating_facts_rows() -> list[ControlSurfaceRow]:
 
 
 # ---------------------------------------------------------------------------
-# H) Module truth adapter
+# I) Module truth adapter
 # ---------------------------------------------------------------------------
 
 def _module_truth_rows() -> list[ControlSurfaceRow]:
@@ -600,7 +670,7 @@ def _module_truth_rows() -> list[ControlSurfaceRow]:
 
 
 # ---------------------------------------------------------------------------
-# I) Broken Register adapter
+# J) Broken Register adapter
 # ---------------------------------------------------------------------------
 
 _BR_PATTERN = re.compile(
@@ -696,7 +766,7 @@ def _broken_register_rows(repo_root: Path | None = None) -> list[ControlSurfaceR
 
 
 # ---------------------------------------------------------------------------
-# J) Runtime state adapter
+# K) Runtime state adapter
 # ---------------------------------------------------------------------------
 
 def _runtime_state_row(repo_root: Path | None = None) -> ControlSurfaceRow | None:
@@ -801,6 +871,7 @@ def build_control_surface_rows(
     loop_rows = _manifest_loop_rows(manifest)
     cron_rows = _manifest_cron_rows(manifest)
     state_rows = _manifest_state_writer_rows(manifest)
+    recursive_rows = _manifest_recursive_discovery_rows(manifest)
 
     # B) Observe API router reality
     for row in api_rows:
@@ -838,16 +909,21 @@ def build_control_surface_rows(
         row.coherence_state = "declared_only"
     rows.extend(state_rows)
 
-    # G) Operating facts (organ-level observed reality)
+    # G) Recursive discovery shadow receipts (fixture-backed only)
+    for row in recursive_rows:
+        _observe_recursive_discovery_shadow(row, root)
+    rows.extend(recursive_rows)
+
+    # H) Operating facts (organ-level observed reality)
     rows.extend(_operating_facts_rows())
 
-    # H) Module truth (observed evidence for major modules)
+    # I) Module truth (observed evidence for major modules)
     rows.extend(_module_truth_rows())
 
-    # I) Broken register (known structural gaps)
+    # J) Broken register (known structural gaps)
     rows.extend(_broken_register_rows(root))
 
-    # J) Runtime state DB (observed)
+    # K) Runtime state DB (observed)
     rt_row = _runtime_state_row(root)
     if rt_row is not None:
         rows.append(rt_row)
@@ -892,6 +968,7 @@ def build_control_surface_summary(
         "BROKEN_REGISTER.md",
         "runtime_state",
         "go_sdk",
+        "recursive_discovery_shadow",
         "code/filesystem",
     ]
 

--- a/dharma_swarm/operator_core/control_surface_models.py
+++ b/dharma_swarm/operator_core/control_surface_models.py
@@ -23,7 +23,7 @@ class EvidenceItem(BaseModel):
 
     kind: Literal[
         "file", "manifest_row", "api_route", "db_probe",
-        "go_receipt", "broken_register", "process", "test",
+        "go_receipt", "recursive_receipt", "broken_register", "process", "test",
     ]
     source: str
     line_range: tuple[int, int] | None = None
@@ -102,6 +102,7 @@ ROW_KINDS = (
     "memory_surface",
     "broken_register",
     "go_receipt",
+    "recursive_discovery",
     "doc_surface",
     "integration",
     "feedback_loop",
@@ -215,6 +216,8 @@ def _needs_human_decision(row: ControlSurfaceRow) -> bool:
         return True
     if "go_world_receipt_rejections" in row.gap_codes:
         return True
+    if row.kind == "recursive_discovery" and "human_promotion_required" in row.gap_codes:
+        return True
     label_lower = row.label.lower()
     for kw in _HUMAN_DECISION_KEYWORDS:
         if kw in label_lower or kw in row.owner_module.lower():
@@ -249,6 +252,9 @@ def _build_human_decision_context(row: ControlSurfaceRow) -> HumanDecisionContex
     elif row.kind == "broken_register" and "OPEN" in row.declared_state.upper():
         why_now = f"Open broken register entry: {row.label}"
         recommended_action = f"Fix root cause and close {row.id.replace('br.', 'BR-').replace('_', '-')}"
+    elif row.kind == "recursive_discovery" and "human_promotion_required" in row.gap_codes:
+        why_now = "Recursive discovery shadow has a candidate/promotion receipt"
+        recommended_action = "Review the receipt and promote only through a human PR"
     else:
         for kw in _HUMAN_DECISION_KEYWORDS:
             if kw in row.label.lower() or kw in row.owner_module.lower():

--- a/dharma_swarm/recursive_discovery.py
+++ b/dharma_swarm/recursive_discovery.py
@@ -1,0 +1,329 @@
+"""Shadow-mode receipts for recursive discovery loops.
+
+This module defines a bounded receipt layer for recursive self-improvement:
+limitations, generated evals, candidate diffs, experiment results, witness
+verdicts, and promotion decisions.  It is intentionally shadow-only: it records
+evidence and recommendations, but it does not apply diffs or mutate runtime
+code.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field, field_validator
+
+from dharma_swarm.event_log import EventLog
+from dharma_swarm.models import _new_id, _utc_now
+from dharma_swarm.runtime_contract import RuntimeEnvelope, RuntimeEventType
+
+
+ReceiptType = Literal[
+    "limitation",
+    "generated_eval",
+    "candidate_diff",
+    "experiment_result",
+    "witness_verdict",
+    "promotion_decision",
+]
+WitnessPhase = Literal[
+    "before_generate",
+    "before_apply",
+    "before_eval",
+    "before_archive",
+    "before_promote",
+]
+ReceiptStatus = Literal["pending", "passed", "warned", "blocked", "recorded"]
+PromotionDecision = Literal["promote_to_pr", "revise", "reject", "hold"]
+
+SCHEMA_VERSION = "recursive_discovery.v0"
+EVENT_STREAM = "recursive_discovery"
+RECEIPT_TYPES: tuple[str, ...] = (
+    "limitation",
+    "generated_eval",
+    "candidate_diff",
+    "experiment_result",
+    "witness_verdict",
+    "promotion_decision",
+)
+
+
+def stable_payload_hash(payload: dict[str, Any]) -> str:
+    """Return a stable SHA-256 hash for a JSON-serializable payload."""
+    material = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(material.encode("utf-8")).hexdigest()
+
+
+class CommandReceipt(BaseModel):
+    """One command executed in a sandbox or dry-run context."""
+
+    command: str
+    exit_code: int
+    wall_time_seconds: float | None = None
+
+
+class WitnessVerdict(BaseModel):
+    """Witness outcome for one recursive-discovery phase."""
+
+    phase: WitnessPhase
+    verdict: ReceiptStatus
+    witness_id: str
+    reason: str
+
+
+class RecursiveReceipt(BaseModel):
+    """Minimal receipt schema shared by all recursive discovery artifacts."""
+
+    schema_version: Literal["recursive_discovery.v0"] = SCHEMA_VERSION
+    receipt_id: str = Field(default_factory=_new_id)
+    receipt_type: ReceiptType
+    created_at: str = Field(default_factory=lambda: _utc_now().isoformat())
+    parent_id: str | None = None
+    limitation_id: str | None = None
+    candidate_id: str | None = None
+    model_id: str = ""
+    prompt_hash: str = ""
+    eval_ids: list[str] = Field(default_factory=list)
+    files_touched: list[str] = Field(default_factory=list)
+    commands: list[CommandReceipt] = Field(default_factory=list)
+    cost_usd: float | None = None
+    wall_time_seconds: float | None = None
+    sandbox_path: str = ""
+    witness_verdicts: list[WitnessVerdict] = Field(default_factory=list)
+    rollback_pointer: str = ""
+    status: ReceiptStatus = "recorded"
+    summary: str = ""
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("files_touched")
+    @classmethod
+    def reject_absolute_or_parent_paths(cls, paths: list[str]) -> list[str]:
+        for path in paths:
+            p = Path(path)
+            if p.is_absolute() or ".." in p.parts:
+                raise ValueError(f"unsafe repo path in receipt: {path}")
+        return paths
+
+    def content_hash(self) -> str:
+        payload = self.model_dump(mode="json", exclude={"created_at", "receipt_id"})
+        return stable_payload_hash(payload)
+
+
+class LimitationReceipt(RecursiveReceipt):
+    receipt_type: Literal["limitation"] = "limitation"
+    limitation_id: str
+
+
+class GeneratedEvalReceipt(RecursiveReceipt):
+    receipt_type: Literal["generated_eval"] = "generated_eval"
+    limitation_id: str
+    eval_ids: list[str]
+
+    @field_validator("eval_ids")
+    @classmethod
+    def require_eval_ids(cls, values: list[str]) -> list[str]:
+        if not values:
+            raise ValueError("generated eval receipt requires at least one eval id")
+        return values
+
+
+class CandidateDiffReceipt(RecursiveReceipt):
+    receipt_type: Literal["candidate_diff"] = "candidate_diff"
+    limitation_id: str
+    candidate_id: str
+
+
+class ExperimentResultReceipt(RecursiveReceipt):
+    receipt_type: Literal["experiment_result"] = "experiment_result"
+    candidate_id: str
+    eval_ids: list[str]
+
+
+class WitnessVerdictReceipt(RecursiveReceipt):
+    receipt_type: Literal["witness_verdict"] = "witness_verdict"
+    witness_verdicts: list[WitnessVerdict]
+
+    @field_validator("witness_verdicts")
+    @classmethod
+    def require_witness_verdicts(cls, values: list[WitnessVerdict]) -> list[WitnessVerdict]:
+        if not values:
+            raise ValueError("witness verdict receipt requires at least one verdict")
+        return values
+
+
+class PromotionDecisionReceipt(RecursiveReceipt):
+    receipt_type: Literal["promotion_decision"] = "promotion_decision"
+    decision: PromotionDecision = "hold"
+
+
+@dataclass(frozen=True)
+class RecursiveDiscoveryRecordResult:
+    """Stored event-log result for one recursive discovery receipt."""
+
+    receipt: RecursiveReceipt
+    event: dict[str, Any]
+    stream: str = EVENT_STREAM
+
+
+class RecursiveDiscoveryRecorder:
+    """Append recursive-discovery receipts to the existing runtime EventLog."""
+
+    def __init__(self, event_log: EventLog | None = None) -> None:
+        self.event_log = event_log or EventLog()
+
+    def record(
+        self,
+        receipt: RecursiveReceipt,
+        *,
+        session_id: str,
+        agent_id: str = "recursive_discovery_shadow",
+        trace_id: str | None = None,
+    ) -> RecursiveDiscoveryRecordResult:
+        event = self.event_log.append_envelope(
+            RuntimeEnvelope.create(
+                event_type=RuntimeEventType.ACTION_EVENT,
+                source="recursive.discovery.shadow",
+                agent_id=agent_id,
+                session_id=session_id,
+                trace_id=trace_id or receipt.parent_id or receipt.receipt_id,
+                payload={
+                    "action_name": f"recursive_discovery.{receipt.receipt_type}",
+                    "decision": receipt.status,
+                    "confidence": 1.0,
+                    "receipt_id": receipt.receipt_id,
+                    "receipt_type": receipt.receipt_type,
+                    "receipt_hash": receipt.content_hash(),
+                    "parent_id": receipt.parent_id,
+                    "candidate_id": receipt.candidate_id,
+                    "eval_ids": receipt.eval_ids,
+                    "files_touched": receipt.files_touched,
+                    "rollback_pointer": receipt.rollback_pointer,
+                    "receipt": receipt.model_dump(mode="json"),
+                },
+            ),
+            stream=EVENT_STREAM,
+        )
+        return RecursiveDiscoveryRecordResult(receipt=receipt, event=event)
+
+
+def shadow_fixture_receipts() -> list[RecursiveReceipt]:
+    """Return deterministic fixture receipts for the shadow control surface."""
+    parent_id = "recursive-shadow-demo-001"
+    limitation_id = "lim-docops-authority-drift"
+    candidate_id = "cand-docops-authority-drift-001"
+    eval_id = "eval-docops-authority-registration"
+    prompt_hash = stable_payload_hash(
+        {
+            "prompt": "Find one declared-vs-actual documentation authority gap.",
+            "scope": "docops",
+        }
+    )
+    sandbox = "/tmp/dharma-recursive-shadow-demo"
+    files = [
+        "docs/governance/CANONICAL_DOC_STACK.md",
+        "docs/docops/assertions.yaml",
+    ]
+    return [
+        LimitationReceipt(
+            parent_id=parent_id,
+            limitation_id=limitation_id,
+            model_id="fixture",
+            prompt_hash=prompt_hash,
+            summary="Authority-bearing docs can be changed without a paired canonical registration.",
+            files_touched=files,
+            sandbox_path=sandbox,
+            status="recorded",
+        ),
+        GeneratedEvalReceipt(
+            parent_id=parent_id,
+            limitation_id=limitation_id,
+            model_id="fixture",
+            prompt_hash=prompt_hash,
+            eval_ids=[eval_id],
+            commands=[
+                CommandReceipt(
+                    command="python3 scripts/docops/check_docops_integrity.py --changed-from origin/main",
+                    exit_code=0,
+                    wall_time_seconds=0.4,
+                )
+            ],
+            files_touched=["scripts/docops/check_docops_integrity.py"],
+            sandbox_path=sandbox,
+            summary="Generated eval checks unregistered authority claims against DocOps.",
+            status="passed",
+        ),
+        CandidateDiffReceipt(
+            parent_id=parent_id,
+            limitation_id=limitation_id,
+            candidate_id=candidate_id,
+            model_id="fixture",
+            prompt_hash=prompt_hash,
+            eval_ids=[eval_id],
+            files_touched=files,
+            sandbox_path=sandbox,
+            rollback_pointer="git restore --source=HEAD -- docs/governance/CANONICAL_DOC_STACK.md docs/docops/assertions.yaml",
+            summary="Candidate diff registers authority docs and leaves apply to human promotion.",
+            status="recorded",
+        ),
+        ExperimentResultReceipt(
+            parent_id=parent_id,
+            candidate_id=candidate_id,
+            model_id="fixture",
+            prompt_hash=prompt_hash,
+            eval_ids=[eval_id],
+            files_touched=files,
+            sandbox_path=sandbox,
+            commands=[
+                CommandReceipt(
+                    command="pytest -q tests/test_control_surface.py",
+                    exit_code=0,
+                    wall_time_seconds=2.7,
+                ),
+            ],
+            summary="Shadow experiment passed fixture control-surface checks.",
+            status="passed",
+        ),
+        WitnessVerdictReceipt(
+            parent_id=parent_id,
+            candidate_id=candidate_id,
+            model_id="fixture",
+            prompt_hash=prompt_hash,
+            eval_ids=[eval_id],
+            files_touched=files,
+            sandbox_path=sandbox,
+            witness_verdicts=[
+                WitnessVerdict(
+                    phase="before_promote",
+                    verdict="warned",
+                    witness_id="fixture-witness",
+                    reason="Human promotion required; shadow receipt must not apply its own diff.",
+                )
+            ],
+            summary="Witness allows archive, warns against autonomous promotion.",
+            status="warned",
+        ),
+        PromotionDecisionReceipt(
+            parent_id=parent_id,
+            candidate_id=candidate_id,
+            model_id="fixture",
+            prompt_hash=prompt_hash,
+            eval_ids=[eval_id],
+            files_touched=files,
+            sandbox_path=sandbox,
+            rollback_pointer="human-reviewed PR only",
+            summary="Promotion queue holds candidate for human PR review.",
+            status="pending",
+            decision="hold",
+        ),
+    ]
+
+
+def receipt_counts_by_type(receipts: list[RecursiveReceipt]) -> dict[str, int]:
+    counts = {rtype: 0 for rtype in RECEIPT_TYPES}
+    for receipt in receipts:
+        counts[receipt.receipt_type] = counts.get(receipt.receipt_type, 0) + 1
+    return counts

--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -6,11 +6,11 @@ Do not hand-edit the generated block.
 <!-- DOCOPS:START metric=repo_inventory -->
 | Metric | Value |
 |---|---:|
-| Dharma Python modules | 594 |
-| Top-level Dharma Python modules | 386 |
-| Dharma Python LOC | 257,112 |
-| Test files | 576 |
-| Test function occurrences | 10,209 |
+| Dharma Python modules | 595 |
+| Top-level Dharma Python modules | 387 |
+| Dharma Python LOC | 257,690 |
+| Test files | 577 |
+| Test function occurrences | 10,214 |
 | Markdown files | 691 |
 | Markdown total lines | 176,029 |
 | Bridge files | 22 |

--- a/docs/governance/SOVEREIGN_MANIFEST.md
+++ b/docs/governance/SOVEREIGN_MANIFEST.md
@@ -17,7 +17,7 @@
 These are immutable engineering laws for this repository. Violation = architectural regression.
 
 ### A1: NO FLAT-PACKAGE GROWTH
-The `dharma_swarm/` package currently has **386 files at its top level (65.0% of 594 total Python modules)** (V). No new .py file may be added to the top level. New modules must go into an appropriate subdirectory. Existing top-level files will be organized over time.
+The `dharma_swarm/` package currently has **387 files at its top level (65.0% of 595 total Python modules)** (V). No new .py file may be added to the top level. New modules must go into an appropriate subdirectory. Existing top-level files will be organized over time.
 
 ### A2: NO DUPLICATE IMPLEMENTATIONS
 Before creating a new file for routing, bridging, adapting, or orchestrating, check if one already exists. The repo currently has **22 bridge files** (V), **3 model_routing copies** (2 are identical, 1 is different) (V), **4 orchestrators** (V), **14 adapter files across 7 locations** (V), and **13 router files** (V). Do not add more without deprecating an existing one.
@@ -62,11 +62,11 @@ These are the ground-truth metrics. All other documents citing different numbers
 
 | Metric | Value | Verification |
 |--------|-------|-------------|
-| Total Python modules | **594** | find dharma_swarm -name "*.py" -type f |
-| Top-level (flat) modules | **386 (65.0%)** | find dharma_swarm -maxdepth 1 -name "*.py" -type f |
-| Total Python LOC | **257,112** | wc -l across dharma_swarm Python modules |
-| Test files | **576** | find tests -name "*.py" -type f |
-| Test functions | **10,209 `def test_` occurrences under tests/** | rg "def test_" tests |
+| Total Python modules | **595** | find dharma_swarm -name "*.py" -type f |
+| Top-level (flat) modules | **387 (65.0%)** | find dharma_swarm -maxdepth 1 -name "*.py" -type f |
+| Total Python LOC | **257,690** | wc -l across dharma_swarm Python modules |
+| Test files | **577** | find tests -name "*.py" -type f |
+| Test functions | **10,214 `def test_` occurrences under tests/** | rg "def test_" tests |
 | Tests collected (pytest) | **Needs write-permitted refresh** | not run during this DocOps count pass |
 | Collection errors | **Historical: 16 on 2026-04-04** | refresh before relying on this count |
 | Markdown files | **691** | find . -name "*.md" -type f |

--- a/tests/test_recursive_discovery.py
+++ b/tests/test_recursive_discovery.py
@@ -1,0 +1,156 @@
+"""Tests for recursive discovery shadow receipts and projection."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from dharma_swarm.evaluation_registry import EvaluationRegistry
+from dharma_swarm.event_log import EventLog
+from dharma_swarm.memory_lattice import MemoryLattice
+from dharma_swarm.operator_core.control_surface import build_control_surface_rows
+from dharma_swarm.recursive_discovery import (
+    CandidateDiffReceipt,
+    EVENT_STREAM,
+    RECEIPT_TYPES,
+    RecursiveDiscoveryRecorder,
+    receipt_counts_by_type,
+    shadow_fixture_receipts,
+)
+from dharma_swarm.runtime_state import RuntimeStateStore, SessionState
+
+
+def test_shadow_fixture_receipts_cover_minimum_loop() -> None:
+    receipts = shadow_fixture_receipts()
+    counts = receipt_counts_by_type(receipts)
+
+    assert len(receipts) == len(RECEIPT_TYPES)
+    assert all(counts[receipt_type] == 1 for receipt_type in RECEIPT_TYPES)
+    assert all(receipt.schema_version == "recursive_discovery.v0" for receipt in receipts)
+    assert all(len(receipt.content_hash()) == 64 for receipt in receipts)
+
+
+def test_candidate_diff_receipt_rejects_unsafe_paths() -> None:
+    with pytest.raises(ValueError, match="unsafe repo path"):
+        CandidateDiffReceipt(
+            limitation_id="lim-1",
+            candidate_id="cand-1",
+            files_touched=["/tmp/not-repo-relative.py"],
+        )
+
+
+def test_recorder_writes_valid_runtime_event(tmp_path: Path) -> None:
+    event_log = EventLog(tmp_path / "events")
+    receipt = shadow_fixture_receipts()[1]
+
+    result = RecursiveDiscoveryRecorder(event_log).record(
+        receipt,
+        session_id="session-recursive-shadow",
+        agent_id="test-agent",
+    )
+
+    assert result.stream == EVENT_STREAM
+    assert result.event["payload"]["receipt_type"] == "generated_eval"
+    assert result.event["payload"]["receipt_hash"] == receipt.content_hash()
+    ok, errors = event_log.verify_stream(stream=EVENT_STREAM)
+    assert ok, errors
+
+
+def test_control_surface_projects_recursive_discovery_shadow_rows(tmp_path: Path) -> None:
+    manifest = {
+        "schema_version": 2,
+        "last_updated": "2026-05-14",
+        "api_routers": [],
+        "dashboard_surfaces": [],
+        "agents": [],
+        "integrations": [],
+        "loops": [],
+        "recursive_discovery_surfaces": [
+            {
+                "id": "limitations",
+                "label": "Recursive Limitations",
+                "receipt_type": "limitation",
+                "status": "shadow",
+                "owner_module": "dharma_swarm/recursive_discovery.py",
+                "priority": "p0",
+            },
+            {
+                "id": "promotion_queue",
+                "label": "Recursive Promotion Queue",
+                "receipt_type": "promotion_decision",
+                "status": "shadow",
+                "owner_module": "dharma_swarm/recursive_discovery.py",
+                "priority": "p0",
+            },
+        ],
+    }
+    (tmp_path / "ACTIVE_SURFACE_MANIFEST.yaml").write_text(
+        yaml.dump(manifest, default_flow_style=False),
+        encoding="utf-8",
+    )
+
+    rows = build_control_surface_rows(repo_root=tmp_path)
+    recursive_rows = [row for row in rows if row.kind == "recursive_discovery"]
+
+    assert {row.id for row in recursive_rows} == {
+        "recursive.limitations",
+        "recursive.promotion_queue",
+    }
+    assert all(row.coherence_state == "partial" for row in recursive_rows)
+    assert all("shadow_only" in row.gap_codes for row in recursive_rows)
+
+    promotion = [row for row in recursive_rows if row.id == "recursive.promotion_queue"][0]
+    assert promotion.human_decision_required is True
+    assert promotion.human_decision is not None
+    assert "human PR" in promotion.human_decision.recommended_action
+
+
+@pytest.mark.asyncio
+async def test_evaluation_registry_records_recursive_discovery_receipt(tmp_path: Path) -> None:
+    db_path = tmp_path / "runtime.db"
+    runtime_state = RuntimeStateStore(db_path)
+    memory_lattice = MemoryLattice(db_path=db_path, event_log_dir=tmp_path / "events")
+    await runtime_state.init_db()
+    await memory_lattice.init_db()
+    await runtime_state.upsert_session(
+        SessionState(
+            session_id="sess-recursive",
+            operator_id="operator",
+            status="active",
+            current_task_id="task-recursive",
+        )
+    )
+
+    registry = EvaluationRegistry(
+        runtime_state=runtime_state,
+        memory_lattice=memory_lattice,
+        workspace_root=tmp_path / "workspace" / "sessions",
+        provenance_root=tmp_path / "workspace" / "sessions",
+    )
+    receipt = shadow_fixture_receipts()[1]
+    result = await registry.record_recursive_discovery_receipt(
+        receipt.model_dump(mode="json"),
+        session_id="sess-recursive",
+        task_id="task-recursive",
+        created_by="test-agent",
+    )
+
+    persisted_artifact = await runtime_state.get_artifact(result.artifact.artifact_id)
+    stream_rows = memory_lattice.event_log.read_envelopes(
+        stream=EVENT_STREAM,
+        session_id="sess-recursive",
+    )
+
+    assert persisted_artifact is not None
+    assert persisted_artifact.artifact_kind == "recursive_discovery_receipt"
+    assert {fact.fact_kind for fact in result.facts} == {
+        "recursive_discovery_receipt",
+        "recursive_generated_eval",
+    }
+    assert result.summary["receipt_type"] == "generated_eval"
+    assert result.summary["eval_ids"] == receipt.eval_ids
+    assert stream_rows[-1]["payload"]["action_name"] == "record_recursive_discovery_receipt"
+
+    await memory_lattice.close()


### PR DESCRIPTION
Organ touched: Recursive Discovery Shadow / Control Surface / Eval Registry.

Declared-vs-actual gap closed: The Recursive/DGM-inspired improvement loop now has a typed shadow receipt contract, manifest-declared control-surface rows, fixture-backed projection, and canonical EventLog/EvaluationRegistry recording without autonomous apply.

Proof that re-reads the map:
- pytest -q tests/test_recursive_discovery.py tests/test_control_surface.py tests/test_research_eval_registry.py
- 67 passed, 1 warning
- python -m compileall dharma_swarm/recursive_discovery.py dharma_swarm/evaluation_registry.py dharma_swarm/operator_core/control_surface.py dharma_swarm/operator_core/control_surface_models.py
- python3 scripts/docops/check_docops_integrity.py --changed-from origin/main --report-json /tmp/recursive-discovery-docops.json
- pre-commit during git commit passed: test hygiene, contract tests, uplift guards, docops, gitleaks, semgrep, yaml/toml checks

New drift introduced: No autonomous apply path. Recursive discovery remains shadow-only; candidate and promotion rows require human PR review.