### PR TITLE
[codex] publish Codex toolbelt onboarding

### DIFF
--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -11,11 +11,11 @@ Do not hand-edit the generated block.
 | Dharma Python LOC | 283,300 |
 | Test files | 638 |
 | Test function occurrences | 11,002 |
-| Markdown files | 848 |
-| Markdown total lines | 210,397 |
+| Markdown files | 850 |
+| Markdown total lines | 210,655 |
 | Bridge files | 24 |
 | Adapter files | 21 |
 | Orchestrator files | 4 |
 | Router files | 14 |
-| Authority candidate docs | 370 |
+| Authority candidate docs | 372 |
 <!-- DOCOPS:END -->

--- a/docs/governance/CANONICAL_DOC_STACK.md
+++ b/docs/governance/CANONICAL_DOC_STACK.md
@@ -64,6 +64,7 @@ is **depth-on-demand**. Read it when you need it. Do not memorise a read order.
 | PR coherence gate | `docs/governance/COHERENCE_DELTA.md` | PR template |
 | PR review / merge-control operations | `docs/ops/PR_REVIEW_CONTROL.md` | Merge Master Mike workflows, PR janitor playbook |
 | Action warrant | `docs/governance/FOURFOLD_ACTION_WARRANT.md` | — |
+| Agent onboarding (ops) | `docs/ops/AGENT_ONBOARDING.md`, `docs/ops/CODEX_TOOLBELT_ONBOARDING.md` | — |
 | Module-level what-does-what | `docs/architecture/NAVIGATION.md` | — |
 | Router/TaskBoard domain pinning | `docs/architecture/ROUTERS_AND_TASKBOARD.md` | — |
 | Model / provider routing | `docs/architecture/MODEL_ROUTING_CANON.md` | root `MODEL_ROUTING_MAP.md` (archive pointer) |

--- a/docs/governance/SOVEREIGN_MANIFEST.md
+++ b/docs/governance/SOVEREIGN_MANIFEST.md
@@ -124,8 +124,8 @@ These are the ground-truth metrics. All other documents citing different numbers
 | Test functions | **11,002 `def test_` occurrences under tests/** | rg "def test_" tests |
 | Tests collected (pytest) | **Needs write-permitted refresh** | not run during this DocOps count pass |
 | Collection errors | **Historical: 16 on 2026-04-04** | refresh before relying on this count |
-| Markdown files | **848** | find . -name "*.md" -type f |
-| Markdown total lines | **210,397** | wc -l across all .md |
+| Markdown files | **850** | find . -name "*.md" -type f |
+| Markdown total lines | **210,655** | wc -l across all .md |
 | Bridge files | **24** | find dharma_swarm -name "*bridge*.py" |
 | Adapter files | **21 across 8 locations** | find dharma_swarm -type f \| rg -i "adapter" |
 | Orchestrator files | **4** (6,034 LOC total) | find dharma_swarm -name "*orchestrat*" |

--- a/docs/ops/AGENT_ONBOARDING.md
+++ b/docs/ops/AGENT_ONBOARDING.md
@@ -1,0 +1,97 @@
+# Agent Onboarding
+
+This is the generic first stop for any new agent entering `dharma_swarm`. It ties live tool status, codebase context tools, governance, active build tracks, and persistent-agent state into one route.
+
+Start here:
+
+```bash
+cd ~/dharma_swarm
+make onboard
+```
+
+`make onboard` is read-only. It prints the live Codex/MCP toolbelt status, branch/dirty-tree state, and links to the highest-value docs.
+
+GitHub-only agents cannot see local credentials, `dkeys`, or live process environment. Do not conclude "no LLM provider is configured" from repository contents alone; that claim requires a current local `make onboard`, `dkeys list`, `python -m dharma_swarm.api_key_audit --no-agentic`, or `/api/chat/status` check from the operator machine.
+
+## First Five Minutes
+
+Read in this order:
+
+1. [`CLAUDE.md`](../../CLAUDE.md): repo behavior, engineering rules, architecture summary, build/test commands.
+2. [`CODEX_TOOLBELT_ONBOARDING.md`](CODEX_TOOLBELT_ONBOARDING.md): large-codebase context tools, MCP health, Sourcegraph/GDrive/Postgres gates, Sourcebot lane.
+3. [`BUILD_SESSION_ENTRYPOINT.md`](../governance/BUILD_SESSION_ENTRYPOINT.md): mandatory build-session read order and current active track.
+4. [`MEGAFILE_INDEX.md`](../MEGAFILE_INDEX.md): the ten durable onboarding surfaces.
+5. The task-specific row below that matches the work you are doing.
+
+Do not read the whole repo. Pick the smallest route that gives you evidence.
+
+## Context Tool Stack
+
+Use this stack before inventing a new search/indexing path:
+
+| Need | First tool | When blocked |
+|---|---|---|
+| Local code graph, impact, call paths | GitNexus MCP | run `npx gitnexus analyze`, then retry |
+| Semantic repo navigation | Context+ MCP | use `rg` plus targeted file reads |
+| Exact text/evidence | `rg` | `git grep`, then `find`/`grep` |
+| Repo/PR/issue/CI state | GitHub MCP or `gh` | local `git` if remote is unavailable |
+| Current library/API docs | Context7 MCP | official docs only |
+| Public-code search | `/Users/dhyana/.local/bin/src search 'context:global ...'` | web search |
+| Sourcegraph-like self-hosted search | Sourcebot, if running | GitNexus + Context+ |
+| Google Drive docs | GDrive MCP, after auth | ask operator for local copies |
+| SQL/schema inspection | Postgres MCP, after DSN | SQLite/read-only local probes |
+
+Sourcegraph Enterprise MCP is not a dependency. Sourcegraph, GDrive, and Postgres MCPs were removed from global Codex config because they were unprovisioned and caused repeated scout startup warnings. Re-add them only through the gates in [`CODEX_TOOLBELT_ONBOARDING.md`](CODEX_TOOLBELT_ONBOARDING.md).
+
+## Task Routes
+
+| Task | Read these first |
+|---|---|
+| Any code change | [`BUILD_SESSION_ENTRYPOINT.md`](../governance/BUILD_SESSION_ENTRYPOINT.md), [`SOVEREIGN_MANIFEST.md`](../governance/SOVEREIGN_MANIFEST.md), [`000_MASTER_COHERENCE_SYNTHESIS.md`](../../reports/audit/end_to_end/000_MASTER_COHERENCE_SYNTHESIS.md), [`CANONICAL_DOC_STACK.md`](../governance/CANONICAL_DOC_STACK.md) |
+| Architecture/navigation | [`NAVIGATION.md`](../architecture/NAVIGATION.md), [`MEGAFILE_INDEX.md`](../MEGAFILE_INDEX.md), GitNexus/Context+ |
+| Runtime wiring or bugfix | [`INTERFACE_MISMATCH_MAP.md`](../../INTERFACE_MISMATCH_MAP.md), [`CYBERNETIC_LOOP_MAP.md`](../../CYBERNETIC_LOOP_MAP.md), relevant tests |
+| Current live state | [`LIVE_OPS_DASHBOARD.md`](../state/LIVE_OPS_DASHBOARD.md), [`BROKEN_REGISTER.md`](../state/BROKEN_REGISTER.md), `~/.dharma` evidence |
+| Active build track | [`ONTOLOGY_NATIVE_OPERATOR_BRIEF_MASTER_SPEC.md`](../plans/ONTOLOGY_NATIVE_OPERATOR_BRIEF_MASTER_SPEC.md), [`NEXT_10_SUBSTRATE_TODO.md`](../plans/NEXT_10_SUBSTRATE_TODO.md), [`HANDOFF_ONTOLOGY_NATIVE_OPERATOR_BRIEF.md`](../plans/HANDOFF_ONTOLOGY_NATIVE_OPERATOR_BRIEF.md) |
+| Persistent agents | Check the current branch for `docs/agents/` and `docs/research/persistent_agents*/`; if absent, ask the operator for the latest packet rather than inventing L4 readiness claims. |
+| Docs or governance edits | [`CANONICAL_DOC_STACK.md`](../governance/CANONICAL_DOC_STACK.md), [`REPO_GOVERNANCE_AUDIT.md`](../governance/REPO_GOVERNANCE_AUDIT.md) |
+| Doctrine/telos | [`OPERATIONAL_DOCTRINE.md`](../doctrine/OPERATIONAL_DOCTRINE.md), [`LIVE_ROADMAP.md`](../doctrine/LIVE_ROADMAP.md), [`SOVEREIGN_MANIFEST.md`](../governance/SOVEREIGN_MANIFEST.md) |
+| Foundations/glossary | [`foundations/INDEX.md`](../../foundations/INDEX.md), [`foundations/GLOSSARY.md`](../../foundations/GLOSSARY.md) |
+
+## Non-Negotiables
+
+- Do not revert changes you did not make.
+- Do not add new runtime substrates when canonical substrates already exist.
+- Do not add top-level docs or source files.
+- Do not claim an agent is L4 unless the readiness evidence proves it.
+- Do not print secret values. Report only presence/absence of keys or credential files.
+- Do not re-enable optional MCPs globally unless their gates are green.
+
+## Large-Codebase Work Pattern
+
+1. Run `make onboard`.
+2. Identify the task route above.
+3. Use GitNexus or Context+ for structure before reading many files.
+4. Use `rg` for exact evidence.
+5. Before modifying a shared symbol, check impact/blast radius.
+6. Make the smallest scoped change.
+7. Run the relevant test or read-only status script.
+8. Update the owning doc only if the change alters durable truth.
+
+## Handoff Prompt
+
+Use this for a new Codex agent:
+
+```text
+Repo: /Users/dhyana/dharma_swarm
+
+Start by running:
+
+cd /Users/dhyana/dharma_swarm
+make onboard
+
+Read `docs/ops/AGENT_ONBOARDING.md`, then follow the task route that matches the assignment.
+
+Use GitNexus + Context+ + rg as the default large-codebase context stack. Treat Sourcegraph, GDrive, and Postgres MCPs as optional and removed unless their gates in `docs/ops/CODEX_TOOLBELT_ONBOARDING.md` are green.
+
+Never print secrets. Do not revert user or other-agent changes. Do not add new substrates before checking `docs/governance/BUILD_SESSION_ENTRYPOINT.md` and `reports/audit/end_to_end/000_MASTER_COHERENCE_SYNTHESIS.md`.
+```

--- a/docs/ops/CODEX_TOOLBELT_ONBOARDING.md
+++ b/docs/ops/CODEX_TOOLBELT_ONBOARDING.md
@@ -1,0 +1,160 @@
+# Codex Toolbelt Onboarding
+
+Parent entrypoint: [`AGENT_ONBOARDING.md`](AGENT_ONBOARDING.md). Use this file for Codex/MCP tool routing details after running `make onboard`.
+
+Purpose: get a new Codex agent oriented to the local code-intelligence stack without paying for Sourcegraph Enterprise or rediscovering known MCP startup failures.
+
+## First Minute
+
+```bash
+cd ~/dharma_swarm
+bash scripts/runtime/codex_toolbelt_status.sh
+sed -n '1,220p' docs/ops/CODEX_TOOLBELT_ONBOARDING.md
+```
+
+If the status script says `sourcegraph`, `gdrive`, or `postgres` are not globally configured, that is intentional. They are optional and must not be added back until their gates below are satisfied.
+
+## Current Truth
+
+- Sourcegraph MCP is not a default individual-user dependency. Sourcegraph's public MCP endpoint exists, but Sourcegraph's current pricing/docs place full MCP/API/CLI access under Enterprise. Do not make dharma_swarm depend on it.
+- Sourcegraph public code search still works through `/Users/dhyana/.local/bin/src search ...`; use it for public repositories only.
+- GDrive MCP is individual-accessible, but this machine is missing OAuth client JSON and saved credentials.
+- Postgres MCP is local-infra only, but this machine currently has no configured DSN and no always-on database target.
+- Sourcebot is the realistic self-hosted Sourcegraph-like path. Treat it as optional until a local instance and `SOURCEBOT_API_KEY` are present.
+- Provider/API-key truth is local operator state. GitHub-only agents cannot infer it from the repository. Use local non-secret status commands before claiming the runtime has no usable LLM provider.
+
+## Provider Key Reality
+
+`dkeys` is a local helper outside this repo, usually at `~/.dharma/bin/dkeys`. Its canonical key store is `~/.dharma/agent_keys.env`, and its cache is `~/.dharma/keys_status.json`. Neither file belongs in git.
+
+Safe local checks:
+
+```bash
+dkeys list
+python -m dharma_swarm.api_key_audit --no-agentic
+curl -s http://127.0.0.1:8420/api/chat/status
+```
+
+Never print key values. Report only provider presence, live/probe status, and whether a failure is auth, quota/funds, provider retirement, or network/sandbox.
+
+Known naming mismatch to watch:
+
+- `dkeys` tests Gemini with `GEMINI_API_KEY`; dharma runtime uses `GOOGLE_AI_API_KEY`.
+- `dkeys` tests hosted NVIDIA with `NVIDIA_API_KEY`; dharma runtime uses `NVIDIA_NIM_API_KEY`.
+
+If a remote GitHub-only audit says "no configured LLM provider," treat it as stale unless it also cites a current `make onboard`, `dkeys`, runtime audit, or `/api/chat/status` result from the operator machine.
+
+## Default Tool Routing
+
+Use this routing before reaching for paid/external tools:
+
+| Need | Primary path | Fallback |
+|---|---|---|
+| Local code graph, impact, call paths | GitNexus MCP | `npx gitnexus analyze`, then retry |
+| Semantic repo navigation | Context+ MCP | `rg`, `sed`, targeted file reads |
+| Exact local evidence | `rg` | `find`, `grep` |
+| Repo/PR/issue state | GitHub MCP or `gh` | `git` local state |
+| Library/API docs | Context7 MCP | official web docs |
+| Public-code search | `/Users/dhyana/.local/bin/src search 'context:global ...'` | web search |
+| Sourcegraph-like local search | Sourcebot when running | GitNexus + Context+ |
+| Google Drive docs | GDrive MCP only after auth | ask operator for files |
+| SQL schema/data | Postgres MCP only after DSN | SQLite/read-only local probes |
+
+## Removed MCPs
+
+These were removed from global Codex config on 2026-05-21 because they caused repeated handshake failures in every spawned scout:
+
+```bash
+codex mcp remove sourcegraph
+codex mcp remove gdrive
+codex mcp remove postgres
+```
+
+The removals are operational hygiene, not a rejection of the tools. Re-add only when the matching gate is green.
+
+## Re-Add Gates
+
+### Sourcegraph
+
+Do not re-add for normal dharma_swarm work. Re-add only if one of these is true:
+
+- the operator has an Enterprise/team Sourcegraph account with MCP entitlement;
+- `codex mcp login sourcegraph --scopes mcp` succeeds;
+- an MCP-scoped access token is available and verified without printing it.
+
+Preferred OAuth command if entitlement exists:
+
+```bash
+codex mcp add sourcegraph --url https://sourcegraph.com/.api/mcp
+codex mcp login sourcegraph --scopes mcp
+```
+
+Do not depend on `SRC_ACCESS_TOKEN` unless the token scheme is verified with Sourcegraph's current MCP auth behavior.
+
+### GDrive
+
+Re-add only after both files exist:
+
+```bash
+ls ~/.codex/memories/gcp-oauth.keys.json
+ls ~/.codex/memories/gdrive-credentials.json
+```
+
+Auth flow:
+
+```bash
+/Users/dhyana/.codex/mcp-lab/bin/run-gdrive-mcp.sh auth
+codex mcp add gdrive -- /Users/dhyana/.codex/mcp-lab/bin/run-gdrive-mcp.sh
+```
+
+### Postgres
+
+Re-add only after a live target exists and one of these is present:
+
+```bash
+echo 'postgresql://localhost:5432/dbname' > ~/.codex/memories/postgres-url.txt
+# or export MCP_POSTGRES_URL in the shell that launches Codex
+```
+
+Then:
+
+```bash
+codex mcp add postgres -- /Users/dhyana/.codex/mcp-lab/bin/run-postgres-mcp.sh
+```
+
+### Sourcebot
+
+Sourcebot is the replacement lane for a self-hosted Sourcegraph-like index. Do not make it required until Docker/Colima is running and an API key exists.
+
+Expected MCP shape:
+
+```bash
+export SOURCEBOT_API_KEY='<redacted>'
+codex mcp add sourcebot --url http://localhost:3000/api/mcp --bearer-token-env-var SOURCEBOT_API_KEY
+```
+
+Use `bash scripts/runtime/codex_toolbelt_status.sh` to see whether the local endpoint is reachable.
+
+## New Agent Prompt
+
+Use this at the start of code-intelligence-heavy sessions:
+
+```text
+Before using MCPs, run `bash scripts/runtime/codex_toolbelt_status.sh` in `~/dharma_swarm`.
+Treat Sourcegraph MCP, GDrive MCP, and Postgres MCP as optional: do not re-add them unless their documented gates in `docs/ops/CODEX_TOOLBELT_ONBOARDING.md` are green.
+For local code intelligence, use GitNexus + Context+ + rg first.
+For public-code search, use `/Users/dhyana/.local/bin/src search`.
+Never print token values; report only whether required env vars/files are present.
+```
+
+## Failure Pattern To Recognize
+
+If a swarm spawn prints repeated warnings like:
+
+```text
+MCP client for sourcegraph failed to start
+MCP client for gdrive failed to start
+MCP client for postgres failed to start
+```
+
+that usually means optional unprovisioned MCPs are globally configured. It is not evidence that the whole MCP stack is broken. Remove the unprovisioned entries, restart Codex, then rely on GitNexus, Context+, GitHub, Context7, fetch, memory, and local shell tools.

--- a/scripts/governance/agent_onboard.py
+++ b/scripts/governance/agent_onboard.py
@@ -733,7 +733,8 @@ def _load_track_yaml() -> dict[str, Any]:
 
 def main() -> int:
     os.chdir(REPO_ROOT)
-    _refresh_evidence()
+    if os.getenv("AGENT_ONBOARD_REFRESH", "").strip() == "1":
+        _refresh_evidence()
     evidence = _load_evidence()
     track = _load_track_yaml()
 

--- a/scripts/runtime/agent_onboard.sh
+++ b/scripts/runtime/agent_onboard.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -u
+
+ROOT="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+
+cd "${ROOT}" || exit 2
+
+section() {
+  printf '\n== %s ==\n' "$1"
+}
+
+exists_line() {
+  local path="$1"
+  local note="$2"
+  if [ -e "${path}" ]; then
+    printf 'OK   %-72s %s\n' "${path}" "${note}"
+  else
+    printf 'MISS %-72s %s\n' "${path}" "${note}"
+  fi
+}
+
+printf 'dharma_swarm new-agent onboarding\n'
+printf 'repo=%s\n' "${ROOT}"
+printf 'command=make onboard\n'
+
+section "Live Toolbelt"
+if [ -f scripts/runtime/codex_toolbelt_status.sh ]; then
+  bash scripts/runtime/codex_toolbelt_status.sh "${ROOT}"
+else
+  printf 'MISS scripts/runtime/codex_toolbelt_status.sh\n'
+fi
+
+section "Working Tree"
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  branch="$(git branch --show-current 2>/dev/null || true)"
+  dirty_count="$(git status --short | wc -l | tr -d ' ')"
+  printf 'branch=%s\n' "${branch:-unknown}"
+  printf 'dirty_entries=%s\n' "${dirty_count}"
+  if [ "${dirty_count}" != "0" ]; then
+    printf 'WARN worktree is dirty; do not revert user or other-agent changes.\n'
+  fi
+else
+  printf 'WARN not inside a git worktree\n'
+fi
+
+section "Governance Snapshot"
+if [ -f scripts/governance/agent_onboard.py ]; then
+  "${PYTHON:-python3}" scripts/governance/agent_onboard.py || printf 'WARN governance onboarding renderer exited non-zero\n'
+else
+  printf 'MISS scripts/governance/agent_onboard.py\n'
+fi
+
+section "First Read Order"
+exists_line "docs/ops/AGENT_ONBOARDING.md" "this map"
+exists_line "CLAUDE.md" "repo behavior and engineering rules"
+exists_line "docs/ops/CODEX_TOOLBELT_ONBOARDING.md" "MCP/tool routing and Sourcegraph replacement"
+exists_line "docs/governance/BUILD_SESSION_ENTRYPOINT.md" "mandatory build-session pointer"
+exists_line "docs/MEGAFILE_INDEX.md" "ten durable onboarding surfaces"
+
+section "Task-Specific Maps"
+exists_line "docs/governance/SOVEREIGN_MANIFEST.md" "governance and substrate boundaries"
+exists_line "docs/governance/CANONICAL_DOC_STACK.md" "doc ownership rules"
+exists_line "reports/audit/end_to_end/000_MASTER_COHERENCE_SYNTHESIS.md" "canonical substrate table and gaps"
+exists_line "docs/architecture/NAVIGATION.md" "large static architecture map"
+exists_line "INTERFACE_MISMATCH_MAP.md" "known interface mismatches before code edits"
+exists_line "CYBERNETIC_LOOP_MAP.md" "feedback-loop map"
+exists_line "docs/state/LIVE_OPS_DASHBOARD.md" "current live state"
+exists_line "docs/state/BROKEN_REGISTER.md" "known broken surfaces"
+exists_line "docs/ops/CODEX_TOOLBELT_ONBOARDING.md" "Codex/MCP/key-helper gates"
+
+section "Current Build Track"
+exists_line "docs/plans/ONTOLOGY_NATIVE_OPERATOR_BRIEF_MASTER_SPEC.md" "active seam master spec"
+exists_line "docs/plans/NEXT_10_SUBSTRATE_TODO.md" "next substrate tasks"
+exists_line "docs/plans/HANDOFF_ONTOLOGY_NATIVE_OPERATOR_BRIEF.md" "handoff for code agents"
+
+section "Next Commands"
+cat <<'EOF'
+sed -n '1,220p' docs/ops/AGENT_ONBOARDING.md
+sed -n '1,220p' CLAUDE.md
+sed -n '1,220p' docs/governance/BUILD_SESSION_ENTRYPOINT.md
+sed -n '1,220p' docs/ops/CODEX_TOOLBELT_ONBOARDING.md
+EOF

--- a/scripts/runtime/codex_toolbelt_status.sh
+++ b/scripts/runtime/codex_toolbelt_status.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+set -u
+
+ROOT="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+CODEX_CONFIG="${HOME}/.codex/config.toml"
+
+ok() {
+  printf 'OK   %s\n' "$1"
+}
+
+warn() {
+  printf 'WARN %s\n' "$1"
+}
+
+info() {
+  printf 'INFO %s\n' "$1"
+}
+
+present_env() {
+  local name="$1"
+  if [ -n "${!name:-}" ]; then
+    ok "env ${name} is present"
+  else
+    warn "env ${name} is missing"
+  fi
+}
+
+has_cmd() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+server_configured() {
+  local name="$1"
+  if [ -f "${CODEX_CONFIG}" ] && grep -q "^\[mcp_servers\.${name}\]" "${CODEX_CONFIG}"; then
+    return 0
+  fi
+  return 1
+}
+
+printf 'Codex toolbelt status\n'
+printf 'repo=%s\n' "${ROOT}"
+printf 'config=%s\n\n' "${CODEX_CONFIG}"
+
+printf 'Core local stack\n'
+if server_configured gitnexus; then
+  ok "gitnexus MCP configured"
+else
+  warn "gitnexus MCP missing from Codex config"
+fi
+
+if server_configured contextplus; then
+  ok "contextplus MCP configured"
+else
+  warn "contextplus MCP missing from Codex config"
+fi
+
+if has_cmd rg; then
+  ok "rg available"
+else
+  warn "rg missing"
+fi
+
+if [ -x "${HOME}/.local/bin/src" ]; then
+  ok "Sourcegraph src CLI available for public-code search"
+else
+  warn "Sourcegraph src CLI missing; public-code search fallback unavailable"
+fi
+
+printf '\nLocal provider key helper, values not printed\n'
+if has_cmd dkeys; then
+  ok "dkeys CLI available"
+else
+  info "dkeys CLI not found in PATH; it is a local operator helper, not a repo dependency"
+fi
+
+if [ -s "${HOME}/.dharma/agent_keys.env" ]; then
+  ok "local dkeys key store exists"
+else
+  info "local dkeys key store missing"
+fi
+
+if [ -s "${HOME}/.dharma/keys_status.json" ]; then
+  ok "local dkeys status cache exists"
+else
+  info "local dkeys status cache missing"
+fi
+
+present_env OPENAI_API_KEY
+present_env OPENROUTER_API_KEY
+present_env OLLAMA_API_KEY
+present_env NVIDIA_NIM_API_KEY
+present_env GOOGLE_AI_API_KEY
+present_env GEMINI_API_KEY
+
+printf '\nRemoved/optional MCPs\n'
+if server_configured sourcegraph; then
+  warn "sourcegraph MCP still configured; remove unless Enterprise/OAuth access exists"
+else
+  ok "sourcegraph MCP not configured globally"
+fi
+
+if server_configured gdrive; then
+  warn "gdrive MCP configured; verify credentials before spawning agents"
+else
+  ok "gdrive MCP not configured globally"
+fi
+
+if server_configured postgres; then
+  warn "postgres MCP configured; verify DSN before spawning agents"
+else
+  ok "postgres MCP not configured globally"
+fi
+
+printf '\nCredential gates, values not printed\n'
+present_env SRC_ACCESS_TOKEN
+present_env SOURCEBOT_API_KEY
+present_env MCP_POSTGRES_URL
+present_env GDRIVE_OAUTH_PATH
+present_env GDRIVE_CREDENTIALS_PATH
+
+if [ -s "${HOME}/.codex/memories/postgres-url.txt" ]; then
+  ok "postgres DSN file exists"
+else
+  warn "postgres DSN file missing"
+fi
+
+if [ -s "${HOME}/.codex/memories/gcp-oauth.keys.json" ]; then
+  ok "GDrive OAuth client JSON exists"
+else
+  warn "GDrive OAuth client JSON missing"
+fi
+
+if [ -s "${HOME}/.codex/memories/gdrive-credentials.json" ]; then
+  ok "GDrive saved credentials exist"
+else
+  warn "GDrive saved credentials missing"
+fi
+
+printf '\nSourcebot lane\n'
+if curl --max-time 0.3 -fsS http://localhost:3000/api/mcp >/dev/null 2>&1; then
+  ok "Sourcebot MCP endpoint responds on localhost:3000"
+else
+  info "Sourcebot MCP endpoint not reachable on localhost:3000"
+fi
+
+if has_cmd docker; then
+  info "docker CLI present: $(docker --version 2>/dev/null | head -1)"
+else
+  warn "docker CLI missing"
+fi
+
+if has_cmd colima; then
+  info "colima present; run 'colima list' if Sourcebot/Docker is needed"
+else
+  info "colima not found"
+fi
+
+printf '\nRead next: docs/ops/AGENT_ONBOARDING.md and docs/ops/CODEX_TOOLBELT_ONBOARDING.md\n'


### PR DESCRIPTION
## Why

Publishes the repo-visible onboarding/toolbelt truth for GitHub-only agents. This wires `make onboard` through the new runtime onboarding wrapper, documents optional MCP gates and local dkeys/provider-key reality without committing secrets, keeps Sourcegraph/GDrive/Postgres optional until provisioned, and refreshes DocOps counts.

## Surface area touched

- [x] `scripts/...` — `scripts/runtime/agent_onboard.sh`, `scripts/runtime/codex_toolbelt_status.sh`, `scripts/governance/agent_onboard.py`
- [x] `docs/...` / DocOps — `docs/ops/AGENT_ONBOARDING.md`, `docs/ops/CODEX_TOOLBELT_ONBOARDING.md`, `docs/governance/CANONICAL_DOC_STACK.md`, `docs/docops/assertions.yaml`
- [x] `Makefile` — wires `make onboard` through new wrapper

## Interface mismatch impact

- [x] No new mismatch introduced

## Coherence Delta

- Organ touched: onboarding surface (`make onboard` pathway), doc-ownership map, DocOps canonical guard
- Declared-vs-actual gap closed: agents now have a documented toolbelt routing table and provider-key reality guide instead of inferring from stale remote evidence; two new docs registered in canonical guard
- Proof that re-reads the map: `docs/governance/CANONICAL_DOC_STACK.md` ownership map updated with agent onboarding (ops) row; `docs/docops/assertions.yaml` canonical_guard.registered updated
- New drift introduced: none — all new docs are reference/ops, no authority claims beyond their scope

## Pre-flight check (collision prevention)

- [x] No BR-id cited

## Verification

- [x] `make onboard` runs successfully
- [x] `bash -n` syntax checks on runtime scripts
- [x] `py_compile` for governance onboarding
- [x] DocOps integrity clean
- [x] Pre-commit hooks pass (hygiene, contracts, uplift guards, gitleaks, semgrep)

## DocOps impact

- [x] New authority-scope language is registered or locally scoped

## Risk + rollback

- Blast radius: low — docs and scripts only, no runtime code changes
- Rollback: single revert

## Checklist

- [x] No unintended changes
- [x] No new files at repo root
- [x] No `git add -A` / `git add .` in any added scripts

Link to Devin session: https://app.devin.ai/sessions/2987d22290324e5ba8b44d6368115755
Requested by: @AmitabhainArunachala