### PR TITLE
feat(governance): CWT v0 read-only collector + report renderer [impact-checked]

### DIFF
--- a/docs/architecture/NAVIGATION.md
+++ b/docs/architecture/NAVIGATION.md
@@ -109,6 +109,8 @@ Generated: 2026-03-29 | 500 Python modules | 494 test files | 8,848 tests
 | Check kernel integrity | `dgc dharma status` |
 | See evolution trend | `dgc evolve trend` |
 | See subconscious dreams | `dgc hum` |
+| Run the CWT read-only collector v0 | `python3 scripts/runtime/cwt_collect.py` (stdout) or `--out-dir <path>` |
+| Render a CWT v0 report | `python3 scripts/runtime/cwt_report.py` → writes to `reports/control_watch_tower/<ts>/` (doctrine: [`docs/agents/CONTROL_WATCH_TOWER.md`](../agents/CONTROL_WATCH_TOWER.md); schemas: [`schemas/control_watch_tower_*.v0.json`](../../schemas/)) |
 | Find a module | Search this file or `ls dharma_swarm/dharma_swarm/*.py` |
 | Find the data model | `dharma_swarm/models.py` |
 | Find the config | `dharma_swarm/config.py` (env var overrides) |

--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -8,11 +8,11 @@ Do not hand-edit the generated block.
 |---|---:|
 | Dharma Python modules | 650 |
 | Top-level Dharma Python modules | 388 |
-| Dharma Python LOC | 275,557 |
+| Dharma Python LOC | 275,641 |
 | Test files | 602 |
-| Test function occurrences | 10,454 |
+| Test function occurrences | 10,458 |
 | Markdown files | 725 |
-| Markdown total lines | 184,234 |
+| Markdown total lines | 184,236 |
 | Bridge files | 24 |
 | Adapter files | 18 |
 | Orchestrator files | 4 |

--- a/docs/governance/SOVEREIGN_MANIFEST.md
+++ b/docs/governance/SOVEREIGN_MANIFEST.md
@@ -114,11 +114,11 @@ These are the ground-truth metrics. All other documents citing different numbers
 | Top-level (flat) modules | **388 (59.7%)** | find dharma_swarm -maxdepth 1 -name "*.py" -type f |
 | Total Python LOC | **275,557** | wc -l across dharma_swarm Python modules |
 | Test files | **602** | find tests -name "*.py" -type f |
-| Test functions | **10,454 `def test_` occurrences under tests/** | rg "def test_" tests |
+| Test functions | **10,458 `def test_` occurrences under tests/** | rg "def test_" tests |
 | Tests collected (pytest) | **Needs write-permitted refresh** | not run during this DocOps count pass |
 | Collection errors | **Historical: 16 on 2026-04-04** | refresh before relying on this count |
 | Markdown files | **725** | find . -name "*.md" -type f |
-| Markdown total lines | **184,234** | wc -l across all .md |
+| Markdown total lines | **184,236** | wc -l across all .md |
 | Bridge files | **24** | find dharma_swarm -name "*bridge*.py" |
 | Adapter files | **18 across 8 locations** | find dharma_swarm -type f \| rg -i "adapter" |
 | Orchestrator files | **4** (6,034 LOC total) | find dharma_swarm -name "*orchestrat*" |

--- a/scripts/runtime/cwt_collect.py
+++ b/scripts/runtime/cwt_collect.py
@@ -1,0 +1,504 @@
+#!/usr/bin/env python3
+"""CONTROL_WATCH_TOWER v0 collector — read-only census of registered agents to scorecards.
+
+Read-only against live runtime state. Writes only the scorecard JSON files under
+the chosen output directory. Each scorecard conforms to:
+    schemas/control_watch_tower_agent_scorecard.v0.json
+
+Scope per operator-issued work packet (2026-05-21):
+    registered agents -> evidence paths -> scorecard skeleton -> report JSON
+
+What this collector intentionally does NOT do:
+    - mutate any agent file, runtime.db, kaizen/ops.db, stigmergy marks
+    - emit kaizen/stigmergy events
+    - read or print secrets
+    - score performance beyond structural evidence (presence of files, line counts)
+    - render the report (use cwt_report.py for that)
+    - propose promotion (all scorecards return recommendation=hold in v0)
+
+Discovers agents from two surfaces:
+    ~/.dharma/external_agents/{uid}/  (external workers like Hermes, Claude Code CLI)
+    ~/.dharma/agents/{uid}/           (canonical living agents like opus_composer)
+
+Outputs:
+    {out-dir}/scorecard_{agent_uid}.json   (one per agent, schema-conformant)
+    {out-dir}/scorecards_index.json        (collector summary + scorecard list)
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sqlite3
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+HOME = Path.home()
+DEFAULT_STATE_ROOT = HOME / ".dharma"
+
+SCORECARD_SCHEMA_VERSION = "control_watch_tower_agent_scorecard.v0"
+
+DIMENSION_NAMES = [
+    "identity_continuity",
+    "wake_persistence",
+    "work_capacity",
+    "comms_reliability",
+    "memory_evolution",
+    "operational_value",
+    "safety_discipline",
+    "cost_discipline",
+    "collaboration",
+    "promotion_readiness",
+]
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _count_lines(p: Path) -> int:
+    if not p.exists() or not p.is_file():
+        return 0
+    try:
+        with open(p) as f:
+            return sum(1 for _ in f)
+    except Exception:
+        return 0
+
+
+def _file_last_mtime_iso(p: Path) -> str | None:
+    if not p.exists() or not p.is_file():
+        return None
+    return datetime.fromtimestamp(p.stat().st_mtime, tz=timezone.utc).isoformat()
+
+
+def _read_json_safe(p: Path) -> dict[str, Any] | None:
+    if not p.exists():
+        return None
+    try:
+        return json.loads(p.read_text())
+    except Exception:
+        return None
+
+
+@dataclass
+class AgentInventory:
+    """All evidence-path locations for one agent, regardless of surface."""
+
+    uid: str
+    callsign: str
+    surface: str  # "external" or "canonical"
+    sandbox_root: Path
+    registration: Path
+    living_agent: Path
+    a2a_card: Path
+    action_log: Path
+    wake_receipts: Path
+    self_model: Path
+    agentops_contract: Path
+    watch_contract: Path
+    authority_passport: Path
+    soul_md: Path | None
+    raw_authority: str
+
+
+def _build_callsign_from_registration(reg_path: Path, default: str) -> str:
+    r = _read_json_safe(reg_path) or {}
+    # registration.json has fields at top level; some receipt variants nest under "worker"
+    return r.get("callsign") or (r.get("worker") or {}).get("callsign") or default
+
+
+def _authority_from_registration(reg_path: Path) -> str:
+    r = _read_json_safe(reg_path) or {}
+    return r.get("authority") or (r.get("worker") or {}).get("authority") or "unknown"
+
+
+def discover_agents(state_root: Path) -> list[AgentInventory]:
+    out: list[AgentInventory] = []
+    seen: set[str] = set()
+
+    # 1. External agents (have a dedicated sandbox)
+    ext_root = state_root / "external_agents"
+    if ext_root.exists():
+        for d in sorted(ext_root.iterdir()):
+            if not d.is_dir():
+                continue
+            uid = d.name
+            reg = d / "registration.json"
+            callsign = _build_callsign_from_registration(reg, uid)
+            authority = _authority_from_registration(reg)
+            out.append(
+                AgentInventory(
+                    uid=uid,
+                    callsign=callsign,
+                    surface="external",
+                    sandbox_root=d,
+                    registration=reg,
+                    living_agent=state_root / "agents" / uid / "living_agent.json",
+                    a2a_card=state_root / "a2a" / "cards" / f"{callsign}.json",
+                    action_log=d / "logs" / "action_log.jsonl",
+                    wake_receipts=d / "logs" / "wake_receipts.jsonl",
+                    self_model=d / "self_model" / "system_interpretation.md",
+                    agentops_contract=d / "agentops" / "contract.json",
+                    watch_contract=d / "watch" / "contract.json",
+                    authority_passport=d / "authority" / "passport.json",
+                    soul_md=None,
+                    raw_authority=authority,
+                )
+            )
+            seen.add(uid)
+
+    # 2. Canonical living agents that have no external sandbox (e.g. opus_composer, codex_composer)
+    agents_root = state_root / "agents"
+    if agents_root.exists():
+        for d in sorted(agents_root.iterdir()):
+            if not d.is_dir():
+                continue
+            uid = d.name
+            if uid in seen:
+                continue
+            identity = d / "identity.json"
+            iden = _read_json_safe(identity) or {}
+            callsign = iden.get("callsign") or uid
+            authority = iden.get("authority") or iden.get("authority_mode") or "unknown"
+            out.append(
+                AgentInventory(
+                    uid=uid,
+                    callsign=callsign,
+                    surface="canonical",
+                    sandbox_root=d,
+                    registration=identity,
+                    living_agent=d / "living_agent.json",
+                    a2a_card=state_root / "a2a" / "cards" / f"{callsign}.json",
+                    action_log=d / "task_log.jsonl",
+                    wake_receipts=Path("/dev/null"),
+                    self_model=d / "SOUL.md",
+                    agentops_contract=Path("/dev/null"),
+                    watch_contract=Path("/dev/null"),
+                    authority_passport=state_root / "agent_passports" / f"{uid}.json",
+                    soul_md=d / "SOUL.md",
+                    raw_authority=authority,
+                )
+            )
+
+    return out
+
+
+def _dim(
+    score: float,
+    status: str,
+    summary: str,
+    evidence: list[str],
+    last_observed: str | None = None,
+) -> dict[str, Any]:
+    d: dict[str, Any] = {
+        "score": max(0.0, min(1.0, float(score))),
+        "status": status,
+        "summary": summary,
+        "evidence_refs": evidence,
+    }
+    if last_observed is not None:
+        d["last_observed_at"] = last_observed
+    return d
+
+
+def _kaizen_event_count(state_root: Path, uid: str) -> int:
+    db = state_root / "kaizen" / "ops.db"
+    if not db.exists():
+        return 0
+    try:
+        con = sqlite3.connect(db)
+        cur = con.cursor()
+        cur.execute("SELECT COUNT(*) FROM events WHERE source = ?", (uid,))
+        n = cur.fetchone()[0]
+        con.close()
+        return int(n)
+    except Exception:
+        return 0
+
+
+def _stigmergy_marks_for(state_root: Path, uid: str) -> int:
+    marks_path = state_root / "stigmergy" / "marks.jsonl"
+    if not marks_path.exists():
+        return 0
+    n = 0
+    try:
+        with open(marks_path) as f:
+            for line in f:
+                if uid in line:
+                    n += 1
+    except Exception:
+        return 0
+    return n
+
+
+def _telemetry_present(state_root: Path, uid: str) -> bool:
+    db = state_root / "state" / "runtime.db"
+    if not db.exists():
+        return False
+    try:
+        con = sqlite3.connect(db)
+        cur = con.cursor()
+        cur.execute("SELECT COUNT(*) FROM agent_identity WHERE agent_id = ?", (uid,))
+        n = cur.fetchone()[0]
+        con.close()
+        return n > 0
+    except Exception:
+        return False
+
+
+def build_scorecard(inv: AgentInventory, state_root: Path) -> dict[str, Any]:
+    evidence_all: list[str] = []
+
+    # D1: identity_continuity — five canonical files
+    id_files = [
+        inv.registration,
+        inv.living_agent,
+        inv.a2a_card,
+        inv.self_model,
+        inv.authority_passport,
+    ]
+    id_present = sum(1 for f in id_files if f.exists())
+    id_evidence = [str(f) for f in id_files if f.exists()]
+    evidence_all.extend(id_evidence)
+    id_status = "ok" if id_present >= 4 else ("warn" if id_present >= 2 else "fail")
+    d_identity = _dim(
+        id_present / 5,
+        id_status,
+        f"{id_present}/5 identity files present (registration, living_agent, a2a_card, self_model, authority_passport)",
+        id_evidence,
+    )
+
+    # D2: wake_persistence — count of wake_receipts entries
+    wake_count = _count_lines(inv.wake_receipts)
+    wake_last = _file_last_mtime_iso(inv.wake_receipts)
+    if inv.wake_receipts == Path("/dev/null"):
+        d_wake = _dim(0.0, "unknown", "canonical agent — wake_receipts not applicable", [])
+    else:
+        wake_status = "ok" if wake_count >= 5 else ("warn" if wake_count >= 1 else "fail")
+        d_wake = _dim(
+            min(1.0, wake_count / 10),
+            wake_status,
+            f"{wake_count} wake receipts on file",
+            [str(inv.wake_receipts)] if wake_count else [],
+            wake_last,
+        )
+
+    # D3: work_capacity — action_log entries
+    action_count = _count_lines(inv.action_log)
+    action_last = _file_last_mtime_iso(inv.action_log)
+    work_status = "ok" if action_count >= 3 else ("warn" if action_count >= 1 else "fail")
+    d_work = _dim(
+        min(1.0, action_count / 5),
+        work_status,
+        f"{action_count} action_log/task_log entries",
+        [str(inv.action_log)] if action_count else [],
+        action_last,
+    )
+
+    # D4: comms_reliability — A2A card present
+    a2a_present = inv.a2a_card.exists()
+    d_comms = _dim(
+        1.0 if a2a_present else 0.0,
+        "ok" if a2a_present else "fail",
+        "A2A card present (discoverable)" if a2a_present else "A2A card MISSING — not discoverable",
+        [str(inv.a2a_card)] if a2a_present else [],
+    )
+
+    # D5: memory_evolution — self_model exists and is non-placeholder (>500 bytes)
+    if inv.self_model.exists():
+        size = inv.self_model.stat().st_size
+        mem_ok = size > 500
+        d_memory = _dim(
+            1.0 if mem_ok else 0.3,
+            "ok" if mem_ok else "warn",
+            f"self_model size = {size} bytes ({'authored' if mem_ok else 'placeholder or stub'})",
+            [str(inv.self_model)],
+            _file_last_mtime_iso(inv.self_model),
+        )
+    else:
+        d_memory = _dim(0.0, "fail", "self_model missing", [])
+
+    # D6: operational_value — material work beyond registration. Heuristic: action_count > 2 means
+    #     non-registration entries are present (registration alone is ~1, plus self-registration ~1)
+    op_ratio = max(0.0, (action_count - 2) / 8) if action_count > 2 else 0.0
+    op_status = "ok" if action_count > 5 else ("warn" if action_count > 2 else "unknown")
+    d_op = _dim(
+        min(1.0, op_ratio),
+        op_status,
+        f"{action_count} action entries (>2 implies work beyond registration)",
+        [str(inv.action_log)] if action_count else [],
+    )
+
+    # D7: safety_discipline — v0 stub; no incident tracking yet
+    d_safety = _dim(1.0, "unknown", "no incidents tracked in v0 collector", [])
+
+    # D8: cost_discipline — KaizenOps event count proxy
+    kz_count = _kaizen_event_count(state_root, inv.uid)
+    cost_evidence = [str(state_root / "kaizen" / "ops.db")] if kz_count else []
+    d_cost = _dim(
+        0.5,
+        "unknown",
+        f"{kz_count} KaizenOps events (cost dimension deferred to v1)",
+        cost_evidence,
+    )
+
+    # D9: collaboration — stigmergy mark presence
+    stig_count = _stigmergy_marks_for(state_root, inv.uid)
+    d_collab = _dim(
+        1.0 if stig_count else 0.0,
+        "ok" if stig_count else "warn",
+        f"{stig_count} stigmergy marks reference this agent",
+        [str(state_root / "stigmergy" / "marks.jsonl")] if stig_count else [],
+    )
+
+    # D10: promotion_readiness — passport + watch_contract presence
+    has_passport = inv.authority_passport.exists()
+    has_watch = inv.watch_contract.exists()
+    promo_evidence = []
+    if has_passport:
+        promo_evidence.append(str(inv.authority_passport))
+    if has_watch:
+        promo_evidence.append(str(inv.watch_contract))
+    promo_score = (int(has_passport) + int(has_watch)) / 2
+    promo_status = "ok" if promo_score >= 0.8 else ("warn" if promo_score >= 0.4 else "fail")
+    d_promo = _dim(
+        promo_score,
+        promo_status,
+        f"passport={'yes' if has_passport else 'no'}, watch_contract={'yes' if has_watch else 'no'}",
+        promo_evidence,
+    )
+
+    dims = {
+        "identity_continuity": d_identity,
+        "wake_persistence": d_wake,
+        "work_capacity": d_work,
+        "comms_reliability": d_comms,
+        "memory_evolution": d_memory,
+        "operational_value": d_op,
+        "safety_discipline": d_safety,
+        "cost_discipline": d_cost,
+        "collaboration": d_collab,
+        "promotion_readiness": d_promo,
+    }
+
+    overall = sum(d["score"] for d in dims.values()) / len(dims)
+
+    # Determine status (matches scorecard.v0 enum)
+    if action_count >= 3 and id_present >= 4:
+        agent_status = "active"
+    elif id_present >= 2:
+        agent_status = "registered"
+    else:
+        agent_status = "unknown"
+
+    # Blockers
+    blockers: list[str] = []
+    if not inv.registration.exists():
+        blockers.append("registration.json missing")
+    if not inv.living_agent.exists():
+        blockers.append("living_agent.json missing — not discoverable in canonical registry")
+    if not inv.a2a_card.exists():
+        blockers.append("a2a card missing — not discoverable via A2A")
+    if action_count == 0:
+        blockers.append("no action_log entries — agent has not logged any material actions")
+    if not _telemetry_present(state_root, inv.uid):
+        blockers.append("runtime.db agent_identity row missing — telemetry identity not present")
+
+    # Promotion recommendation — v0 always 'hold' per operator directive
+    recommendation = {
+        "recommendation": "hold",
+        "reason": (
+            "v0 collector — structural-evidence scorecard only; human review and "
+            "live-collector consumption are required before any promotion."
+        ),
+        "required_human_decision": True,
+        "required_next_evidence": [
+            "human review of scorecard",
+            "operator decision on authority rank",
+            "live-collector incident/AOTAM data (v1)",
+        ],
+    }
+
+    scorecard_id = hashlib.sha256(
+        f"{inv.uid}:{_now()}:{SCORECARD_SCHEMA_VERSION}".encode()
+    ).hexdigest()[:24]
+
+    return {
+        "schema_version": SCORECARD_SCHEMA_VERSION,
+        "scorecard_id": scorecard_id,
+        "agent_uid": inv.uid,
+        "callsign": inv.callsign,
+        "evaluated_at": _now(),
+        "authority": inv.raw_authority,
+        "status": agent_status,
+        "overall_score": round(overall, 4),
+        "trust_band": "evidence_only",
+        "dimensions": dims,
+        "clearance_state": "none",
+        "current_flight_plan": None,
+        "evidence_refs": evidence_all,
+        "blockers": blockers,
+        "warnings": [],
+        "incidents": [],
+        "aotams": [],
+        "promotion_recommendation": recommendation,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="CWT v0 read-only collector: registered agents -> scorecards"
+    )
+    parser.add_argument(
+        "--state-root", type=Path, default=DEFAULT_STATE_ROOT,
+        help="State root (default: ~/.dharma)",
+    )
+    parser.add_argument(
+        "--out-dir", type=Path, default=None,
+        help="Output directory; if omitted, prints index JSON to stdout",
+    )
+    args = parser.parse_args()
+
+    inventories = discover_agents(args.state_root)
+    scorecards = [build_scorecard(inv, args.state_root) for inv in inventories]
+
+    index = {
+        "schema_version": "cwt_collector_output.v0",
+        "generated_at": _now(),
+        "state_root": str(args.state_root),
+        "scorecard_count": len(scorecards),
+        "scorecards": [
+            {
+                "agent_uid": sc["agent_uid"],
+                "callsign": sc["callsign"],
+                "overall_score": sc["overall_score"],
+                "status": sc["status"],
+                "blocker_count": len(sc["blockers"]),
+            }
+            for sc in scorecards
+        ],
+    }
+
+    if args.out_dir:
+        args.out_dir.mkdir(parents=True, exist_ok=True)
+        for sc in scorecards:
+            (args.out_dir / f"scorecard_{sc['agent_uid']}.json").write_text(
+                json.dumps(sc, indent=2, sort_keys=True) + "\n"
+            )
+        (args.out_dir / "scorecards_index.json").write_text(
+            json.dumps(index, indent=2, sort_keys=True) + "\n"
+        )
+        print(f"Wrote {len(scorecards)} scorecards to {args.out_dir}")
+        for sc in scorecards:
+            print(f"  {sc['agent_uid']:<48} score={sc['overall_score']:.3f}  status={sc['status']}  blockers={len(sc['blockers'])}")
+    else:
+        print(json.dumps(index, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/runtime/cwt_report.py
+++ b/scripts/runtime/cwt_report.py
@@ -1,0 +1,417 @@
+#!/usr/bin/env python3
+"""CONTROL_WATCH_TOWER v0 report renderer.
+
+Builds a top-level report conforming to:
+    schemas/control_watch_tower_report.v0.json
+
+Pipeline:
+    1. Run cwt_collect.py to generate scorecards under {out-dir}/
+    2. Assemble report.json with common_operational_picture, source statuses,
+       per-agent summaries (referencing scorecard files), blockers, warnings,
+       next_operator_actions.
+    3. Write to:
+         reports/control_watch_tower/{timestamp}/report.json
+         reports/control_watch_tower/{timestamp}/scorecards/scorecard_{uid}.json (via collector)
+         reports/control_watch_tower/{timestamp}/scorecards/scorecards_index.json (via collector)
+         reports/control_watch_tower/{timestamp}/REPORT.md (human-readable summary)
+
+Read-only against live state. Only writes under the report directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sqlite3
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+HOME = Path.home()
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_STATE_ROOT = HOME / ".dharma"
+DEFAULT_REPORTS_BASE = REPO_ROOT / "reports" / "control_watch_tower"
+COLLECTOR_PATH = REPO_ROOT / "scripts" / "runtime" / "cwt_collect.py"
+
+REPORT_SCHEMA_VERSION = "control_watch_tower_report.v0"
+GENERATED_BY = "CONTROL_WATCH_TOWER cwt_report.v0"
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _source_status(name: str, status: str, severity: str, summary: str, evidence_paths: list[str] | None = None, metrics: dict[str, Any] | None = None) -> dict[str, Any]:
+    return {
+        "source": name,
+        "status": status,
+        "severity": severity,
+        "summary": summary,
+        "evidence_paths": evidence_paths or [],
+        "metrics": metrics or {},
+        "checked_at": _now(),
+    }
+
+
+def collect_source_statuses(state_root: Path) -> list[dict[str, Any]]:
+    statuses: list[dict[str, Any]] = []
+
+    # external_agents
+    ext = state_root / "external_agents"
+    if ext.exists():
+        n = sum(1 for p in ext.iterdir() if p.is_dir())
+        statuses.append(_source_status(
+            "external_agents_dir", "ok", "INFO",
+            f"{n} external agent sandboxes present",
+            [str(ext)], {"agent_dir_count": n},
+        ))
+    else:
+        statuses.append(_source_status(
+            "external_agents_dir", "missing", "WARNING",
+            "external agent root does not exist", [str(ext)],
+        ))
+
+    # canonical agents
+    ag = state_root / "agents"
+    if ag.exists():
+        n = sum(1 for p in ag.iterdir() if p.is_dir())
+        statuses.append(_source_status(
+            "agents_dir", "ok", "INFO",
+            f"{n} canonical agent dirs present",
+            [str(ag)], {"agent_dir_count": n},
+        ))
+    else:
+        statuses.append(_source_status(
+            "agents_dir", "missing", "WARNING",
+            "canonical agents root does not exist", [str(ag)],
+        ))
+
+    # a2a cards
+    a2a = state_root / "a2a" / "cards"
+    if a2a.exists():
+        n = sum(1 for p in a2a.iterdir() if p.suffix == ".json")
+        statuses.append(_source_status(
+            "a2a_cards_dir", "ok", "INFO",
+            f"{n} A2A discovery cards present",
+            [str(a2a)], {"card_count": n},
+        ))
+    else:
+        statuses.append(_source_status(
+            "a2a_cards_dir", "missing", "WARNING",
+            "A2A cards root does not exist", [str(a2a)],
+        ))
+
+    # runtime.db (telemetry identity)
+    rt = state_root / "state" / "runtime.db"
+    if rt.exists():
+        try:
+            con = sqlite3.connect(rt)
+            cur = con.cursor()
+            cur.execute("SELECT COUNT(*) FROM agent_identity")
+            n_id = cur.fetchone()[0]
+            con.close()
+            statuses.append(_source_status(
+                "runtime_db_agent_identity", "ok", "INFO",
+                f"{n_id} telemetry identity rows present",
+                [str(rt)], {"agent_identity_rows": n_id},
+            ))
+        except Exception as e:
+            statuses.append(_source_status(
+                "runtime_db_agent_identity", "fail", "BLOCKER",
+                f"runtime.db query error: {type(e).__name__}",
+                [str(rt)],
+            ))
+    else:
+        statuses.append(_source_status(
+            "runtime_db_agent_identity", "missing", "WARNING",
+            "runtime.db does not exist", [str(rt)],
+        ))
+
+    # kaizen ops.db
+    kz = state_root / "kaizen" / "ops.db"
+    if kz.exists():
+        try:
+            con = sqlite3.connect(kz)
+            cur = con.cursor()
+            cur.execute("SELECT COUNT(*) FROM events WHERE category = 'external_agent_registration'")
+            n = cur.fetchone()[0]
+            con.close()
+            statuses.append(_source_status(
+                "kaizen_ops_db_events", "ok", "INFO",
+                f"{n} external_agent_registration events on file",
+                [str(kz)], {"registration_event_count": n},
+            ))
+        except Exception as e:
+            statuses.append(_source_status(
+                "kaizen_ops_db_events", "fail", "WARNING",
+                f"kaizen/ops.db query error: {type(e).__name__}",
+                [str(kz)],
+            ))
+    else:
+        statuses.append(_source_status(
+            "kaizen_ops_db_events", "missing", "INFO",
+            "kaizen/ops.db does not exist", [str(kz)],
+        ))
+
+    # stigmergy marks
+    stig = state_root / "stigmergy" / "marks.jsonl"
+    if stig.exists():
+        try:
+            with open(stig) as f:
+                lines = sum(1 for _ in f)
+            statuses.append(_source_status(
+                "stigmergy_marks", "ok", "INFO",
+                f"{lines} stigmergy marks recorded",
+                [str(stig)], {"mark_line_count": lines},
+            ))
+        except Exception as e:
+            statuses.append(_source_status(
+                "stigmergy_marks", "fail", "WARNING",
+                f"stigmergy read error: {type(e).__name__}",
+                [str(stig)],
+            ))
+    else:
+        statuses.append(_source_status(
+            "stigmergy_marks", "missing", "INFO",
+            "stigmergy/marks.jsonl does not exist", [str(stig)],
+        ))
+
+    # passports
+    pp = state_root / "agent_passports"
+    if pp.exists():
+        n = sum(1 for p in pp.iterdir() if p.suffix == ".json")
+        statuses.append(_source_status(
+            "agent_passports_dir", "ok", "INFO",
+            f"{n} agent passports present",
+            [str(pp)], {"passport_count": n},
+        ))
+    else:
+        statuses.append(_source_status(
+            "agent_passports_dir", "missing", "INFO",
+            "agent_passports root does not exist", [str(pp)],
+        ))
+
+    return statuses
+
+
+def aggregate_agent_summaries(scorecards_dir: Path) -> tuple[list[dict[str, Any]], dict[str, int]]:
+    summaries: list[dict[str, Any]] = []
+    counts = {"registered": 0, "active": 0, "blocked": 0, "lost_comms": 0, "quarantined": 0, "retired": 0, "unknown": 0, "incident": 0, "promotion_candidate": 0}
+    for sc_path in sorted(scorecards_dir.glob("scorecard_*.json")):
+        try:
+            sc = json.loads(sc_path.read_text())
+        except Exception:
+            continue
+        status = sc.get("status", "unknown")
+        if status in counts:
+            counts[status] += 1
+        else:
+            counts["unknown"] += 1
+        summaries.append({
+            "agent_uid": sc["agent_uid"],
+            "callsign": sc["callsign"],
+            "authority": sc.get("authority", "unknown"),
+            "status": status,
+            "scorecard_ref": str(sc_path.relative_to(scorecards_dir.parent.parent)),
+            "blockers": sc.get("blockers", []),
+        })
+        rec = sc.get("promotion_recommendation", {}).get("recommendation", "hold")
+        if rec in ("promote_candidate", "promote_scoped"):
+            counts["promotion_candidate"] += 1
+    return summaries, counts
+
+
+def build_report(state_root: Path, report_dir: Path) -> dict[str, Any]:
+    scorecards_dir = report_dir / "scorecards"
+    scorecards_dir.mkdir(parents=True, exist_ok=True)
+
+    # 1. Run collector with output directory
+    collector_cmd = [
+        sys.executable, str(COLLECTOR_PATH),
+        "--state-root", str(state_root),
+        "--out-dir", str(scorecards_dir),
+    ]
+    collector_result = subprocess.run(collector_cmd, capture_output=True, text=True)
+    if collector_result.returncode != 0:
+        raise RuntimeError(f"cwt_collect.py failed (exit {collector_result.returncode}): {collector_result.stderr[:500]}")
+
+    # 2. Source statuses
+    sources = collect_source_statuses(state_root)
+
+    # 3. Agent summaries
+    summaries, counts = aggregate_agent_summaries(scorecards_dir)
+
+    # 4. Common operational picture
+    cop = {
+        "summary": (
+            f"v0 read-only collector pass. {counts['active']} active, "
+            f"{counts['registered']} registered, {counts['unknown']} unknown. "
+            f"{counts['promotion_candidate']} promotion candidates."
+        ),
+        "registered_agents": sum([counts["registered"], counts["active"], counts["blocked"]]),
+        "active_agents": counts["active"],
+        "lost_comms_agents": counts["lost_comms"],
+        "blocked_agents": counts["blocked"],
+        "incident_count": counts["incident"],
+        "promotion_candidates": counts["promotion_candidate"],
+    }
+
+    # 5. Overall status from source severities
+    overall = "ok"
+    if any(s["severity"] == "BLOCKER" for s in sources):
+        overall = "fail"
+    elif any(s["severity"] == "WARNING" for s in sources):
+        overall = "warn"
+
+    # 6. Blockers + warnings (collected from sources + scorecards)
+    blockers_list: list[str] = []
+    warnings_list: list[str] = []
+    for s in sources:
+        if s["severity"] == "BLOCKER":
+            blockers_list.append(f"{s['source']}: {s['summary']}")
+        elif s["severity"] == "WARNING":
+            warnings_list.append(f"{s['source']}: {s['summary']}")
+    for summ in summaries:
+        for b in summ.get("blockers", []):
+            blockers_list.append(f"{summ['agent_uid']}: {b}")
+
+    next_actions = [
+        "Review per-agent scorecards under reports/control_watch_tower/<ts>/scorecards/",
+        "For agents with 'no action_log entries' blocker — verify they have a real wake/work loop or accept registered-only status.",
+        "For agents missing a2a card or telemetry identity — re-register via scripts/register_external_agent.py.",
+        "v1 collector should add: incident tracking, AOTAM ingestion, cost-discipline real metrics, true comms_reliability via heartbeat checks.",
+    ]
+
+    report_id = hashlib.sha256(f"cwt_report:{_now()}".encode()).hexdigest()[:20]
+
+    report = {
+        "schema_version": REPORT_SCHEMA_VERSION,
+        "report_id": report_id,
+        "generated_at": _now(),
+        "repo_root": str(REPO_ROOT),
+        "state_dir": str(state_root),
+        "generated_by": GENERATED_BY,
+        "battle_rhythm_window": {
+            "from": _now(),
+            "to": _now(),
+            "cadence": "on_demand_v0",
+        },
+        "overall_status": overall,
+        "common_operational_picture": cop,
+        "sources": sources,
+        "agents": summaries,
+        "aotams": [],
+        "incidents": [],
+        "blockers": blockers_list,
+        "warnings": warnings_list,
+        "next_operator_actions": next_actions,
+        "evidence_paths": [
+            str(state_root / "external_agents"),
+            str(state_root / "agents"),
+            str(state_root / "a2a" / "cards"),
+            str(state_root / "state" / "runtime.db"),
+            str(state_root / "kaizen" / "ops.db"),
+            str(state_root / "stigmergy" / "marks.jsonl"),
+            str(state_root / "agent_passports"),
+        ],
+    }
+    return report
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    lines = [
+        f"# CONTROL_WATCH_TOWER Report — {report['generated_at']}",
+        "",
+        f"- **report_id:** `{report['report_id']}`",
+        f"- **overall_status:** `{report['overall_status']}`",
+        f"- **schema_version:** `{report['schema_version']}`",
+        "",
+        "## Common Operational Picture",
+        "",
+        f"> {report['common_operational_picture']['summary']}",
+        "",
+        f"- registered_agents: **{report['common_operational_picture']['registered_agents']}**",
+        f"- active_agents: **{report['common_operational_picture']['active_agents']}**",
+        f"- blocked_agents: **{report['common_operational_picture']['blocked_agents']}**",
+        f"- lost_comms_agents: **{report['common_operational_picture']['lost_comms_agents']}**",
+        f"- promotion_candidates: **{report['common_operational_picture']['promotion_candidates']}**",
+        f"- incident_count: **{report['common_operational_picture']['incident_count']}**",
+        "",
+        "## Sources",
+        "",
+        "| Source | Status | Severity | Summary |",
+        "|---|---|---|---|",
+    ]
+    for s in report["sources"]:
+        lines.append(f"| `{s['source']}` | {s['status']} | {s['severity']} | {s['summary']} |")
+    lines.extend([
+        "",
+        "## Agents",
+        "",
+        "| agent_uid | callsign | authority | status | blockers |",
+        "|---|---|---|---|---|",
+    ])
+    for a in report["agents"]:
+        lines.append(
+            f"| `{a['agent_uid']}` | `{a['callsign']}` | {a['authority']} | {a['status']} | {len(a['blockers'])} |"
+        )
+    if report["blockers"]:
+        lines.extend(["", "## Blockers", ""])
+        for b in report["blockers"]:
+            lines.append(f"- {b}")
+    if report["warnings"]:
+        lines.extend(["", "## Warnings", ""])
+        for w in report["warnings"]:
+            lines.append(f"- {w}")
+    if report["next_operator_actions"]:
+        lines.extend(["", "## Next Operator Actions", ""])
+        for a in report["next_operator_actions"]:
+            lines.append(f"- {a}")
+    return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="CWT v0 report renderer")
+    parser.add_argument(
+        "--state-root", type=Path, default=DEFAULT_STATE_ROOT,
+        help="State root (default: ~/.dharma)",
+    )
+    parser.add_argument(
+        "--reports-base", type=Path, default=DEFAULT_REPORTS_BASE,
+        help="Reports base dir (default: reports/control_watch_tower under repo root)",
+    )
+    parser.add_argument(
+        "--timestamp", type=str, default=None,
+        help="Override timestamp dir (default: current UTC stamp)",
+    )
+    args = parser.parse_args()
+
+    stamp = args.timestamp or _stamp()
+    report_dir = args.reports_base / stamp
+    report_dir.mkdir(parents=True, exist_ok=True)
+
+    report = build_report(args.state_root, report_dir)
+
+    (report_dir / "report.json").write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n"
+    )
+    (report_dir / "REPORT.md").write_text(render_markdown(report))
+
+    print(f"CWT v0 report written:")
+    print(f"  {report_dir / 'report.json'}")
+    print(f"  {report_dir / 'REPORT.md'}")
+    print(f"  {report_dir / 'scorecards'}/  ({len(report['agents'])} scorecards)")
+    print(f"")
+    print(f"overall_status: {report['overall_status']}")
+    print(f"agents: {len(report['agents'])}  blockers: {len(report['blockers'])}  warnings: {len(report['warnings'])}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Organ touched: Control Watch Tower runtime reporting seam; scripts/runtime CWT collector/report plus architecture navigation.
Declared-vs-actual gap closed: Adds the read-only v0 collector and report renderer promised by the CONTROL_WATCH_TOWER doctrine, using existing schema-shaped scorecards and no live-state mutation.
Proof that re-reads the map: docs/architecture/NAVIGATION.md was updated for the new seam; DocOps inventory was refreshed after merging current main; py_compile passed for scripts/runtime/cwt_collect.py and scripts/runtime/cwt_report.py.
New drift introduced: No intentional authority drift; generated DocOps count drift was reconciled in this PR, and CWT v0 remains read-only with promotion/write behavior deferred to v1.

Summary:
- Adds scripts/runtime/cwt_collect.py for structural agent scorecards.
- Adds scripts/runtime/cwt_report.py for common operational picture reports under reports/control_watch_tower/.
- Updates architecture navigation and generated DocOps counts.

Validation:
- python3 scripts/docops/check_docops_integrity.py --write-auto-sections
- python3 -m py_compile scripts/runtime/cwt_collect.py scripts/runtime/cwt_report.py