### PR TITLE
PR-H5 (scaffold): openapi-typescript codegen pipeline

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -9,7 +9,9 @@
     "lint": "eslint",
     "test:visual": "playwright test",
     "test:visual:ui": "playwright test --ui",
-    "test:visual:update": "playwright test --update-snapshots"
+    "test:visual:update": "playwright test --update-snapshots",
+    "gen:types": "openapi-typescript ${OPENAPI_URL:-http://127.0.0.1:8420/openapi.json} -o src/lib/api-generated.ts",
+    "gen:types:check": "openapi-typescript ${OPENAPI_URL:-http://127.0.0.1:8420/openapi.json} -o /tmp/api-generated.check.ts && diff -q src/lib/api-generated.ts /tmp/api-generated.check.ts"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.90.21",
@@ -41,6 +43,7 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
+    "openapi-typescript": "^7.4.4",
     "tailwindcss": "^4",
     "typescript": "^5"
   }

--- a/dashboard/src/lib/api-generated.ts
+++ b/dashboard/src/lib/api-generated.ts
@@ -1,0 +1,45 @@
+/**
+ * AUTO-GENERATED — DO NOT EDIT BY HAND.
+ *
+ * This file is the destination for `npm run gen:types`, which runs
+ * `openapi-typescript` against the FastAPI app's `/openapi.json` endpoint
+ * and overwrites this file in place.
+ *
+ * STATUS (PR-H5 scaffold): not yet wired.
+ * ------------------------------------------------------------------
+ * This placeholder exists so that:
+ *   1. The path `@/lib/api-generated` resolves under TypeScript strict
+ *      checks without requiring contributors to run codegen on first
+ *      checkout.
+ *   2. Reviewers can see the migration target without diffing through
+ *      a multi-thousand-line generated artifact in this PR.
+ *
+ * Until codegen runs against a live API, NO hook should import from
+ * this module. Hand-written types in `./types.ts` (and the per-surface
+ * contract files alongside it) remain the source of truth.
+ *
+ * MIGRATION
+ * ------------------------------------------------------------------
+ * See `docs/reports/openapi_codegen_migration_plan.md` for the
+ * staged H5a → H5-migrate plan. The first surface targeted is
+ * `useHealth.ts` against `GET /api/health`, behind a side-by-side
+ * type assertion so any drift between generated and hand-written
+ * shapes surfaces as a compile error rather than a runtime bug.
+ *
+ * REGEN
+ * ------------------------------------------------------------------
+ *   # from repo root, with FastAPI running on the default port (8420):
+ *   cd dashboard
+ *   npm run gen:types
+ *
+ *   # CI parity check (fails if generated file is stale):
+ *   npm run gen:types:check
+ *
+ * The OpenAPI URL can be overridden via the OPENAPI_URL env var.
+ */
+
+// Intentionally empty. The codegen step will REPLACE this entire file
+// with the typed `components`, `paths`, and `operations` exports from
+// openapi-typescript. Do not add hand-written declarations here.
+
+export {};

--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -11,8 +11,8 @@ Do not hand-edit the generated block.
 | Dharma Python LOC | 283,151 |
 | Test files | 631 |
 | Test function occurrences | 10,879 |
-| Markdown files | 841 |
-| Markdown total lines | 208,977 |
+| Markdown files | 843 |
+| Markdown total lines | 209,252 |
 | Bridge files | 24 |
 | Adapter files | 21 |
 | Orchestrator files | 4 |

--- a/docs/governance/SOVEREIGN_MANIFEST.md
+++ b/docs/governance/SOVEREIGN_MANIFEST.md
@@ -124,8 +124,8 @@ These are the ground-truth metrics. All other documents citing different numbers
 | Test functions | **10,879 `def test_` occurrences under tests/** | rg "def test_" tests |
 | Tests collected (pytest) | **Needs write-permitted refresh** | not run during this DocOps count pass |
 | Collection errors | **Historical: 16 on 2026-04-04** | refresh before relying on this count |
-| Markdown files | **841** | find . -name "*.md" -type f |
-| Markdown total lines | **208,977** | wc -l across all .md |
+| Markdown files | **843** | find . -name "*.md" -type f |
+| Markdown total lines | **209,252** | wc -l across all .md |
 | Bridge files | **24** | find dharma_swarm -name "*bridge*.py" |
 | Adapter files | **21 across 8 locations** | find dharma_swarm -type f \| rg -i "adapter" |
 | Orchestrator files | **4** (6,034 LOC total) | find dharma_swarm -name "*orchestrat*" |

--- a/docs/reports/openapi_codegen_migration_plan.md
+++ b/docs/reports/openapi_codegen_migration_plan.md
@@ -1,0 +1,174 @@
+# PR-H5 — openapi-typescript codegen migration plan
+
+**Status:** scaffold-only. This PR adds the generation pipeline. No
+hand-written dashboard types are removed or replaced in this PR.
+
+**Authority:** `external_worker_evidence_only` — every subsequent
+migration step (H5a, H5b, …) ships as its own operator-approved PR.
+
+**Active track:** `runtime-truth-spine-2026-06`.
+
+## Why scaffold-only
+
+The hardening audit framed the dashboard's hand-written types as
+"42 type files duplicating the FastAPI schema." Surveying the
+actual code revealed two corrections to that framing:
+
+1. The dashboard does not have 42 separate type files. It has one
+   primary `dashboard/src/lib/types.ts` plus a handful of per-surface
+   contract files (e.g. `chatProfiles.ts`, `chatSessionContract.ts`,
+   `controlPlanePageMeta.ts`, `runtimeOperatorHandbook.ts`). These
+   are not pure DTO mirrors — several encode UI-side invariants and
+   `zod` runtime validation that the OpenAPI schema does not express.
+2. Wholesale replacement of those types with `components["schemas"]`
+   from `openapi-typescript` would touch every hook, every page, and
+   every test in a single PR. That violates the doctrine's preference
+   for piecewise, reversible changes on the active runtime-truth-spine
+   track.
+
+The mitigation is the same scaffold-only contract pattern used for
+PR-H3 (provider_registry) and PR-H4 (storage_schema_registry):
+
+- New module / new pipeline is purely additive.
+- Existing code paths are untouched.
+- Opt-in is per-surface, behind a review gate.
+- Rollback = delete the new files; zero blast radius.
+
+## What this PR adds
+
+| Path | Purpose |
+|------|---------|
+| `dashboard/package.json` | adds `openapi-typescript` devDep + `gen:types`, `gen:types:check` scripts |
+| `dashboard/src/lib/api-generated.ts` | placeholder destination file for codegen; documents the migration target; intentionally empty so no hook can import from it yet |
+| `docs/reports/openapi_codegen_migration_plan.md` | this document |
+| `inter_agent/devin/outbound/2026-05-30-devin-openapi-codegen.md` | outbound notice |
+
+What this PR **does not** do:
+
+- Does not run codegen in CI.
+- Does not replace any hand-written types.
+- Does not modify any hook, page, component, or test.
+- Does not modify `api/main.py` or any router (no backend changes).
+- Does not modify any frozen surface
+  (`dharma_swarm/spine/**`, `orchestrator.py`, `agent_runner.py`,
+   `runtime_state.py`, `tests/test_dispatch_dropoff_sources.py`,
+   `tools/spine_check.py`).
+
+## Generation entry point
+
+The FastAPI app (`api/main.py`) already serves the OpenAPI schema at
+`/openapi.json` (default port `8420`, matching the dashboard's
+`DEFAULT_INTERNAL_API_URL`). The new npm scripts target that URL by
+default and honor `OPENAPI_URL` for CI or non-default deployments:
+
+```bash
+# Default (FastAPI on 127.0.0.1:8420):
+cd dashboard && npm run gen:types
+
+# Override (CI, alt port, alt host):
+OPENAPI_URL=http://api.internal/openapi.json npm run gen:types
+
+# Drift check (non-zero exit if generated file is stale):
+cd dashboard && npm run gen:types:check
+```
+
+## Staged migration
+
+Each stage is one PR. Each PR is operator-approved before the next
+starts. Each stage is independently revertable.
+
+### H5a — first opt-in surface (`useHealth` against `/api/health`)
+
+- Run `npm run gen:types` against a live FastAPI to populate
+  `api-generated.ts` with real types.
+- In `useHealth.ts`, import the generated type alongside the
+  hand-written `HealthOut`, then assert structural equivalence at
+  compile time using a satisfies-style check:
+
+  ```ts
+  import type { components } from "@/lib/api-generated";
+  import type { HealthOut } from "@/lib/types";
+  type GeneratedHealth = components["schemas"]["HealthOut"];
+  // Compile-time drift guard — if the FastAPI schema drifts from the
+  // hand-written type, this assignment fails type-check.
+  const _drift_guard: GeneratedHealth = {} as HealthOut;
+  void _drift_guard;
+  ```
+
+- Does NOT remove `HealthOut` from `types.ts`. Does NOT change the
+  hook's public type. The only purpose is to prove the round-trip.
+
+### H5b — H5n — expand opt-in surfaces one router at a time
+
+In rough order of how schema-stable each router is, judged from
+existing audit reports:
+
+- `health` (smallest, most stable) — covered in H5a
+- `agents`
+- `evolution`
+- `ontology`
+- `lineage`
+- `stigmergy`
+- `commands`
+- `chat` and chat-session contracts (LAST — these encode the most
+  UI-side invariants and likely keep hand-written types even after
+  migration completes)
+
+Each step adds a drift guard, leaves the hand-written type in place,
+and is reviewed against a generated diff.
+
+### H5-ci — CI drift check
+
+Add `npm run gen:types:check` (or equivalent) to CI on a job that
+spins up the FastAPI app, regenerates types, and fails if the
+committed `api-generated.ts` differs from a fresh generation. This
+catches backend schema changes that the dashboard hasn't picked up.
+
+### H5-migrate — replace hand-written types where safe
+
+Per-surface, replace the hand-written type alias with a re-export
+from `api-generated`:
+
+```ts
+// before:
+export interface HealthOut { ... }
+
+// after:
+import type { components } from "@/lib/api-generated";
+export type HealthOut = components["schemas"]["HealthOut"];
+```
+
+Hand-written types that encode UI invariants the OpenAPI schema
+cannot express (validation refinements, narrowed unions, frontend-
+only fields) are kept and documented inline.
+
+## Rollback
+
+This PR is fully reversible by deleting four files:
+
+```
+dashboard/src/lib/api-generated.ts
+docs/reports/openapi_codegen_migration_plan.md
+inter_agent/devin/outbound/2026-05-30-devin-openapi-codegen.md
+```
+
+…and reverting the `package.json` additions (devDep + two scripts).
+No installed dependency is required for the rest of the codebase to
+build, because `openapi-typescript` is a devDependency only invoked
+by an explicit npm script.
+
+## Anti-doctrine self-check
+
+- New substrate? No — adds a build-time codegen step to existing
+  Next.js/TypeScript tooling.
+- Meta-framework? No — uses the widely-adopted
+  [`openapi-typescript`](https://github.com/openapi-ts/openapi-typescript)
+  library; no in-house abstraction.
+- Parallel governance? No — generated types live alongside hand-
+  written types; the hand-written types remain the public contract
+  until each surface is explicitly migrated under operator review.
+- Vague prose? Each migration stage names the file edited, the
+  router targeted, and the rollback step.
+- Autonomous merging? No — every stage ships as its own PR with
+  operator approval.
+- Frozen surfaces touched? No.

--- a/inter_agent/devin/outbound/2026-05-30-devin-openapi-codegen.md
+++ b/inter_agent/devin/outbound/2026-05-30-devin-openapi-codegen.md
@@ -1,0 +1,101 @@
+# Devin outbound — 2026-05-30 — PR-H5 openapi-typescript codegen (scaffold)
+
+**From:** Devin (Roaming) AGT-DEVIN_ROAMING_2987D222
+**Track:** `runtime-truth-spine-2026-06`
+**Authority:** `external_worker_evidence_only`
+**Branch:** `devin/2026-05-30-openapi-codegen` (sibling, not stacked)
+**PR:** TBD (opened immediately after this notice lands)
+**Slate position:** H5 of the {H1, H2, H3, H4, H5} hardening slate.
+
+## Summary
+
+Adds a scaffold for dashboard type generation from the FastAPI
+OpenAPI schema. No hand-written types are removed or replaced. No
+hook, page, component, or test is modified. The pipeline is purely
+opt-in and will be wired surface-by-surface in follow-up PRs.
+
+## What ships
+
+- `dashboard/package.json` — `openapi-typescript@^7.4.4` added to
+  `devDependencies`; new scripts `gen:types` and `gen:types:check`
+  pointing at `/openapi.json` (overridable via `OPENAPI_URL`).
+- `dashboard/src/lib/api-generated.ts` — placeholder destination,
+  documented as "do not import yet."
+- `docs/reports/openapi_codegen_migration_plan.md` — H5a → H5-migrate
+  staged plan with rollback section.
+- This outbound notice.
+
+## Why scaffold-only
+
+The audit's claim of "42 hand-written type files duplicating FastAPI
+schema" was a text-match overcount. Survey of `dashboard/src/lib/`
+showed:
+
+- One primary `types.ts` plus a handful of per-surface contract
+  files (`chatProfiles.ts`, `chatSessionContract.ts`,
+  `controlPlanePageMeta.ts`, `runtimeOperatorHandbook.ts`, etc.).
+- Several of those files encode UI-side invariants (`zod` schemas,
+  narrowed unions, frontend-only fields) that the OpenAPI schema
+  cannot express, so they cannot be wholesale replaced.
+
+A single-PR mass rewrite would touch every hook, every page, and
+every test, which violates the doctrine's preference for piecewise,
+reversible changes. Scaffold-only matches the pattern used for
+PR-H3 (provider_registry) and PR-H4 (storage_schema_registry).
+
+## Anti-doctrine self-check
+
+- **New substrate?** No — `openapi-typescript` is the standard
+  community tool for this. No in-house abstraction.
+- **Meta-framework?** No — codegen is a build-time script, not a
+  runtime layer.
+- **Parallel governance?** No — hand-written types remain the
+  public contract on every surface until that surface is migrated
+  under operator review.
+- **Vague prose?** Migration plan names every file, every router,
+  and every rollback step.
+- **Autonomous merging?** No — every staged migration ships as its
+  own PR with operator approval.
+- **Frozen surfaces touched?** No.
+  - `dharma_swarm/spine/**` — untouched
+  - `orchestrator.py` — untouched
+  - `agent_runner.py` — untouched
+  - `runtime_state.py` — untouched
+  - `tests/test_dispatch_dropoff_sources.py` — untouched
+  - `tools/spine_check.py` — untouched
+- **Backend touched?** No. `api/main.py` and routers are unchanged.
+  The pipeline only consumes the OpenAPI schema FastAPI already
+  serves at `/openapi.json`.
+
+## Verification
+
+- `package.json` is valid JSON (parsed via `python -m json.tool`).
+- `api-generated.ts` exports nothing usable; any hook trying to
+  import a named symbol from it will fail type-check, preventing
+  accidental adoption before H5a is reviewed.
+- Migration plan documents the drift-guard pattern that makes H5a
+  safe: a `satisfies`-style compile-time assertion between the
+  generated type and the hand-written type. If FastAPI's schema
+  drifts from the hand-written type, the dashboard build fails
+  before runtime.
+
+## Rollback
+
+Delete the four files listed in
+`docs/reports/openapi_codegen_migration_plan.md#rollback` and revert
+the `package.json` additions. Zero behavioral blast radius — no
+existing build path consumes `openapi-typescript` until an
+operator-approved follow-up PR opts in.
+
+## Follow-up PRs queued (each operator-approved)
+
+- **H5a** — wire `useHealth.ts` to a compile-time drift guard
+  against `components["schemas"]["HealthOut"]`. Hand-written type
+  stays.
+- **H5b–H5n** — opt in `agents`, `evolution`, `ontology`,
+  `lineage`, `stigmergy`, `commands`, then chat last.
+- **H5-ci** — CI drift check via `npm run gen:types:check`.
+- **H5-migrate** — per-surface, replace hand-written aliases with
+  `components["schemas"][...]` re-exports where the OpenAPI schema
+  is a complete description of the type. Hand-written types that
+  encode UI-only invariants stay and are documented inline.


### PR DESCRIPTION
## PR-H5 (scaffold): openapi-typescript codegen pipeline

Adds the dashboard type generation pipeline against FastAPI's
`/openapi.json` without removing or replacing any hand-written
types.

**Authority:** `external_worker_evidence_only`
**Track:** `runtime-truth-spine-2026-06`
**Slate position:** H5 of `{H1, H2, H3, H4, H5}` (sibling PR, not stacked).

## What this adds

| Path | Purpose |
|------|---------|
| `dashboard/package.json` | `openapi-typescript@^7.4.4` devDep + `gen:types`, `gen:types:check` scripts (default `http://127.0.0.1:8420/openapi.json`, overridable via `OPENAPI_URL`) |
| `dashboard/src/lib/api-generated.ts` | Placeholder destination, documented "do not import yet." Exports nothing so accidental adoption fails type-check. |
| `docs/reports/openapi_codegen_migration_plan.md` | Staged H5a → H5b..n → H5-ci → H5-migrate plan with drift-guard pattern and per-stage rollback. |
| `inter_agent/devin/outbound/2026-05-30-devin-openapi-codegen.md` | Outbound notice with anti-doctrine self-check. |

## What this does NOT do

- Does **not** run codegen in CI.
- Does **not** modify any hook, page, component, test, or hand-written type file.
- Does **not** modify `api/main.py` or any router (no backend changes).
- Does **not** touch frozen surfaces (`spine/**`, `orchestrator.py`, `agent_runner.py`, `runtime_state.py`, `tests/test_dispatch_dropoff_sources.py`, `tools/spine_check.py`).

## Audit correction

The audit's claim of "42 hand-written type files duplicating
FastAPI schema" was a text-match overcount. Survey of
`dashboard/src/lib/` shows one primary `types.ts` plus a handful
of per-surface contract files (`chatProfiles.ts`,
`chatSessionContract.ts`, `controlPlanePageMeta.ts`,
`runtimeOperatorHandbook.ts`, …). Several encode UI-side invariants
(`zod` schemas, narrowed unions, frontend-only fields) the OpenAPI
schema cannot express, so they cannot be wholesale replaced.

A single-PR mass rewrite would touch every hook, every page, and
every test, violating the doctrine's preference for piecewise,
reversible changes. Scaffold-only matches the pattern used for
PR-H3 (#389) and PR-H4 (#390).

## Drift-guard pattern (staged for H5a)

When `useHealth.ts` opts in, the migration plan calls for a
compile-time `satisfies`-style assertion between the generated
type and the hand-written `HealthOut`. If the FastAPI schema
drifts, the dashboard build fails before runtime — the
hand-written type is not removed in that step.

## Rollback

Delete the three new files and revert the `package.json`
additions. Zero behavioral blast radius — no existing build path
consumes `openapi-typescript` until an operator-approved follow-up
PR opts in.

## Anti-doctrine self-check

- New substrate? **No** — `openapi-typescript` is the standard community tool.
- Meta-framework? **No** — codegen is a build-time script, not a runtime layer.
- Parallel governance? **No** — hand-written types remain the public contract until each surface is migrated under operator review.
- Vague prose? **No** — migration plan names every file, router, and rollback step.
- Autonomous merging? **No** — every stage ships as its own PR.
- Frozen surfaces? **None touched.**

## Verification

- `package.json` parses as valid JSON.
- `api-generated.ts` exports nothing usable; any hook trying to import a named symbol from it will fail type-check, preventing accidental adoption before H5a is reviewed.

## Follow-up PRs (each operator-approved)

- **H5a** — wire `useHealth.ts` to a compile-time drift guard against `components["schemas"]["HealthOut"]`. Hand-written type stays.
- **H5b–H5n** — opt in `agents`, `evolution`, `ontology`, `lineage`, `stigmergy`, `commands`, then chat last.
- **H5-ci** — CI drift check via `npm run gen:types:check`.
- **H5-migrate** — per-surface, replace hand-written aliases with `components["schemas"][...]` re-exports where the OpenAPI schema is a complete description of the type.

## Coherence Delta

- Organ touched: dashboard/codegen (scaffold)
- Declared-vs-actual gap closed: Creates openapi-typescript codegen pipeline
- Proof that re-reads the map: Scaffold only — no existing code modified
- New drift introduced: None — additive scaffold