### PR TITLE
fix(guardian): quote SQL identifiers in runtime context checks [impact-checked]

### DIFF
--- a/dharma_swarm/guardian_runtime_checks.py
+++ b/dharma_swarm/guardian_runtime_checks.py
@@ -256,10 +256,12 @@ def runtime_rows_missing_context(
     else:
         return 0
 
+    quoted_table = '"' + table.replace('"', '""') + '"'
+    quoted_ts = '"' + timestamp_column.replace('"', '""') + '"'
     row = db.execute(
-        f"SELECT COUNT(*) FROM {table} t "
+        f"SELECT COUNT(*) FROM {quoted_table} t "
         f"LEFT JOIN context_bundles cb ON {join_clause} "
-        f"WHERE t.{timestamp_column} >= ? "
+        f"WHERE t.{quoted_ts} >= ? "
         "AND t.status IN ('claimed', 'running', 'completed', 'failed') "
         "AND cb.bundle_id IS NULL",
         (since_iso,),
@@ -283,8 +285,10 @@ def runtime_context_status_counts(
         columns = _runtime_table_columns(db, table)
         if timestamp_column not in columns or "metadata_json" not in columns:
             continue
+        quoted_table = '"' + table.replace('"', '""') + '"'
+        quoted_ts = '"' + timestamp_column.replace('"', '""') + '"'
         rows = db.execute(
-            f"SELECT metadata_json FROM {table} WHERE {timestamp_column} >= ?",
+            f"SELECT metadata_json FROM {quoted_table} WHERE {quoted_ts} >= ?",
             (since_iso,),
         ).fetchall()
         for (metadata_json,) in rows:
@@ -307,7 +311,10 @@ def _runtime_table_names(db: sqlite3.Connection) -> set[str]:
 
 
 def _runtime_table_columns(db: sqlite3.Connection, table: str) -> set[str]:
-    return {str(row[1]) for row in db.execute(f"PRAGMA table_info({table})").fetchall()}
+    if table not in _runtime_table_names(db):
+        return set()
+    quoted_table = '"' + table.replace('"', '""') + '"'
+    return {str(row[1]) for row in db.execute(f"PRAGMA table_info({quoted_table})").fetchall()}
 
 
 def _json_load(raw: object, default: object) -> object:

--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -8,9 +8,9 @@ Do not hand-edit the generated block.
 |---|---:|
 | Dharma Python modules | 650 |
 | Top-level Dharma Python modules | 388 |
-| Dharma Python LOC | 275,557 |
+| Dharma Python LOC | 275,648 |
 | Test files | 602 |
-| Test function occurrences | 10,454 |
+| Test function occurrences | 10,459 |
 | Markdown files | 725 |
 | Markdown total lines | 184,234 |
 | Bridge files | 24 |

--- a/docs/governance/SOVEREIGN_MANIFEST.md
+++ b/docs/governance/SOVEREIGN_MANIFEST.md
@@ -114,7 +114,7 @@ These are the ground-truth metrics. All other documents citing different numbers
 | Top-level (flat) modules | **388 (59.7%)** | find dharma_swarm -maxdepth 1 -name "*.py" -type f |
 | Total Python LOC | **275,557** | wc -l across dharma_swarm Python modules |
 | Test files | **602** | find tests -name "*.py" -type f |
-| Test functions | **10,454 `def test_` occurrences under tests/** | rg "def test_" tests |
+| Test functions | **10,459 `def test_` occurrences under tests/** | rg "def test_" tests |
 | Tests collected (pytest) | **Needs write-permitted refresh** | not run during this DocOps count pass |
 | Collection errors | **Historical: 16 on 2026-04-04** | refresh before relying on this count |
 | Markdown files | **725** | find . -name "*.md" -type f |

--- a/tests/test_guardian_runtime_checks.py
+++ b/tests/test_guardian_runtime_checks.py
@@ -24,6 +24,7 @@ from dharma_swarm.guardian_runtime_checks import (
     runtime_context_bundle_injection_findings,
     runtime_rows_missing_context,
     runtime_context_status_counts,
+    _runtime_table_columns,
     _REGISTERED_DHARMA_TOP_LEVEL_DIRS,
 )
 
@@ -285,3 +286,26 @@ class TestRuntimeContextStatusCounts:
         assert counts.get("failed", 0) == 2
         assert counts.get("missing_runtime_state", 0) == 1
         db.close()
+
+
+def test_runtime_table_columns_quotes_identifiers_and_guards_missing():
+    """Regression for SQL identifier injection in _runtime_table_columns.
+
+    The helper must (1) return an empty set for tables that do not exist
+    rather than interpolating an unchecked name into a PRAGMA, and
+    (2) safely handle table names that require quoting/escaping.
+    """
+    db = sqlite3.connect(":memory:")
+    db.execute("CREATE TABLE task_queue (id TEXT, status TEXT)")
+    # A table name containing a double quote — must be quote-escaped, not injected.
+    db.execute('CREATE TABLE "weird""name" (alpha TEXT, beta TEXT)')
+    db.commit()
+
+    assert _runtime_table_columns(db, "task_queue") == {"id", "status"}
+    assert _runtime_table_columns(db, 'weird"name') == {"alpha", "beta"}
+    # Unknown table is guarded before any PRAGMA interpolation.
+    assert _runtime_table_columns(db, "no_such_table") == set()
+    # A classic injection payload is treated as a (non-existent) table name.
+    assert _runtime_table_columns(db, "task_queue); DROP TABLE task_queue;--") == set()
+    assert _runtime_table_columns(db, "task_queue") == {"id", "status"}
+    db.close()


### PR DESCRIPTION
## Why

Clean re-do of #329 on **current `main`**. The original branch was based on a stale `main` (`71652c8`) and its diff deleted shipped work (BoardStore facade, Sakshi, Dhyana, two workflows). This PR carries **only** the intended security hardening, applied to current `main`.

The SQLite introspection helpers in `guardian_runtime_checks.py` interpolated table/column identifiers directly into `PRAGMA`/`SELECT` strings — a SQL identifier-injection surface. This quotes and escapes those identifiers and guards `_runtime_table_columns` against unknown table names.

## Surface area touched

- [x] `dharma_swarm/...` — `dharma_swarm/guardian_runtime_checks.py`
- [x] `tests/...` — `tests/test_guardian_runtime_checks.py` (regression test)

### Worktree mirrors checked

Not a hot-path module; defensive change only.

## Interface mismatch impact

- [x] No new mismatch introduced

## Coherence Delta

- Organ touched: `dharma_swarm/guardian_runtime_checks.py` (Guardian runtime-checks layer) — `_runtime_table_columns`, `runtime_rows_missing_context`, `runtime_context_status_counts`; regression test in `tests/test_guardian_runtime_checks.py`.
- Declared-vs-actual gap closed: these helpers interpolated table/column identifiers straight into PRAGMA/SELECT text (SQL identifier-injection surface); now identifiers are double-quote-escaped and `_runtime_table_columns` returns empty for unknown tables before any interpolation.
- Proof that re-reads the map: reviewed the three helpers; confirmed `main`'s copy of the file is byte-identical to the original branch's base, so the change applies cleanly; the module's 19 tests pass; `make docops-integrity` green (full and `--changed-from origin/main`).
- New drift introduced: none — internal input hardening; no public API or schema change.

## Pre-flight check (collision prevention)

- [x] No BR-id cited. Supersedes #329 (same guardian change, clean base).

## Verification

- [x] `python3 -m pytest tests/test_guardian_runtime_checks.py -q` → 19 passed
- [x] `make docops-integrity` green (full and `--changed-from origin/main`)

## Risk + rollback

- Blast radius: low — defensive identifier quoting in three internal helpers
- Rollback: single revert

## Checklist

- [x] No unintended changes
- [x] No new files at repo root
- [x] No `git add -A` / `git add .`
- [x] Tests added for behavior change

[impact-checked]

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpKJ8uyYo63VnPnGAHUk6k)_