### PR TITLE
PR-H1: disambiguate ClosureEvidenceReceipt from spine EvidenceReceipt

### DIFF
--- a/dharma_swarm/operator_core/closure_v0.py
+++ b/dharma_swarm/operator_core/closure_v0.py
@@ -1,10 +1,16 @@
 """Organism Closure v0 — file-native proof loop.
 
-Proves: EvidenceReceipt(success=True) yields a different NextDecision than
-EvidenceReceipt(success=False). Scope locked by Track 3 plan, 2026-05-08:
-file-native dataclasses, JSON I/O only, imports stdlib + operating_facts,
-correlation_id mandatory, DarwinProposalCandidate is data only (never
-submitted to evolution.py), module-private (no public re-export).
+Proves: ClosureEvidenceReceipt(success=True) yields a different NextDecision
+than ClosureEvidenceReceipt(success=False). Scope locked by Track 3 plan,
+2026-05-08: file-native dataclasses, JSON I/O only, imports stdlib +
+operating_facts, correlation_id mandatory, DarwinProposalCandidate is data
+only (never submitted to evolution.py), module-private (no public re-export).
+
+Naming note (2026-05-30, PR-H1): the class was previously named
+``EvidenceReceipt``. It is now ``ClosureEvidenceReceipt`` to disambiguate
+from ``dharma_swarm.spine.receipt.EvidenceReceipt``, which is a distinct
+class modelling the runtime dispatch artifact. ``EvidenceReceipt`` remains
+available in this module as a deprecated alias for backward compatibility.
 """
 from __future__ import annotations
 
@@ -60,7 +66,7 @@ class WorkPacket:
             raise ClosureContractError(f"WorkPacket.review_tier ∉ {_REVIEW_TIERS}")
 
 @dataclass(frozen=True)
-class EvidenceReceipt:
+class ClosureEvidenceReceipt:
     receipt_id: str
     correlation_id: str
     work_packet_id: str
@@ -74,9 +80,14 @@ class EvidenceReceipt:
 
     def __post_init__(self) -> None:
         if not (self.correlation_id and self.replay_command):
-            raise ClosureContractError("EvidenceReceipt missing correlation_id/replay_command")
+            raise ClosureContractError("ClosureEvidenceReceipt missing correlation_id/replay_command")
         if self.success != (self.test_exit_code == 0):
             raise EvidenceInconsistentError(f"success={self.success} but exit={self.test_exit_code}")
+
+
+# Deprecated alias — use ClosureEvidenceReceipt. Retained for one release
+# cycle so external consumers can migrate. Will be removed in a follow-up PR.
+EvidenceReceipt = ClosureEvidenceReceipt
 
 @dataclass(frozen=True)
 class VSMProjection:
@@ -147,9 +158,9 @@ def record_evidence_receipt(
     correlation_id: str,
     created_at: str,
     duration_ms: float = 0.0,
-) -> EvidenceReceipt:
+) -> ClosureEvidenceReceipt:
     success = _success_from_agentops(agentops_fact)
-    return EvidenceReceipt(
+    return ClosureEvidenceReceipt(
         receipt_id=_hid("ev", correlation_id, packet.packet_id, str(success)),
         correlation_id=correlation_id,
         work_packet_id=packet.packet_id,
@@ -166,7 +177,7 @@ def record_evidence_receipt(
 
 def project_vsm(
     bundle: OperatingFactBundle,
-    receipt: EvidenceReceipt | None,
+    receipt: ClosureEvidenceReceipt | None,
     *,
     correlation_id: str,
     captured_at: str,
@@ -205,7 +216,7 @@ def project_vsm(
     )
 
 def kaizen_link(
-    receipt: EvidenceReceipt,
+    receipt: ClosureEvidenceReceipt,
     *,
     human_yds: HumanQualityRatingFact | None = None,
     waste_patterns: tuple[str, ...] = (),

--- a/dharma_swarm/operator_core/go_evidence_bridge.py
+++ b/dharma_swarm/operator_core/go_evidence_bridge.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from dharma_swarm.operator_core.closure_v0 import EvidenceReceipt, WorkPacket, record_evidence_receipt
+from dharma_swarm.operator_core.closure_v0 import ClosureEvidenceReceipt, WorkPacket, record_evidence_receipt
 from dharma_swarm.operator_core.operating_facts import AgentOpsRunFact
 
 
@@ -99,7 +99,7 @@ def closure_evidence_from_go_receipt(
     *,
     created_at: str,
     duration_ms: float = 0.0,
-) -> EvidenceReceipt:
+) -> ClosureEvidenceReceipt:
     """Project a Go sidecar receipt into closure_v0 evidence.
 
     Go stays outside the decision loop; Python performs the closure projection.

--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -8,14 +8,14 @@ Do not hand-edit the generated block.
 |---|---:|
 | Dharma Python modules | 668 |
 | Top-level Dharma Python modules | 391 |
-| Dharma Python LOC | 283,502 |
+| Dharma Python LOC | 283,513 |
 | Test files | 639 |
 | Test function occurrences | 11,005 |
-| Markdown files | 854 |
-| Markdown total lines | 211,598 |
+| Markdown files | 855 |
+| Markdown total lines | 211,690 |
 | Bridge files | 24 |
 | Adapter files | 21 |
 | Orchestrator files | 5 |
 | Router files | 14 |
-| Authority candidate docs | 375 |
+| Authority candidate docs | 376 |
 <!-- DOCOPS:END -->

--- a/docs/governance/SOVEREIGN_MANIFEST.md
+++ b/docs/governance/SOVEREIGN_MANIFEST.md
@@ -124,8 +124,8 @@ These are the ground-truth metrics. All other documents citing different numbers
 | Test functions | **11,005 `def test_` occurrences under tests/** | rg "def test_" tests |
 | Tests collected (pytest) | **Needs write-permitted refresh** | not run during this DocOps count pass |
 | Collection errors | **Historical: 16 on 2026-04-04** | refresh before relying on this count |
-| Markdown files | **854** | find . -name "*.md" -type f |
-| Markdown total lines | **211,598** | wc -l across all .md |
+| Markdown files | **855** | find . -name "*.md" -type f |
+| Markdown total lines | **211,690** | wc -l across all .md |
 | Bridge files | **24** | find dharma_swarm -name "*bridge*.py" |
 | Adapter files | **21 across 8 locations** | find dharma_swarm -type f \| rg -i "adapter" |
 | Orchestrator files | **4** (6,034 LOC total) | find dharma_swarm -name "*orchestrat*" |

--- a/inter_agent/devin/outbound/2026-05-30-devin-receipt-disambiguation.md
+++ b/inter_agent/devin/outbound/2026-05-30-devin-receipt-disambiguation.md
@@ -25,7 +25,7 @@ These are not duplicates. Merging them would have been wrong. The audit's "53 pr
 
 ## What this PR does instead
 
-**Disambiguates the names** so future readers, future agents, and the manifest checker can speak about each one unambiguously. Zero behavior change.
+**Disambiguates the names** so future readers, future agents, and the manifest checker can speak about each one unambiguously. Runtime data flow remains compatible through the temporary alias, but the validation exception text now says `ClosureEvidenceReceipt missing correlation_id/replay_command`.
 
 1. **Rename** `operator_core/closure_v0.py:class EvidenceReceipt:` → `class ClosureEvidenceReceipt:`
    - All in-file references updated (`record_evidence_receipt` return type, `project_vsm`/`kaizen_link` param types).

--- a/inter_agent/devin/outbound/2026-05-30-devin-receipt-disambiguation.md
+++ b/inter_agent/devin/outbound/2026-05-30-devin-receipt-disambiguation.md
@@ -1,0 +1,92 @@
+# Devin Outbound — PR-H1 Receipt Disambiguation
+
+**From:** Devin (Roaming) `AGT-DEVIN_ROAMING_2987D222`
+**Authority:** `external_worker_evidence_only`
+**Date:** 2026-05-30
+**Branch:** `devin/2026-05-30-receipt-disambiguation` (stacked on `devin/2026-05-30-manifest-check`, PR #384)
+**Active track:** `runtime-truth-spine-2026-06` — not displaced.
+**Frozen surfaces touched:** none.
+
+## What this is — and what the audit got wrong
+
+The original modularity audit framed `operator_core/closure_v0.py:EvidenceReceipt` and `dharma_swarm/spine/receipt.py:EvidenceReceipt` as a **duplication problem** (53 imports of one, 1 import of the other, fragmented truth surface).
+
+**Survey on the actual code corrected that framing.** The two classes share a name but model **completely different concepts**:
+
+| | `spine/receipt.py` | `operator_core/closure_v0.py` |
+|---|---|---|
+| **Concept** | Runtime dispatch artifact (one per agent invocation) | Operator closure-loop artifact (one per PR/test-run) |
+| **Identity field** | `receipt_id: UUID` | `receipt_id: str` (hash-derived) |
+| **Domain fields** | trace_id, span_id, agent_id, provider, model, input_tokens, output_tokens, cost_usd, latency_ms, status, error_source | correlation_id, work_packet_id, agentops_source, test_exit_code, files_changed, duration_ms, replay_command, success |
+| **Serializer** | `to_otel_span()` (OTel GenAI export) | `to_jsonable()` + `write_json()` (file-native proof loop) |
+| **Production import sites** | 4 (`spine/__init__.py`, `spine/invoke.py`, `spine/persistence.py`, 1 test) | 3 (`closure_v0.py` self, `go_evidence_bridge.py`, 1 test) |
+
+These are not duplicates. Merging them would have been wrong. The audit's "53 production uses" was a text-match overcount — actual class-symbol references total ~10 files.
+
+## What this PR does instead
+
+**Disambiguates the names** so future readers, future agents, and the manifest checker can speak about each one unambiguously. Zero behavior change.
+
+1. **Rename** `operator_core/closure_v0.py:class EvidenceReceipt:` → `class ClosureEvidenceReceipt:`
+   - All in-file references updated (`record_evidence_receipt` return type, `project_vsm`/`kaizen_link` param types).
+   - **Backward-compat alias** retained: `EvidenceReceipt = ClosureEvidenceReceipt` at module level, with a comment marking it deprecated for removal in a follow-up PR. External consumers still importing the old name keep working for one release cycle.
+
+2. **Update import sites** to use the new name:
+   - `dharma_swarm/operator_core/go_evidence_bridge.py` (import + return-type annotation)
+   - `tests/test_organism_closure_v0.py` (import + 3 constructor calls + section header comment)
+
+3. **Update `tools/manifest_check.py` `_CANONICAL_RECEIPT_SITES`** in the same PR (as the checker's own contract requires when canonical sites change):
+   - Was: `{closure_v0.py, spine/receipt.py}` — 2 sites, "exactly two" check
+   - Now: `{spine/receipt.py}` — 1 site, "exactly one `class EvidenceReceipt:` definition" check
+   - The closure-loop receipt is now `class ClosureEvidenceReceipt`, which is **not** subject to the uniqueness check (different class name).
+   - Inline comment documents the 2026-05-30 disambiguation rationale so the next reader/agent knows why the set shrank.
+
+4. **Module docstring updated** at `closure_v0.py` to record the rename and point at the canonical spine receipt.
+
+## What this catches the next time someone tries it
+
+- Defining a class named `EvidenceReceipt` anywhere outside `dharma_swarm/spine/receipt.py` → **CI fail** with a hint to import from canonical or rename (e.g. `ClosureEvidenceReceipt`).
+- Removing `class EvidenceReceipt:` from `spine/receipt.py` without editing `_CANONICAL_RECEIPT_SITES` in the same PR → **CI fail**.
+
+## Validation
+
+```
+$ python -m pytest tests/test_organism_closure_v0.py
+======================== 19 passed in 0.66s ========================
+
+$ python tools/manifest_check.py --report -v
+manifest-check info:
+  state_dir_paths_via_helper: literals=28, budget=28, offender files=19
+
+manifest-check: all checks passed.
+```
+
+Backward-compat verified:
+```
+>>> from dharma_swarm.operator_core.closure_v0 import ClosureEvidenceReceipt, EvidenceReceipt
+>>> ClosureEvidenceReceipt is EvidenceReceipt
+True
+>>> from dharma_swarm.spine.receipt import EvidenceReceipt as SpineReceipt
+>>> SpineReceipt is not ClosureEvidenceReceipt
+True
+```
+
+## Anti-doctrine self-check
+
+- Builds AGI? No.
+- Uncontrolled self-modification? No.
+- Autonomous capital deployment? No.
+- Autonomous external messaging? No.
+- Deceptive memetic engineering? No.
+- Parallel governance? No.
+- Vague prose? No — one class renamed, one alias retained, one canonical site declared, 19 tests pass.
+- New substrate? No.
+- Meta-framework? No.
+- Touches a frozen surface? **No.** `spine/receipt.py` and `tests/test_dispatch_dropoff_sources.py` are unchanged. Only `closure_v0.py`, `go_evidence_bridge.py`, `test_organism_closure_v0.py`, and the checker's canonical-set declaration are modified.
+
+## Follow-ups
+
+- **Deprecation removal:** in 1–2 PR cycles, drop the `EvidenceReceipt = ClosureEvidenceReceipt` alias and require all consumers to use the explicit new name.
+- **PR-H3, PR-H4, PR-H5** queued separately. Each is its own sibling branch on top of `main` (not stacked).
+
+Authority compliance: this notice + open PR + await operator merge. No autonomous merge.

--- a/tests/test_organism_closure_v0.py
+++ b/tests/test_organism_closure_v0.py
@@ -18,9 +18,9 @@ import pytest
 
 from dharma_swarm.operator_core.closure_v0 import (
     ClosureContractError,
+    ClosureEvidenceReceipt,
     DarwinProposalCandidate,
     EvidenceInconsistentError,
-    EvidenceReceipt,
     KaizenReviewLink,
     NextDecision,
     TelosObjective,
@@ -118,12 +118,12 @@ def _run_loop(variant: str, *, truth_stale_override: bool = False):
 
 
 # ---------------------------------------------------------------------------
-# T1–T2 — EvidenceReceipt invariants
+# T1–T2 — ClosureEvidenceReceipt invariants
 # ---------------------------------------------------------------------------
 
 def test_t1_evidence_inconsistent_success_with_failing_exit() -> None:
     with pytest.raises(EvidenceInconsistentError):
-        EvidenceReceipt(
+        ClosureEvidenceReceipt(
             receipt_id="ev_x", correlation_id=CORRELATION_ID,
             work_packet_id="wp_x", agentops_source="src",
             test_exit_code=1, files_changed=(), duration_ms=0.0,
@@ -133,14 +133,14 @@ def test_t1_evidence_inconsistent_success_with_failing_exit() -> None:
 
 def test_t2_evidence_requires_correlation_and_replay() -> None:
     with pytest.raises(ClosureContractError):
-        EvidenceReceipt(
+        ClosureEvidenceReceipt(
             receipt_id="ev_x", correlation_id="",
             work_packet_id="wp_x", agentops_source="src",
             test_exit_code=0, files_changed=(), duration_ms=0.0,
             replay_command="pytest x", success=True, created_at=CREATED_AT,
         )
     with pytest.raises(ClosureContractError):
-        EvidenceReceipt(
+        ClosureEvidenceReceipt(
             receipt_id="ev_x", correlation_id=CORRELATION_ID,
             work_packet_id="wp_x", agentops_source="src",
             test_exit_code=0, files_changed=(), duration_ms=0.0,

--- a/tools/manifest_check.py
+++ b/tools/manifest_check.py
@@ -27,8 +27,11 @@ Five invariants enforced:
      Compared against a budget; failures only when the count grows.
 
   5. evidence_receipt_uniqueness
-     Exactly two `class EvidenceReceipt:` definitions exist
-     (operator_core/closure_v0.py — production; spine/receipt.py — doctrine).
+     Exactly one `class EvidenceReceipt:` definition exists
+     (spine/receipt.py — the runtime dispatch artifact, OTel-aligned).
+     The operator-closure-loop artifact lives at
+     operator_core/closure_v0.py:ClosureEvidenceReceipt (different concept,
+     different fields, deliberately disambiguated).
      No third definition may be introduced.
 
 Exit codes: 0 on pass, 1 on violation. Use `--report` for human-readable
@@ -69,11 +72,19 @@ _BUDGET_PATH = _REPO_ROOT / "tools" / "manifest_check_budgets.json"
 # Supported manifest schema versions. Bump when intentional breaking changes.
 _SUPPORTED_SCHEMA_VERSIONS = {2}
 
-# The two canonical EvidenceReceipt definition sites. Any third site is a
-# violation; missing either is also a violation.
+# Canonical `class EvidenceReceipt:` definition site. Any other site is a
+# violation; missing this site is also a violation.
+#
+# Note (2026-05-30, PR-H1): the operator closure loop defined its own
+# `class EvidenceReceipt` at operator_core/closure_v0.py modelling a
+# completely different concept (PR/test-run evidence: correlation_id,
+# work_packet_id, test_exit_code, files_changed, replay_command). That
+# class is now `ClosureEvidenceReceipt`, with `EvidenceReceipt` kept as a
+# deprecated alias for one release cycle. Only the runtime spine receipt
+# (UUID identity, trace/span/agent/model/tokens/cost, OTel export) is the
+# canonical `class EvidenceReceipt:` definition.
 _CANONICAL_RECEIPT_SITES = {
-    "dharma_swarm/operator_core/closure_v0.py",  # proven, 53+ uses
-    "dharma_swarm/spine/receipt.py",  # doctrine, OTel-aligned
+    "dharma_swarm/spine/receipt.py",  # doctrine, OTel-aligned, runtime dispatch
 }
 
 # Regex for raw ~/.dharma literals in Python sources.
@@ -361,9 +372,9 @@ def check_state_dir_literals(report: CheckReport, budgets: dict[str, int]) -> in
 
 
 def check_receipt_uniqueness(report: CheckReport) -> None:
-    """Exactly two `class EvidenceReceipt:` definitions may exist, at the
-    two canonical sites. Any other site is a violation; missing either site
-    is also a violation."""
+    """Exactly one `class EvidenceReceipt:` definition may exist, at the
+    canonical site. Any other site is a violation; missing the canonical
+    site is also a violation."""
     found_sites: set[str] = set()
     extra_sites: list[str] = []
 
@@ -411,10 +422,11 @@ def check_receipt_uniqueness(report: CheckReport) -> None:
             Violation(
                 "evidence_receipt_uniqueness",
                 "error",
-                f"third EvidenceReceipt class defined at {extra}. The two "
-                f"canonical definitions are {sorted(_CANONICAL_RECEIPT_SITES)}. "
-                f"Adding a third receipt class fragments the truth surface. "
-                f"Import from a canonical site or rename your class.",
+                f"non-canonical EvidenceReceipt class defined at {extra}. "
+                f"The canonical site is {sorted(_CANONICAL_RECEIPT_SITES)}. "
+                f"Adding another receipt class fragments the truth surface. "
+                f"Import from the canonical site or rename your class "
+                f"(e.g. ClosureEvidenceReceipt).",
                 path=extra,
             )
         )


### PR DESCRIPTION
## PR-H1 — Disambiguate `ClosureEvidenceReceipt` from spine `EvidenceReceipt`

**Authority:** `external_worker_evidence_only`
**Stacked on:** PR #384 (PR-H2 manifest-check). Base: `devin/2026-05-30-manifest-check`.
**Frozen surfaces touched:** **none.** `spine/receipt.py` and `tests/test_dispatch_dropoff_sources.py` are unchanged.

### Reframe: the audit was wrong about duplication

Survey on the actual code showed the "two `EvidenceReceipt` classes" are **two different concepts that happen to share a name**:

| | `spine/receipt.py` | `operator_core/closure_v0.py` |
|---|---|---|
| Concept | runtime dispatch artifact (per agent invocation) | operator closure-loop artifact (per PR/test-run) |
| Identity | `receipt_id: UUID` | `receipt_id: str` (hash-derived) |
| Fields | trace/span/agent/model/tokens/cost | correlation_id, work_packet, test_exit_code, files_changed, replay_command |
| Serializer | `to_otel_span()` | `to_jsonable()` + `write_json()` |
| Import sites | 4 | 3 |

Merging them would be wrong. Disambiguate instead.

### Changes

- `closure_v0.py`: `class EvidenceReceipt:` -> `class ClosureEvidenceReceipt:`. Backward-compat alias `EvidenceReceipt = ClosureEvidenceReceipt` retained for one release cycle. All in-file return types / param types updated.
- `go_evidence_bridge.py`: import + return-type annotation updated.
- `tests/test_organism_closure_v0.py`: import + 3 constructor calls + section header updated. **All 19 tests still pass.**
- `tools/manifest_check.py`: `_CANONICAL_RECEIPT_SITES` shrinks from 2 to 1 (only `spine/receipt.py`). This is allowed because the checker's own contract requires editing `_CANONICAL_RECEIPT_SITES` in the same PR that changes canonical sites. Docstring + error message wording updated.
- `reports/governance/pr388_receipt_disambiguation_proof.json`: machine-readable receipt for focused pytest, manifest-check, DocOps generated metrics, and the temporary alias probe.

## Coherence Delta

- Organ touched: receipt identity boundary between `spine/receipt.py` runtime dispatch receipts and `dharma_swarm/operator_core/closure_v0.py` closure-loop receipts.
- Declared-vs-actual gap closed: the manifest/checker treated both `EvidenceReceipt` classes as canonical receipt sites even though the closure receipt is a different artifact with different fields and serializers.
- Proof that re-reads the map: `reports/governance/pr388_receipt_disambiguation_proof.json` records `python -m pytest tests/test_organism_closure_v0.py` passing 19 tests, `python tools/manifest_check.py` passing, `python scripts/docops/check_docops_integrity.py` passing with generated metrics, and the alias probe confirming `ClosureEvidenceReceipt is EvidenceReceipt`.
- New drift introduced: `EvidenceReceipt = ClosureEvidenceReceipt` remains as a compatibility alias for one release cycle and must be removed after external consumers migrate.

### Validation

```
$ python -m pytest tests/test_organism_closure_v0.py
======================== 19 passed in 0.66s ========================

$ python tools/manifest_check.py
manifest-check: all checks passed.

>>> from dharma_swarm.operator_core.closure_v0 import ClosureEvidenceReceipt, EvidenceReceipt
>>> ClosureEvidenceReceipt is EvidenceReceipt
True
```

### What this catches next

- Defining a class named `EvidenceReceipt` anywhere outside `spine/receipt.py` -> CI fail with hint to import canonical or rename (e.g. `ClosureEvidenceReceipt`).
- Removing `class EvidenceReceipt:` from `spine/receipt.py` without editing `_CANONICAL_RECEIPT_SITES` in same PR -> CI fail.

### Follow-up

Drop the `EvidenceReceipt = ClosureEvidenceReceipt` alias in 1-2 PR cycles once external consumers have migrated.

Outbound notice: `inter_agent/devin/outbound/2026-05-30-devin-receipt-disambiguation.md`.

Authority compliance: this PR + outbound notice + await operator merge.
