### PR TITLE
[codex] Default runtime context through Memory Kernel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,7 @@ For machine-readable status, see [`reports/governance/active_track_evidence.md`]
 - **DarwinEngine** (`dharma_swarm/evolution.py`): Self-improvement via gated evolution.
 - **LoopEngine** (`dharma_swarm/cascade.py`): F(S)=S universal convergence loop across 5 domains.
 - **DharmaKernel** (`dharma_swarm/dharma_kernel.py`): 25 immutable axioms (SHA-256 signed).
+- **MemoryKernel** (`dharma_swarm/memory_kernel/`): Canonical front door for agent memory context; legacy MemoryPlane, RuntimeState facts, MemoryPalace, MemoryLattice, vector, graph, log, and wiki stores are subordinate sources, adapters, projections, or promotion feeds.
 - **TelosGatekeeper** (`dharma_swarm/telos_gates.py`): 11 dharmic safety gates.
 - **StigmergyStore** (`dharma_swarm/stigmergy.py`): Pheromone-trail coordination.
 - **CatalyticGraph** (`dharma_swarm/catalytic_graph.py`): Autocatalytic set detection (Tarjan SCC).

--- a/dharma_swarm/context_compiler.py
+++ b/dharma_swarm/context_compiler.py
@@ -7,13 +7,9 @@ from pathlib import Path
 from typing import Any, Callable
 
 from dharma_swarm.context_compiler_utils import (
-    ContextSection,
-    approx_char_budget as _approx_char_budget,
-    canonical_json as _canonical_json,
-    context_scan_metadata as _context_scan_metadata,
-    dedupe_strings as _dedupe,
-    sha256_text as _sha256,
-    truncate_text as _truncate,
+    ContextSection, approx_char_budget as _approx_char_budget,
+    canonical_json as _canonical_json, context_scan_metadata as _context_scan_metadata,
+    dedupe_strings as _dedupe, sha256_text as _sha256, truncate_text as _truncate,
     utc_now as _utc_now,
 )
 from dharma_swarm.memory_lattice import MemoryLattice, MemoryRecallHit
@@ -25,22 +21,11 @@ from dharma_swarm.memory_kernel.context_compiler_shadow import (
     notify_memory_kernel_context_canary,
     run_memory_kernel_context_canary,
 )
-from dharma_swarm.memory_kernel import (
-    MemoryContextBudget,
-    MemoryContextPack,
-    MemoryKernel,
-    MemoryQuery,
-    TruthState,
-)
+from dharma_swarm.memory_kernel.default_context import build_memory_kernel_default_context
 from dharma_swarm.provider_policy import ProviderPolicyRouter, ProviderRouteRequest
 from dharma_swarm.runtime_state import (
-    ArtifactRecord,
-    ContextBundleRecord,
-    DelegationRun,
-    MemoryFact,
-    RuntimeStateStore,
-    SessionState,
-    WorkspaceLease,
+    ArtifactRecord, ContextBundleRecord, DelegationRun, MemoryFact, RuntimeStateStore,
+    SessionState, WorkspaceLease,
 )
 
 logger = logging.getLogger(__name__)
@@ -81,7 +66,7 @@ class ContextCompiler:
         memory_palace: Any = None,
         graph_store: Any = None,
         knowledge_store: Any = None,
-        memory_kernel: MemoryKernel | None = None,
+        memory_kernel: Any = None,
     ) -> None:
         self.runtime_state = runtime_state
         self.memory_lattice = memory_lattice
@@ -136,9 +121,7 @@ class ContextCompiler:
         memory_kernel_shadow_surfaces: tuple[str, ...] = (),
         memory_kernel_shadow_callback: Callable[[object], object] | None = None,
     ) -> ContextBundleRecord:
-        # ── MemPO-style truncation ──────────────────────────────────
-        # When ENABLE_MEM_TRUNCATION is set and a previous_mem is provided,
-        # replace the full context assembly with a compact summary.
+        # Optional MemPO-style truncation can replace full assembly.
         import os as _os
         _mem_truncation = _os.getenv("ENABLE_MEM_TRUNCATION", "false").strip().lower()
         if (
@@ -289,9 +272,8 @@ class ContextCompiler:
             query=query,
             task_id=task_id,
         )
-        memory_kernel_section, memory_kernel_metadata = self._memory_kernel_section(
-            recall_query=recall_query,
-            token_budget=token_budget,
+        memory_kernel_section, memory_kernel_metadata = build_memory_kernel_default_context(
+            self.memory_kernel, recall_query=recall_query, token_budget=token_budget
         )
         recall_hits = (
             await self.memory_lattice.recall(
@@ -391,9 +373,7 @@ class ContextCompiler:
                     metadata=dict(canary.metadata),
                 ),
             ]
-            source_refs = _dedupe(
-                (*source_refs, *memory_kernel_context_source_refs(canary))
-            )
+            source_refs = _dedupe((*source_refs, *memory_kernel_context_source_refs(canary)))
         created_at = _utc_now()
         checksum = _sha256(
             _canonical_json(
@@ -552,7 +532,6 @@ class ContextCompiler:
 
         if memory_kernel_section is not None:
             sections.append(memory_kernel_section)
-
         if always_on.strip():
             sections.append(
                 ContextSection(
@@ -712,69 +691,6 @@ class ContextCompiler:
             )
 
         return sections
-
-    def _memory_kernel_section(
-        self,
-        *,
-        recall_query: str,
-        token_budget: int,
-    ) -> tuple[ContextSection | None, dict[str, Any]]:
-        if self.memory_kernel is None:
-            return None, {"status": "not_configured"}
-
-        try:
-            atom_budget = max(4, min(24, int(token_budget) // 100))
-            pack = self.memory_kernel.preview_memory_pack(
-                query=MemoryQuery(
-                    limit_total=atom_budget,
-                    limit_per_surface=atom_budget,
-                    include_content=True,
-                    max_canon_risk=None,
-                    max_pii_risk=None,
-                    include_high_risk=False,
-                    include_projections=False,
-                    include_unsafe=False,
-                    require_source_digest=True,
-                    require_source_row_key=True,
-                ),
-                budget=MemoryContextBudget(
-                    max_candidate_atoms=atom_budget,
-                    max_admitted_atoms=max(1, min(8, atom_budget)),
-                    max_total_chars=max(600, min(2400, int(token_budget) * 2)),
-                    max_atom_chars=420,
-                    include_content=True,
-                    require_context_admissible=False,
-                    allow_projections=False,
-                    allow_high_risk=False,
-                    allowed_truth_states=(
-                        TruthState.OBSERVED,
-                        TruthState.CLAIMED,
-                        TruthState.CURATED,
-                        TruthState.CANONICAL,
-                    ),
-                ),
-            )
-        except Exception as exc:
-            logger.debug("Memory Kernel default context failed", exc_info=True)
-            return None, {
-                "status": "failed",
-                "error_type": type(exc).__name__,
-                "error": str(exc)[:240],
-            }
-
-        metadata = _memory_kernel_pack_metadata(pack)
-        metadata["status"] = "used"
-        metadata["query_present"] = bool(recall_query)
-        return (
-            ContextSection(
-                name="Memory Kernel",
-                priority=4,
-                content=_format_memory_kernel_pack(pack),
-                source_refs=_memory_kernel_pack_source_refs(pack),
-                metadata=metadata,
-            ),
-            metadata,
-        )
 
     def _fit_sections(
         self,
@@ -1080,75 +996,3 @@ class ContextCompiler:
             logger.debug("Semantic graph query failed: %s", exc)
 
         return results
-
-
-def _memory_kernel_pack_metadata(pack: MemoryContextPack) -> dict[str, Any]:
-    return {
-        "pack_id": pack.pack_id,
-        "candidate_count": pack.candidate_count,
-        "admitted_count": pack.admitted_count,
-        "omitted_count": pack.omitted_count,
-        "candidate_truncated": pack.candidate_truncated,
-        "warnings": list(pack.warnings),
-    }
-
-
-def _memory_kernel_pack_source_refs(pack: MemoryContextPack) -> list[str]:
-    refs: list[str] = []
-    for item in pack.items:
-        if not item.admitted:
-            continue
-        refs.append(f"memory_kernel:{item.surface_id}")
-        refs.extend(item.source_refs)
-    return _dedupe(refs)
-
-
-def _format_memory_kernel_pack(pack: MemoryContextPack) -> str:
-    lines = [
-        f"- pack_id={pack.pack_id}",
-        f"- candidates={pack.candidate_count}",
-        f"- admitted={pack.admitted_count}",
-        f"- omitted={pack.omitted_count}",
-    ]
-    if pack.warnings:
-        lines.append(f"- warnings={', '.join(str(item) for item in pack.warnings)}")
-
-    admitted = [item for item in pack.items if item.admitted]
-    if admitted:
-        lines.extend(["", "Admitted atoms:"])
-        for item in admitted[:8]:
-            lines.append(
-                "- "
-                f"rank={item.rank} surface={item.surface_id} "
-                f"type={_enum_value(item.atom_type)} truth={_enum_value(item.truth_state)} "
-                f"authority={_enum_value(item.authority_level)}"
-            )
-            if item.selection_reasons:
-                lines.append(f"  reasons={', '.join(item.selection_reasons)}")
-            if item.content_snippet:
-                lines.append(f"  snippet={_inline_context(item.content_snippet, 420)}")
-    else:
-        lines.extend(["", "Admitted atoms:", "- none"])
-
-    omitted = [item for item in pack.items if not item.admitted]
-    if omitted:
-        lines.extend(["", "Omitted atoms:"])
-        for item in omitted[:8]:
-            lines.append(
-                "- "
-                f"surface={item.surface_id} type={_enum_value(item.atom_type)} "
-                f"truth={_enum_value(item.truth_state)} "
-                f"reasons={', '.join(item.omission_reasons)}"
-            )
-    return "\n".join(lines)
-
-
-def _enum_value(value: Any) -> str:
-    return str(getattr(value, "value", value))
-
-
-def _inline_context(value: str, max_chars: int) -> str:
-    text = " ".join(str(value).split())
-    if len(text) <= max_chars:
-        return text
-    return text[: max(0, max_chars - 14)].rstrip() + "...<truncated>"

--- a/dharma_swarm/context_compiler.py
+++ b/dharma_swarm/context_compiler.py
@@ -25,6 +25,13 @@ from dharma_swarm.memory_kernel.context_compiler_shadow import (
     notify_memory_kernel_context_canary,
     run_memory_kernel_context_canary,
 )
+from dharma_swarm.memory_kernel import (
+    MemoryContextBudget,
+    MemoryContextPack,
+    MemoryKernel,
+    MemoryQuery,
+    TruthState,
+)
 from dharma_swarm.provider_policy import ProviderPolicyRouter, ProviderRouteRequest
 from dharma_swarm.runtime_state import (
     ArtifactRecord,
@@ -53,13 +60,14 @@ class ContextCompiler:
         "Governance": 0.09,
         "Operator Intent": 0.10,
         "Task State": 0.10,
-        "Always-On Memory": 0.12,
-        "Relevant Knowledge": 0.10,  # Sprint 2: PlugMem knowledge block
-        "Recent Session": 0.09,
-        "Retrieved Recall": 0.09,
-        "Memory Palace": 0.09,
-        "Semantic Context": 0.05,
-        "Durable Facts": 0.08,
+        "Memory Kernel": 0.12,
+        "Always-On Memory": 0.09,
+        "Relevant Knowledge": 0.08,  # Sprint 2: PlugMem knowledge block
+        "Recent Session": 0.08,
+        "Retrieved Recall": 0.07,
+        "Memory Palace": 0.07,
+        "Semantic Context": 0.04,
+        "Durable Facts": 0.07,
         "Artifacts": 0.05,
         "Workspace": 0.04,
     }
@@ -73,6 +81,7 @@ class ContextCompiler:
         memory_palace: Any = None,
         graph_store: Any = None,
         knowledge_store: Any = None,
+        memory_kernel: MemoryKernel | None = None,
     ) -> None:
         self.runtime_state = runtime_state
         self.memory_lattice = memory_lattice
@@ -80,6 +89,7 @@ class ContextCompiler:
         self.memory_palace = memory_palace
         self.graph_store = graph_store  # Phase 7b: semantic graph
         self.knowledge_store = knowledge_store  # Sprint 2: PlugMem knowledge store
+        self.memory_kernel = memory_kernel
         # Frozen snapshot cache: session_id -> ContextBundleRecord
         self._frozen_bundles: dict[str, ContextBundleRecord] = {}
 
@@ -279,6 +289,10 @@ class ContextCompiler:
             query=query,
             task_id=task_id,
         )
+        memory_kernel_section, memory_kernel_metadata = self._memory_kernel_section(
+            recall_query=recall_query,
+            token_budget=token_budget,
+        )
         recall_hits = (
             await self.memory_lattice.recall(
                 recall_query,
@@ -324,6 +338,7 @@ class ContextCompiler:
             task_description=task_description,
             policy_constraints=policy_constraints or [],
             provider_request=provider_request,
+            memory_kernel_section=memory_kernel_section,
             always_on=always_on,
             recent_events=recent_events,
             recall_hits=recall_hits,
@@ -392,6 +407,8 @@ class ContextCompiler:
             )
         )
         bundle_metadata = memory_kernel_context_metadata(metadata, canary)
+        if memory_kernel_metadata:
+            bundle_metadata["memory_kernel_default"] = memory_kernel_metadata
         bundle_metadata["context_scan"] = _context_scan_metadata(rendered_text)
         bundle = ContextBundleRecord(
             bundle_id=self.runtime_state.new_bundle_id(),
@@ -449,6 +466,7 @@ class ContextCompiler:
         task_description: str,
         policy_constraints: list[str],
         provider_request: ProviderRouteRequest | None,
+        memory_kernel_section: ContextSection | None,
         always_on: str,
         recent_events: list[dict[str, Any]],
         recall_hits: list[MemoryRecallHit],
@@ -531,6 +549,9 @@ class ContextCompiler:
                     source_refs=[],
                 )
             )
+
+        if memory_kernel_section is not None:
+            sections.append(memory_kernel_section)
 
         if always_on.strip():
             sections.append(
@@ -691,6 +712,69 @@ class ContextCompiler:
             )
 
         return sections
+
+    def _memory_kernel_section(
+        self,
+        *,
+        recall_query: str,
+        token_budget: int,
+    ) -> tuple[ContextSection | None, dict[str, Any]]:
+        if self.memory_kernel is None:
+            return None, {"status": "not_configured"}
+
+        try:
+            atom_budget = max(4, min(24, int(token_budget) // 100))
+            pack = self.memory_kernel.preview_memory_pack(
+                query=MemoryQuery(
+                    limit_total=atom_budget,
+                    limit_per_surface=atom_budget,
+                    include_content=True,
+                    max_canon_risk=None,
+                    max_pii_risk=None,
+                    include_high_risk=False,
+                    include_projections=False,
+                    include_unsafe=False,
+                    require_source_digest=True,
+                    require_source_row_key=True,
+                ),
+                budget=MemoryContextBudget(
+                    max_candidate_atoms=atom_budget,
+                    max_admitted_atoms=max(1, min(8, atom_budget)),
+                    max_total_chars=max(600, min(2400, int(token_budget) * 2)),
+                    max_atom_chars=420,
+                    include_content=True,
+                    require_context_admissible=False,
+                    allow_projections=False,
+                    allow_high_risk=False,
+                    allowed_truth_states=(
+                        TruthState.OBSERVED,
+                        TruthState.CLAIMED,
+                        TruthState.CURATED,
+                        TruthState.CANONICAL,
+                    ),
+                ),
+            )
+        except Exception as exc:
+            logger.debug("Memory Kernel default context failed", exc_info=True)
+            return None, {
+                "status": "failed",
+                "error_type": type(exc).__name__,
+                "error": str(exc)[:240],
+            }
+
+        metadata = _memory_kernel_pack_metadata(pack)
+        metadata["status"] = "used"
+        metadata["query_present"] = bool(recall_query)
+        return (
+            ContextSection(
+                name="Memory Kernel",
+                priority=4,
+                content=_format_memory_kernel_pack(pack),
+                source_refs=_memory_kernel_pack_source_refs(pack),
+                metadata=metadata,
+            ),
+            metadata,
+        )
 
     def _fit_sections(
         self,
@@ -996,3 +1080,75 @@ class ContextCompiler:
             logger.debug("Semantic graph query failed: %s", exc)
 
         return results
+
+
+def _memory_kernel_pack_metadata(pack: MemoryContextPack) -> dict[str, Any]:
+    return {
+        "pack_id": pack.pack_id,
+        "candidate_count": pack.candidate_count,
+        "admitted_count": pack.admitted_count,
+        "omitted_count": pack.omitted_count,
+        "candidate_truncated": pack.candidate_truncated,
+        "warnings": list(pack.warnings),
+    }
+
+
+def _memory_kernel_pack_source_refs(pack: MemoryContextPack) -> list[str]:
+    refs: list[str] = []
+    for item in pack.items:
+        if not item.admitted:
+            continue
+        refs.append(f"memory_kernel:{item.surface_id}")
+        refs.extend(item.source_refs)
+    return _dedupe(refs)
+
+
+def _format_memory_kernel_pack(pack: MemoryContextPack) -> str:
+    lines = [
+        f"- pack_id={pack.pack_id}",
+        f"- candidates={pack.candidate_count}",
+        f"- admitted={pack.admitted_count}",
+        f"- omitted={pack.omitted_count}",
+    ]
+    if pack.warnings:
+        lines.append(f"- warnings={', '.join(str(item) for item in pack.warnings)}")
+
+    admitted = [item for item in pack.items if item.admitted]
+    if admitted:
+        lines.extend(["", "Admitted atoms:"])
+        for item in admitted[:8]:
+            lines.append(
+                "- "
+                f"rank={item.rank} surface={item.surface_id} "
+                f"type={_enum_value(item.atom_type)} truth={_enum_value(item.truth_state)} "
+                f"authority={_enum_value(item.authority_level)}"
+            )
+            if item.selection_reasons:
+                lines.append(f"  reasons={', '.join(item.selection_reasons)}")
+            if item.content_snippet:
+                lines.append(f"  snippet={_inline_context(item.content_snippet, 420)}")
+    else:
+        lines.extend(["", "Admitted atoms:", "- none"])
+
+    omitted = [item for item in pack.items if not item.admitted]
+    if omitted:
+        lines.extend(["", "Omitted atoms:"])
+        for item in omitted[:8]:
+            lines.append(
+                "- "
+                f"surface={item.surface_id} type={_enum_value(item.atom_type)} "
+                f"truth={_enum_value(item.truth_state)} "
+                f"reasons={', '.join(item.omission_reasons)}"
+            )
+    return "\n".join(lines)
+
+
+def _enum_value(value: Any) -> str:
+    return str(getattr(value, "value", value))
+
+
+def _inline_context(value: str, max_chars: int) -> str:
+    text = " ".join(str(value).split())
+    if len(text) <= max_chars:
+        return text
+    return text[: max(0, max_chars - 14)].rstrip() + "...<truncated>"

--- a/dharma_swarm/memory_kernel/default_context.py
+++ b/dharma_swarm/memory_kernel/default_context.py
@@ -1,0 +1,155 @@
+"""Default Memory Kernel context section helpers."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from dharma_swarm.context_compiler_utils import (
+    ContextSection,
+    dedupe_strings as _dedupe,
+)
+from dharma_swarm.memory_kernel import (
+    MemoryContextBudget,
+    MemoryContextPack,
+    MemoryQuery,
+    TruthState,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def build_memory_kernel_default_context(
+    memory_kernel: Any,
+    *,
+    recall_query: str,
+    token_budget: int,
+) -> tuple[ContextSection | None, dict[str, Any]]:
+    if memory_kernel is None:
+        return None, {"status": "not_configured"}
+
+    try:
+        atom_budget = max(4, min(24, int(token_budget) // 100))
+        pack = memory_kernel.preview_memory_pack(
+            query=MemoryQuery(
+                limit_total=atom_budget,
+                limit_per_surface=atom_budget,
+                include_content=True,
+                max_canon_risk=None,
+                max_pii_risk=None,
+                include_high_risk=False,
+                include_projections=False,
+                include_unsafe=False,
+                require_source_digest=True,
+                require_source_row_key=True,
+            ),
+            budget=MemoryContextBudget(
+                max_candidate_atoms=atom_budget,
+                max_admitted_atoms=max(1, min(8, atom_budget)),
+                max_total_chars=max(600, min(2400, int(token_budget) * 2)),
+                max_atom_chars=420,
+                include_content=True,
+                require_context_admissible=False,
+                allow_projections=False,
+                allow_high_risk=False,
+                allowed_truth_states=(
+                    TruthState.OBSERVED,
+                    TruthState.CLAIMED,
+                    TruthState.CURATED,
+                    TruthState.CANONICAL,
+                ),
+            ),
+        )
+    except Exception as exc:
+        logger.debug("Memory Kernel default context failed", exc_info=True)
+        return None, {
+            "status": "failed",
+            "error_type": type(exc).__name__,
+            "error": str(exc)[:240],
+        }
+
+    metadata = memory_kernel_pack_metadata(pack)
+    metadata["status"] = "used"
+    metadata["query_present"] = bool(recall_query)
+    return (
+        ContextSection(
+            name="Memory Kernel",
+            priority=4,
+            content=format_memory_kernel_pack(pack),
+            source_refs=memory_kernel_pack_source_refs(pack),
+            metadata=metadata,
+        ),
+        metadata,
+    )
+
+
+def memory_kernel_pack_metadata(pack: MemoryContextPack) -> dict[str, Any]:
+    return {
+        "pack_id": pack.pack_id,
+        "candidate_count": pack.candidate_count,
+        "admitted_count": pack.admitted_count,
+        "omitted_count": pack.omitted_count,
+        "candidate_truncated": pack.candidate_truncated,
+        "warnings": list(pack.warnings),
+    }
+
+
+def memory_kernel_pack_source_refs(pack: MemoryContextPack) -> list[str]:
+    refs: list[str] = []
+    for item in pack.items:
+        if not item.admitted:
+            continue
+        refs.append(f"memory_kernel:{item.surface_id}")
+        refs.extend(item.source_refs)
+    return _dedupe(refs)
+
+
+def format_memory_kernel_pack(pack: MemoryContextPack) -> str:
+    lines = [
+        f"- pack_id={pack.pack_id}",
+        f"- candidates={pack.candidate_count}",
+        f"- admitted={pack.admitted_count}",
+        f"- omitted={pack.omitted_count}",
+    ]
+    if pack.warnings:
+        lines.append(f"- warnings={', '.join(str(item) for item in pack.warnings)}")
+
+    admitted = [item for item in pack.items if item.admitted]
+    if admitted:
+        lines.extend(["", "Admitted atoms:"])
+        for item in admitted[:8]:
+            lines.append(
+                "- "
+                f"rank={item.rank} surface={item.surface_id} "
+                f"type={_enum_value(item.atom_type)} truth={_enum_value(item.truth_state)} "
+                f"authority={_enum_value(item.authority_level)}"
+            )
+            if item.selection_reasons:
+                lines.append(f"  reasons={', '.join(item.selection_reasons)}")
+            if item.content_snippet:
+                lines.append(f"  snippet={_inline_context(item.content_snippet, 420)}")
+    else:
+        lines.extend(["", "Admitted atoms:", "- none"])
+
+    omitted = [item for item in pack.items if not item.admitted]
+    if omitted:
+        lines.extend(["", "Omitted atoms:"])
+        for item in omitted[:8]:
+            lines.append(
+                "- "
+                f"surface={item.surface_id} type={_enum_value(item.atom_type)} "
+                f"truth={_enum_value(item.truth_state)} "
+                f"reasons={', '.join(item.omission_reasons)}"
+            )
+    return "\n".join(lines)
+
+
+def _enum_value(value: Any) -> str:
+    return str(getattr(value, "value", value))
+
+
+def _inline_context(value: str, max_chars: int) -> str:
+    text = " ".join(str(value).split())
+    if len(text) <= max_chars:
+        return text
+    return text[: max(0, max_chars - 14)].rstrip() + "...<truncated>"

--- a/dharma_swarm/memory_kernel/orchestrator_context.py
+++ b/dharma_swarm/memory_kernel/orchestrator_context.py
@@ -1,0 +1,47 @@
+"""Orchestrator helpers for Memory Kernel-backed context bundles."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+MEMORY_KERNEL_DISPATCH_KEYS = (
+    "memory_kernel_status",
+    "memory_kernel_pack_id",
+    "memory_kernel_admitted_count",
+    "memory_kernel_omitted_count",
+    "memory_kernel_warnings",
+)
+
+
+def build_orchestrator_memory_kernel(*, repo_root: Path) -> Any:
+    from dharma_swarm.memory_kernel import CensusConfig, MemoryKernel, MemoryKernelConfig
+
+    memory_kernel_home = Path(
+        os.getenv("DHARMA_MEMORY_KERNEL_HOME") or Path.home()
+    ).expanduser()
+    return MemoryKernel(
+        MemoryKernelConfig(
+            census=CensusConfig(
+                repo_root=repo_root,
+                home=memory_kernel_home,
+                include_discovered=False,
+            )
+        )
+    )
+
+
+def memory_kernel_dispatch_metadata(
+    bundle_metadata: dict[str, Any],
+) -> dict[str, Any]:
+    kernel_meta = dict(bundle_metadata.get("memory_kernel_default") or {})
+    if not kernel_meta:
+        return {}
+    return {
+        "memory_kernel_status": kernel_meta.get("status", "unknown"),
+        "memory_kernel_pack_id": kernel_meta.get("pack_id", ""),
+        "memory_kernel_admitted_count": kernel_meta.get("admitted_count", 0),
+        "memory_kernel_omitted_count": kernel_meta.get("omitted_count", 0),
+        "memory_kernel_warnings": kernel_meta.get("warnings", []),
+    }

--- a/dharma_swarm/orchestrator.py
+++ b/dharma_swarm/orchestrator.py
@@ -916,13 +916,11 @@ class Orchestrator:
             meta["context_bundle_status"] = "missing_task"
             td.metadata["context_bundle_status"] = "missing_task"
             return meta
-
         store = self._runtime_lifecycle._runtime_state_store()
         if store is None:
             meta["context_bundle_status"] = "missing_runtime_state"
             td.metadata["context_bundle_status"] = "missing_runtime_state"
             return meta
-
         run_id = self._runtime_lifecycle.ensure_runtime_run_id(td)
         runtime_root = self._runtime_root()
         operator_intent = self._operator_intent_for_task(task, meta)
@@ -941,7 +939,6 @@ class Orchestrator:
                 build_orchestrator_memory_kernel,
                 memory_kernel_dispatch_metadata,
             )
-
             lattice = MemoryLattice(
                 db_path=store.db_path,
                 event_log_dir=runtime_root / "events",
@@ -987,7 +984,6 @@ class Orchestrator:
                     await lattice.close()
                 except Exception:
                     logger.debug("Memory lattice close failed", exc_info=True)
-
         bundle_id = bundle.bundle_id
         runtime_db_path = str(store.db_path)
         state_dir = str(runtime_root)
@@ -1061,10 +1057,8 @@ class Orchestrator:
     ) -> AgentState | None:
         if not idle_agents:
             return None
-
         preferred_names = self._task_preferred_agent_names(task)
         preferred_roles = self._task_preferred_roles(task)
-
         # Prefer exact agent-name routing when the task already knows its seats.
         name_matched: list[AgentState] = []
         if preferred_names:
@@ -1079,14 +1073,12 @@ class Orchestrator:
                     name_matched.append(agent)
                     seen.add(agent.id)
                     break
-
         # Collect ALL role-matched candidates (not just first match)
         role_matched: list[AgentState] = []
         for agent in idle_agents:
             role_value = str(getattr(agent.role, "value", agent.role)).lower()
             if any(role_value == p for p in preferred_roles):
                 role_matched.append(agent)
-
         # Pick from name-matched subset first, then role-matched subset, else all candidates.
         candidates = name_matched or role_matched or list(idle_agents)
 
@@ -1095,7 +1087,6 @@ class Orchestrator:
         if best is not None:
             idle_agents.remove(best)
             return best
-
         # Fitness-biased selection (feature-flagged, best-effort)
         best = self._fitness_biased_pick(candidates, task)
         if best is not None:

--- a/dharma_swarm/orchestrator.py
+++ b/dharma_swarm/orchestrator.py
@@ -936,32 +936,20 @@ class Orchestrator:
         try:
             from dharma_swarm.context_compiler import ContextCompiler
             from dharma_swarm.memory_lattice import MemoryLattice
-            from dharma_swarm.memory_kernel import (
-                CensusConfig,
-                MemoryKernel,
-                MemoryKernelConfig,
+            from dharma_swarm.memory_kernel.orchestrator_context import (
+                MEMORY_KERNEL_DISPATCH_KEYS,
+                build_orchestrator_memory_kernel,
+                memory_kernel_dispatch_metadata,
             )
 
             lattice = MemoryLattice(
                 db_path=store.db_path,
                 event_log_dir=runtime_root / "events",
             )
-            memory_kernel_home = Path(
-                os.getenv("DHARMA_MEMORY_KERNEL_HOME") or Path.home()
-            ).expanduser()
-            memory_kernel = MemoryKernel(
-                MemoryKernelConfig(
-                    census=CensusConfig(
-                        repo_root=Path.cwd(),
-                        home=memory_kernel_home,
-                        include_discovered=False,
-                    )
-                )
-            )
             compiler = ContextCompiler(
                 runtime_state=store,
                 memory_lattice=lattice,
-                memory_kernel=memory_kernel,
+                memory_kernel=build_orchestrator_memory_kernel(repo_root=Path.cwd()),
             )
             bundle = await compiler.compile_bundle(
                 session_id=self._ledger.session_id,
@@ -978,19 +966,7 @@ class Orchestrator:
                 },
                 workspace_root=runtime_root,
             )
-            kernel_meta = dict(bundle.metadata.get("memory_kernel_default") or {})
-            if kernel_meta:
-                meta["memory_kernel_status"] = kernel_meta.get("status", "unknown")
-                meta["memory_kernel_pack_id"] = kernel_meta.get("pack_id", "")
-                meta["memory_kernel_admitted_count"] = kernel_meta.get(
-                    "admitted_count",
-                    0,
-                )
-                meta["memory_kernel_omitted_count"] = kernel_meta.get(
-                    "omitted_count",
-                    0,
-                )
-                meta["memory_kernel_warnings"] = kernel_meta.get("warnings", [])
+            meta.update(memory_kernel_dispatch_metadata(bundle.metadata))
         except Exception as exc:
             error = str(exc)[:300]
             meta["context_bundle_status"] = "failed"
@@ -1024,13 +1000,7 @@ class Orchestrator:
         td.metadata["context_bundle_status"] = "attached"
         td.metadata["runtime_db_path"] = runtime_db_path
         td.metadata.setdefault("state_dir", state_dir)
-        for key in (
-            "memory_kernel_status",
-            "memory_kernel_pack_id",
-            "memory_kernel_admitted_count",
-            "memory_kernel_omitted_count",
-            "memory_kernel_warnings",
-        ):
+        for key in MEMORY_KERNEL_DISPATCH_KEYS:
             if key in meta:
                 td.metadata[key] = meta[key]
         return meta
@@ -1156,7 +1126,6 @@ class Orchestrator:
         if len(candidates) <= 1:
             return candidates[0] if candidates else None
 
-        import os
         if os.getenv("ENABLE_EFE_ROUTING", "").lower() not in ("1", "true", "yes"):
             return None  # Falls through to fitness-biased or FIFO
 
@@ -1192,7 +1161,6 @@ class Orchestrator:
             return candidates[0] if candidates else None
 
         # Feature flag: ENABLE_FITNESS_ROUTING (default off until enough data)
-        import os
         if os.getenv("ENABLE_FITNESS_ROUTING", "").lower() not in ("1", "true", "yes"):
             return None  # Falls through to FIFO
 

--- a/dharma_swarm/orchestrator.py
+++ b/dharma_swarm/orchestrator.py
@@ -19,6 +19,7 @@ import hashlib
 import inspect
 import json
 import logging
+import os
 import re
 import time
 from datetime import datetime, timezone
@@ -935,14 +936,32 @@ class Orchestrator:
         try:
             from dharma_swarm.context_compiler import ContextCompiler
             from dharma_swarm.memory_lattice import MemoryLattice
+            from dharma_swarm.memory_kernel import (
+                CensusConfig,
+                MemoryKernel,
+                MemoryKernelConfig,
+            )
 
             lattice = MemoryLattice(
                 db_path=store.db_path,
                 event_log_dir=runtime_root / "events",
             )
+            memory_kernel_home = Path(
+                os.getenv("DHARMA_MEMORY_KERNEL_HOME") or Path.home()
+            ).expanduser()
+            memory_kernel = MemoryKernel(
+                MemoryKernelConfig(
+                    census=CensusConfig(
+                        repo_root=Path.cwd(),
+                        home=memory_kernel_home,
+                        include_discovered=False,
+                    )
+                )
+            )
             compiler = ContextCompiler(
                 runtime_state=store,
                 memory_lattice=lattice,
+                memory_kernel=memory_kernel,
             )
             bundle = await compiler.compile_bundle(
                 session_id=self._ledger.session_id,
@@ -959,6 +978,19 @@ class Orchestrator:
                 },
                 workspace_root=runtime_root,
             )
+            kernel_meta = dict(bundle.metadata.get("memory_kernel_default") or {})
+            if kernel_meta:
+                meta["memory_kernel_status"] = kernel_meta.get("status", "unknown")
+                meta["memory_kernel_pack_id"] = kernel_meta.get("pack_id", "")
+                meta["memory_kernel_admitted_count"] = kernel_meta.get(
+                    "admitted_count",
+                    0,
+                )
+                meta["memory_kernel_omitted_count"] = kernel_meta.get(
+                    "omitted_count",
+                    0,
+                )
+                meta["memory_kernel_warnings"] = kernel_meta.get("warnings", [])
         except Exception as exc:
             error = str(exc)[:300]
             meta["context_bundle_status"] = "failed"
@@ -992,6 +1024,15 @@ class Orchestrator:
         td.metadata["context_bundle_status"] = "attached"
         td.metadata["runtime_db_path"] = runtime_db_path
         td.metadata.setdefault("state_dir", state_dir)
+        for key in (
+            "memory_kernel_status",
+            "memory_kernel_pack_id",
+            "memory_kernel_admitted_count",
+            "memory_kernel_omitted_count",
+            "memory_kernel_warnings",
+        ):
+            if key in meta:
+                td.metadata[key] = meta[key]
         return meta
 
     @staticmethod

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -16,6 +16,10 @@ hints, and the doc-ownership map. If any prose in this file or any other
 doc disagrees with that output, trust the onboarding output and update the
 stale prose.
 
+For memory/context work, Memory Kernel is the canonical front door. Older
+memory surfaces remain subordinate evidence, projection, adapter, backend, or
+promotion-feed layers unless the Memory Kernel production bar says otherwise.
+
 ## Authority Model
 
 Do not infer authority from confident language.

--- a/docs/architecture/MEMORY_KERNEL_PROD_BAR.md
+++ b/docs/architecture/MEMORY_KERNEL_PROD_BAR.md
@@ -1,6 +1,6 @@
 # Memory Kernel Production Bar
 
-Status: pre-merge hardening contract
+Status: post-merge rollout contract
 Date: 2026-05-23
 
 ## Purpose
@@ -10,9 +10,9 @@ central database, and it is not allowed to become another competing memory
 surface.
 
 This document defines the bar for calling Memory Kernel production-integrated.
-The read-only/shadow release may merge before every item below is live, but no
-agent, dashboard, PR, or audit may describe the system as production memory
-unless these invariants hold.
+The read-only/shadow release has merged. The next rollout step is default
+runtime read-path use. No agent, dashboard, PR, or audit may describe the
+system as production memory unless these invariants hold.
 
 ## Production Meaning
 
@@ -93,11 +93,12 @@ Canonical memory requires a governed promotion path.
 - Vector, LanceDB, graph, retrieval feedback, routing memory, raw logs, and
   generated summaries cannot become canon by retrieval score alone.
 
-## Merge Boundary
+## Runtime Default Boundary
 
-The current Memory Kernel release may merge as read-only/shadow infrastructure
-when the readiness, writer sentinel, context eval, and focused tests pass.
+The current Memory Kernel release is allowed to become the default context
+read path when the readiness, writer sentinel, context eval, focused tests, and
+operator smoke checks pass.
 
-It must not be called full production memory until the default agent context
-path, write policy, Lattice/Palace subordination, and promotion gates are all
-enforced in runtime code.
+It must not be called full production memory until the write policy,
+Lattice/Palace subordination, and promotion gates are all enforced in runtime
+code.

--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -6,16 +6,16 @@ Do not hand-edit the generated block.
 <!-- DOCOPS:START metric=repo_inventory -->
 | Metric | Value |
 |---|---:|
-| Dharma Python modules | 666 |
+| Dharma Python modules | 668 |
 | Top-level Dharma Python modules | 391 |
-| Dharma Python LOC | 283,300 |
-| Test files | 638 |
-| Test function occurrences | 11,002 |
+| Dharma Python LOC | 283,502 |
+| Test files | 639 |
+| Test function occurrences | 11,005 |
 | Markdown files | 851 |
-| Markdown total lines | 210,818 |
+| Markdown total lines | 210,824 |
 | Bridge files | 24 |
 | Adapter files | 21 |
-| Orchestrator files | 4 |
+| Orchestrator files | 5 |
 | Router files | 14 |
 | Authority candidate docs | 372 |
 <!-- DOCOPS:END -->

--- a/docs/governance/SOVEREIGN_MANIFEST.md
+++ b/docs/governance/SOVEREIGN_MANIFEST.md
@@ -117,15 +117,15 @@ These are the ground-truth metrics. All other documents citing different numbers
 
 | Metric | Value | Verification |
 |--------|-------|-------------|
-| Total Python modules | **666** | find dharma_swarm -name "*.py" -type f |
+| Total Python modules | **668** | find dharma_swarm -name "*.py" -type f |
 | Top-level (flat) modules | **391 (58.7%)** | find dharma_swarm -maxdepth 1 -name "*.py" -type f |
 | Total Python LOC | **283,300** | wc -l across dharma_swarm Python modules |
-| Test files | **638** | find tests -name "*.py" -type f |
-| Test functions | **11,002 `def test_` occurrences under tests/** | rg "def test_" tests |
+| Test files | **639** | find tests -name "*.py" -type f |
+| Test functions | **11,005 `def test_` occurrences under tests/** | rg "def test_" tests |
 | Tests collected (pytest) | **Needs write-permitted refresh** | not run during this DocOps count pass |
 | Collection errors | **Historical: 16 on 2026-04-04** | refresh before relying on this count |
 | Markdown files | **851** | find . -name "*.md" -type f |
-| Markdown total lines | **210,818** | wc -l across all .md |
+| Markdown total lines | **210,824** | wc -l across all .md |
 | Bridge files | **24** | find dharma_swarm -name "*bridge*.py" |
 | Adapter files | **21 across 8 locations** | find dharma_swarm -type f \| rg -i "adapter" |
 | Orchestrator files | **4** (6,034 LOC total) | find dharma_swarm -name "*orchestrat*" |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "dharma-swarm",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "dharma-swarm",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/scripts/governance/check_memory_kernel_canonical.py
+++ b/scripts/governance/check_memory_kernel_canonical.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Prevent new memory-authority sprawl outside the Memory Kernel boundary."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import fnmatch
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+AUTHORITY_EXACT_NAMES = {
+    "MemoryKernel",
+    "MemoryPlane",
+}
+AUTHORITY_SUFFIXES = (
+    "MemoryStore",
+    "MemoryRouter",
+    "MemoryRegistry",
+    "MemorySubstrate",
+)
+AUTHORITY_MODULE_NAMES = {
+    "memory_kernel.py",
+    "memory_plane.py",
+    "memory_router.py",
+    "memory_registry.py",
+    "memory_substrate.py",
+}
+AUTHORITY_MODULE_SUFFIXES = (
+    "_memory_store.py",
+    "_memory_router.py",
+    "_memory_registry.py",
+    "_memory_substrate.py",
+)
+ALLOWLIST_PATTERNS = (
+    "dharma_swarm/memory_kernel/**",
+    "dharma_swarm/contracts/intelligence.py",
+    "dharma_swarm/contracts/intelligence_adapters.py",
+    "dharma_swarm/contracts/intelligence_evaluation_services.py",
+    "dharma_swarm/contracts/intelligence_stack.py",
+    "dharma_swarm/runtime_state.py",
+    "dharma_swarm/memory_lattice.py",
+    "dharma_swarm/memory_palace.py",
+    "dharma_swarm/routing_memory.py",
+    "dharma_swarm/engine/event_memory.py",
+    "dharma_swarm/engine/conversation_memory.py",
+    "dharma_swarm/engine/knowledge_store.py",
+    "scripts/governance/check_memory_kernel_canonical.py",
+)
+
+
+@dataclass(frozen=True)
+class Finding:
+    path: str
+    line: int
+    name: str
+    reason: str
+
+    def render(self) -> str:
+        if self.line:
+            return f"  {self.path}:{self.line}  {self.name} ({self.reason})"
+        return f"  {self.path}  {self.name} ({self.reason})"
+
+
+def path_matches(rel_path: str, pattern: str) -> bool:
+    if pattern.endswith("/**"):
+        return rel_path.startswith(pattern[:-3])
+    return fnmatch.fnmatch(rel_path, pattern)
+
+
+def is_allowlisted(rel_path: str) -> bool:
+    return any(path_matches(rel_path, pattern) for pattern in ALLOWLIST_PATTERNS)
+
+
+def is_test_path(rel_path: str) -> bool:
+    path = Path(rel_path)
+    return rel_path.startswith("tests/") or "/tests/" in rel_path or path.name.startswith("test_")
+
+
+def looks_authoritative_name(name: str) -> bool:
+    return name in AUTHORITY_EXACT_NAMES or name.endswith(AUTHORITY_SUFFIXES)
+
+
+def looks_authoritative_module(path: Path) -> bool:
+    name = path.name
+    return name in AUTHORITY_MODULE_NAMES or name.endswith(AUTHORITY_MODULE_SUFFIXES)
+
+
+def scan_text(rel_path: str, text: str) -> list[Finding]:
+    if is_test_path(rel_path) or is_allowlisted(rel_path):
+        return []
+
+    findings: list[Finding] = []
+    path = Path(rel_path)
+    if looks_authoritative_module(path):
+        findings.append(
+            Finding(
+                path=rel_path,
+                line=0,
+                name=path.name,
+                reason="authority-looking module outside Memory Kernel allowlist",
+            )
+        )
+
+    try:
+        tree = ast.parse(text, filename=rel_path)
+    except SyntaxError:
+        return findings
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and looks_authoritative_name(node.name):
+            findings.append(
+                Finding(
+                    path=rel_path,
+                    line=node.lineno,
+                    name=node.name,
+                    reason="authority-looking class outside Memory Kernel allowlist",
+                )
+            )
+    return findings
+
+
+def run_git(args: list[str]) -> list[str]:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode:
+        return []
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def changed_paths(base_ref: str, head_ref: str, include_worktree: bool) -> list[Path]:
+    rel_paths: set[str] = set()
+    for rel in run_git(
+        ["diff", "--name-only", "--diff-filter=AM", f"{base_ref}...{head_ref}", "--", "*.py"]
+    ):
+        rel_paths.add(rel)
+    if include_worktree:
+        for rel in run_git(["diff", "--name-only", "--diff-filter=AM", "--", "*.py"]):
+            rel_paths.add(rel)
+        for rel in run_git(["ls-files", "--others", "--exclude-standard", "--", "*.py"]):
+            rel_paths.add(rel)
+    return sorted(REPO_ROOT / rel for rel in rel_paths)
+
+
+def scan_paths(paths: list[Path]) -> list[Finding]:
+    findings: list[Finding] = []
+    for path in paths:
+        if not path.exists() or not path.is_file():
+            continue
+        try:
+            rel = path.relative_to(REPO_ROOT).as_posix()
+        except ValueError:
+            continue
+        if not rel.endswith(".py"):
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        findings.extend(scan_text(rel, text))
+    return findings
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-ref", default="origin/main")
+    parser.add_argument("--head-ref", default="HEAD")
+    parser.add_argument("--no-worktree", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    paths = changed_paths(
+        base_ref=args.base_ref,
+        head_ref=args.head_ref,
+        include_worktree=not args.no_worktree,
+    )
+    findings = scan_paths(paths)
+
+    print("Memory Kernel canonicality gate")
+    print("-" * 60)
+    print(f"Scanned changed Python files: {len(paths)}")
+
+    if not findings:
+        print()
+        print("No new memory-authority surfaces found outside the allowlist.")
+        return 0
+
+    print()
+    print("New memory-authority-looking surfaces must be Memory Kernel adapters, projections, or backends:")
+    for finding in findings:
+        print(finding.render())
+    print()
+    print("Move the surface under `dharma_swarm/memory_kernel/` or add a reviewed allowlist entry.")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/memory_kernel_context.py
+++ b/scripts/memory_kernel_context.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Render a read-only Memory Kernel context pack."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from dharma_swarm.memory_kernel import (
+    CensusConfig,
+    MemoryContextBudget,
+    MemoryKernel,
+    MemoryKernelConfig,
+    MemoryQuery,
+    TruthState,
+    render_memory_context_pack_markdown,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("query", nargs="?", default="")
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--home", default=str(Path.home()))
+    parser.add_argument("--surface-id", action="append", default=[])
+    parser.add_argument("--candidate-limit", type=int, default=24)
+    parser.add_argument("--admitted-limit", type=int, default=8)
+    parser.add_argument("--include-discovered", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    kernel = MemoryKernel(
+        MemoryKernelConfig(
+            census=CensusConfig(
+                repo_root=Path(args.repo_root),
+                home=Path(args.home).expanduser(),
+                include_discovered=bool(args.include_discovered),
+            )
+        )
+    )
+    pack = kernel.preview_memory_pack(
+        surface_ids=tuple(args.surface_id) or None,
+        query=MemoryQuery(
+            limit_total=max(1, args.candidate_limit),
+            limit_per_surface=max(1, args.candidate_limit),
+            include_content=True,
+            include_high_risk=False,
+            include_projections=False,
+            include_unsafe=False,
+            require_source_digest=True,
+            require_source_row_key=True,
+        ),
+        budget=MemoryContextBudget(
+            max_candidate_atoms=max(1, args.candidate_limit),
+            max_admitted_atoms=max(1, args.admitted_limit),
+            max_total_chars=4000,
+            max_atom_chars=600,
+            include_content=True,
+            require_context_admissible=False,
+            allow_projections=False,
+            allow_high_risk=False,
+            allowed_truth_states=(
+                TruthState.OBSERVED,
+                TruthState.CLAIMED,
+                TruthState.CURATED,
+                TruthState.CANONICAL,
+            ),
+        ),
+    )
+    if args.query:
+        print(f"# Memory Kernel Context Query\n\nQuery: `{args.query}`\n")
+    print(render_memory_context_pack_markdown(pack))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_context_compiler_memory_kernel.py
+++ b/tests/test_context_compiler_memory_kernel.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from dharma_swarm.context_compiler import ContextCompiler
+
+
+def _compiler(memory_kernel: object) -> ContextCompiler:
+    runtime = MagicMock()
+    runtime.init_db = AsyncMock()
+    runtime.get_session = AsyncMock(return_value=None)
+    runtime.list_delegation_runs = AsyncMock(return_value=[])
+    runtime.list_memory_facts = AsyncMock(return_value=[])
+    runtime.list_artifacts = AsyncMock(return_value=[])
+    runtime.list_workspace_leases = AsyncMock(return_value=[])
+    runtime.new_bundle_id = MagicMock(return_value="bnd_memory_kernel")
+    runtime.record_context_bundle = AsyncMock(side_effect=lambda bundle: bundle)
+
+    lattice = MagicMock()
+    lattice.init_db = AsyncMock()
+    lattice.replay_session = AsyncMock(return_value=[])
+    lattice.recall = AsyncMock(return_value=[])
+    lattice.always_on_context = AsyncMock(return_value="")
+
+    return ContextCompiler(
+        runtime_state=runtime,
+        memory_lattice=lattice,
+        memory_kernel=memory_kernel,  # type: ignore[arg-type]
+    )
+
+
+def _pack() -> SimpleNamespace:
+    admitted = SimpleNamespace(
+        admitted=True,
+        rank=1,
+        surface_id="home.witness",
+        atom_type="witness_event",
+        truth_state="observed",
+        authority_level="medium",
+        content_snippet="safe witness note",
+        selection_reasons=("context_admissible_override", "truth_state:observed"),
+        source_refs=("memory_kernel:home.witness",),
+    )
+    omitted = SimpleNamespace(
+        admitted=False,
+        rank=None,
+        surface_id="home.lancedb",
+        atom_type="source_chunk",
+        truth_state="derived",
+        authority_level="none",
+        content_snippet=None,
+        selection_reasons=(),
+        omission_reasons=("truth_state_not_allowed", "projection_blocked"),
+        source_refs=(),
+    )
+    return SimpleNamespace(
+        pack_id="memory_context_pack:test",
+        candidate_count=2,
+        admitted_count=1,
+        omitted_count=1,
+        candidate_truncated=False,
+        warnings=("preview_only_no_runtime_prompt_injection",),
+        items=(admitted, omitted),
+    )
+
+
+class _FakeMemoryKernel:
+    def __init__(self, pack: SimpleNamespace | None = None, error: Exception | None = None) -> None:
+        self.pack = pack
+        self.error = error
+        self.kwargs: dict[str, object] = {}
+
+    def preview_memory_pack(self, **kwargs: object) -> SimpleNamespace:
+        self.kwargs = kwargs
+        if self.error is not None:
+            raise self.error
+        assert self.pack is not None
+        return self.pack
+
+
+@pytest.mark.asyncio
+async def test_context_compiler_adds_memory_kernel_default_section() -> None:
+    kernel = _FakeMemoryKernel(_pack())
+    compiler = _compiler(kernel)
+
+    bundle = await compiler.compile_bundle(
+        session_id="sess_memory_kernel",
+        task_id="task_memory_kernel",
+        task_description="Use governed memory.",
+        query="governed memory",
+        token_budget=1200,
+    )
+
+    assert "## Memory Kernel" in bundle.rendered_text
+    assert "safe witness note" in bundle.rendered_text
+    assert "projection_blocked" in bundle.rendered_text
+    metadata = bundle.metadata["memory_kernel_default"]
+    assert metadata["status"] == "used"
+    assert metadata["pack_id"] == "memory_context_pack:test"
+    assert metadata["admitted_count"] == 1
+    assert metadata["omitted_count"] == 1
+    budget = kernel.kwargs["budget"]
+    assert getattr(budget, "require_context_admissible") is False
+    assert getattr(budget, "allow_projections") is False
+    assert getattr(budget, "allow_high_risk") is False
+
+
+@pytest.mark.asyncio
+async def test_context_compiler_falls_back_when_memory_kernel_fails() -> None:
+    compiler = _compiler(_FakeMemoryKernel(error=RuntimeError("kernel unavailable")))
+
+    bundle = await compiler.compile_bundle(
+        session_id="sess_memory_kernel_fail",
+        task_description="Continue with legacy context.",
+        token_budget=1200,
+    )
+
+    assert "# DGC Context Bundle" in bundle.rendered_text
+    assert "## Memory Kernel" not in bundle.rendered_text
+    metadata = bundle.metadata["memory_kernel_default"]
+    assert metadata["status"] == "failed"
+    assert metadata["error_type"] == "RuntimeError"

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -3,6 +3,8 @@
 import asyncio
 import json
 import time
+from datetime import datetime, timezone
+
 import pytest
 
 from dharma_swarm.models import (
@@ -565,6 +567,81 @@ async def test_assign_dispatch_telos_block_marks_failed_and_skips_assignment(age
         and "TELOS BLOCK (dispatch)" in str(fields.get("result", ""))
         for task_id, fields in board.updates
     )
+
+
+@pytest.mark.asyncio
+async def test_attach_context_bundle_exposes_memory_kernel_metadata(
+    tmp_path,
+    monkeypatch,
+):
+    from dharma_swarm.runtime_state import ContextBundleRecord
+
+    class FakeMemoryLattice:
+        def __init__(self, **_kwargs):
+            pass
+
+        async def close(self):
+            pass
+
+    class FakeContextCompiler:
+        def __init__(self, **kwargs):
+            assert kwargs.get("memory_kernel") is not None
+
+        async def compile_bundle(self, **kwargs):
+            return ContextBundleRecord(
+                bundle_id="bnd_memory_kernel",
+                session_id=kwargs["session_id"],
+                task_id=kwargs["task_id"],
+                run_id=kwargs["run_id"],
+                token_budget=kwargs["token_budget"],
+                rendered_text="# DGC Context Bundle\n\n## Memory Kernel\nused",
+                sections=[{"name": "Memory Kernel"}],
+                source_refs=["memory_kernel:home.witness"],
+                checksum="checksum",
+                created_at=datetime.now(timezone.utc),
+                metadata={
+                    "memory_kernel_default": {
+                        "status": "used",
+                        "pack_id": "memory_context_pack:test",
+                        "admitted_count": 1,
+                        "omitted_count": 2,
+                        "warnings": ["preview_only_no_runtime_prompt_injection"],
+                    }
+                },
+            )
+
+    monkeypatch.setattr(
+        "dharma_swarm.memory_lattice.MemoryLattice",
+        FakeMemoryLattice,
+    )
+    monkeypatch.setattr(
+        "dharma_swarm.memory_kernel.MemoryKernel",
+        lambda *_args, **_kwargs: object(),
+    )
+    monkeypatch.setattr(
+        "dharma_swarm.context_compiler.ContextCompiler",
+        FakeContextCompiler,
+    )
+
+    board = MockTaskBoard()
+    task = Task(id="t-memory-kernel", title="Memory task", description="safe")
+    board.tasks = [task]
+    orch = Orchestrator(
+        task_board=board,
+        agent_pool=MockAgentPool(),
+        ledger_dir=tmp_path / "ledgers",
+        runtime_db_path=tmp_path / "runtime.db",
+    )
+    td = TaskDispatch(task_id=task.id, agent_id="a1")
+
+    meta = await orch._attach_context_bundle(task, td, {})
+
+    assert meta["context_bundle_status"] == "attached"
+    assert meta["memory_kernel_status"] == "used"
+    assert meta["memory_kernel_pack_id"] == "memory_context_pack:test"
+    assert meta["memory_kernel_admitted_count"] == 1
+    assert meta["memory_kernel_omitted_count"] == 2
+    assert td.metadata["memory_kernel_status"] == "used"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Organ touched: Memory Kernel runtime context path, ContextCompiler, Orchestrator dispatch metadata, and Memory Kernel governance/read-only operator tooling.
Declared-vs-actual gap closed: After Memory Kernel merged as the canonical memory front door, this PR makes it the default runtime context/read path instead of leaving it only as shadow/canary infrastructure.
Proof that re-reads the map: GitNexus index was refreshed for this worktree; detect_changes reported low risk with 0 affected indexed execution flows; ContextCompiler and _attach_context_bundle impact checks were low risk; focused tests and Memory Kernel preflight passed locally.
New drift introduced: One known remaining drift is module-size pressure in context_compiler.py and orchestrator.py; CI module-budget currently requires decomposition before merge. No new memory-authority surface is introduced outside Memory Kernel; the new canonicality gate blocks future sprawl.

Summary:
- makes Memory Kernel the default read-only context section inside ContextCompiler while keeping existing fallback/shadow behavior
- wires Orchestrator context attachment through MemoryKernel and records memory_kernel_* dispatch metadata
- adds a read-only memory-kernel-context CLI, a canonicality governance gate, Makefile targets, docs, and focused tests

Impact check [impact-checked]:
- refreshed GitNexus index for this worktree
- GitNexus detect_changes on staged diff: low risk, 12 files, 106 changed symbols, 0 affected indexed execution flows
- ContextCompiler impact: low risk, direct importers are orchestrator.py and system_integration_probe.py
- _attach_context_bundle impact: low risk, direct caller is _assign_dispatch

Validation:
- PYTHONPATH=. pytest -q tests/test_context_compiler_memory_kernel.py tests/test_context_compiler_cache.py tests/test_orchestrator.py::test_attach_context_bundle_exposes_memory_kernel_metadata
- PYTHONPATH=. pytest -q tests/test_memory_kernel_*.py tests/test_context_compiler*.py
- make memory-kernel-canonical
- make docops-integrity
- git diff --check
- python3 -m py_compile dharma_swarm/context_compiler.py dharma_swarm/orchestrator.py scripts/memory_kernel_context.py scripts/governance/check_memory_kernel_canonical.py
- make memory-kernel-full-power-preflight
- make memory-kernel-context QUERY='governed memory'

Note:
This makes Memory Kernel the default runtime context/read path. Writer enforcement, deeper semantic ranking, and module-budget decomposition remain follow-up hardening work.