### PR TITLE
feat(pr): add governed review control lane

### DIFF
--- a/.github/workflows/codex-mention-router.yml
+++ b/.github/workflows/codex-mention-router.yml
@@ -8,34 +8,69 @@ on:
 
 permissions:
   contents: read
+  issues: write
+  pull-requests: write
 
 jobs:
   route:
     if: >
       ${{
         contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
-        contains(github.event.comment.body, '@terminal-review')
+        contains(github.event.comment.body, '@terminal-review') &&
+        (github.event_name == 'pull_request_review_comment' || github.event.issue.pull_request)
       }}
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
-      - name: Send event to local Codex bridge
+      - uses: actions/checkout@v4
+
+      - name: Determine PR number
+        id: pr
         run: |
-          test -n "$CODEX_WEBHOOK_URL"
-          test -n "$CODEX_WEBHOOK_TOKEN"
-
-          cat > event.json <<'JSON'
-          ${{ toJson(github.event) }}
-          JSON
-
-          curl --fail-with-body -sS -X POST "$CODEX_WEBHOOK_URL" \
-            -H "Authorization: Bearer $CODEX_WEBHOOK_TOKEN" \
-            -H "Content-Type: application/json" \
-            -H "X-GitHub-Event: ${{ github.event_name }}" \
-            -H "X-GitHub-Delivery: ${{ github.run_id }}-${{ github.run_attempt }}" \
-            --connect-timeout 10 \
-            --max-time 60 \
-            --data-binary @event.json
+          if [ -n "${PR_FROM_REVIEW:-}" ]; then
+            echo "number=${PR_FROM_REVIEW}" >> "${GITHUB_OUTPUT}"
+          else
+            echo "number=${PR_FROM_ISSUE}" >> "${GITHUB_OUTPUT}"
+          fi
         env:
-          CODEX_WEBHOOK_URL: ${{ secrets.CODEX_WEBHOOK_URL }}
-          CODEX_WEBHOOK_TOKEN: ${{ secrets.CODEX_WEBHOOK_TOKEN }}
+          PR_FROM_ISSUE: ${{ github.event.issue.number }}
+          PR_FROM_REVIEW: ${{ github.event.pull_request.number }}
+
+      - name: Run deterministic terminal-review packet
+        id: review
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          set -euo pipefail
+          state_root="${RUNNER_TEMP}/dharma-pr-review"
+          python3 scripts/runtime/pr_merge_control.py --state-root "${state_root}" packet --pr "${PR_NUMBER}"
+          set +e
+          python3 scripts/runtime/pr_merge_control.py --state-root "${state_root}" gate --pr "${PR_NUMBER}"
+          gate_exit="$?"
+          set -e
+          python3 scripts/runtime/pr_merge_control.py --state-root "${state_root}" comment --pr "${PR_NUMBER}" --output "${RUNNER_TEMP}/terminal-review.md"
+          echo "gate_exit=${gate_exit}" >> "${GITHUB_OUTPUT}"
+
+      - name: Post or update terminal-review comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          set -euo pipefail
+          marker="<!-- dharma-pr-review-control:auto -->"
+          existing="$(gh pr view "${PR_NUMBER}" --json comments \
+            --jq '.comments[] | select(.body | startswith("'"${marker}"'")) | .id' \
+            | head -1)"
+          if [ -n "${existing}" ]; then
+            gh api --method PATCH \
+              "/repos/${GITHUB_REPOSITORY}/issues/comments/${existing}" \
+              -f body="$(cat "${RUNNER_TEMP}/terminal-review.md")"
+          else
+            gh pr comment "${PR_NUMBER}" --body-file "${RUNNER_TEMP}/terminal-review.md"
+          fi
+
+      - name: Summarize
+        run: |
+          echo "terminal-review gate exit: ${{ steps.review.outputs.gate_exit }}"
+          cat "${RUNNER_TEMP}/terminal-review.md"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # DHARMA SWARM — Makefile
 # Run `make help` to see all targets.
 
-.PHONY: help boot stop logs health metrics test lint clean install docker-up docker-down gh-auth semgrep semgrep-strict gitleaks precommit-install precommit-run governance-baseline test-hygiene test-contracts uplift-guards module-budget docops-integrity docops-report memory-kernel-readiness memory-kernel-readiness-strict memory-kernel-burn-in memory-kernel-write-receipt-smoke memory-kernel-promotion-smoke memory-kernel-knowledgeops-bridge-smoke memory-kernel-full-power-preflight operator-prod-smoke governance-all spine-check onboard status go-fmt-check go-test go-vet go-ci
+.PHONY: help boot stop logs health metrics test lint clean install docker-up docker-down gh-auth semgrep semgrep-strict gitleaks precommit-install precommit-run governance-baseline test-hygiene test-contracts uplift-guards module-budget docops-integrity docops-report pr-queue pr-packet pr-gate pr-reviewers pr-run-codex pr-run-claude pr-merge memory-kernel-readiness memory-kernel-readiness-strict memory-kernel-burn-in memory-kernel-write-receipt-smoke memory-kernel-promotion-smoke memory-kernel-knowledgeops-bridge-smoke memory-kernel-full-power-preflight operator-prod-smoke governance-all spine-check onboard status go-fmt-check go-test go-vet go-ci
 
 PYTHON ?= python3
 REPO_PYTHON ?= PYTHONPATH=. $(PYTHON)
@@ -45,6 +45,13 @@ help:
 	@echo "  make uplift-guards Run uplift pre-commit guards"
 	@echo "  make docops-integrity Run machine-verifiable documentation checks"
 	@echo "  make docops-report Generate local DocOps JSON/Markdown reports"
+	@echo "  make pr-queue Classify open GitHub PRs into a receipt-backed review queue"
+	@echo "  make pr-packet PR=123 Create a Codex/Claude review packet for one PR"
+	@echo "  make pr-reviewers Show local Codex/Claude reviewer readiness"
+	@echo "  make pr-run-codex PR=123 Run Codex against the latest review packet"
+	@echo "  make pr-run-claude PR=123 Run Claude Code against the latest review packet"
+	@echo "  make pr-gate PR=123 Verify merge gate against live GitHub state"
+	@echo "  make pr-merge PR=123 ARGS='--confirm merge-pr-123' Dry-run gated merge"
 	@echo "  make memory-kernel-readiness Run read-only MemoryKernel readiness gates"
 	@echo "  make memory-kernel-readiness-strict Require 100% strict MemoryKernel readiness"
 	@echo "  make memory-kernel-burn-in Append M3 context preview burn-in receipts"
@@ -210,6 +217,27 @@ docops-report:
 		--report-json reports/docops/check.json \
 		--inventory-json reports/docops/corpus_inventory.json \
 		--inventory-markdown reports/docops/corpus_inventory.md
+
+pr-queue:
+	$(PYTHON) scripts/runtime/pr_merge_control.py queue $${ARGS:-}
+
+pr-packet:
+	$(PYTHON) scripts/runtime/pr_merge_control.py packet --pr "$${PR:?set PR=number}" $${ARGS:-}
+
+pr-gate:
+	$(PYTHON) scripts/runtime/pr_merge_control.py gate --pr "$${PR:?set PR=number}" $${ARGS:-}
+
+pr-reviewers:
+	$(PYTHON) scripts/runtime/pr_merge_control.py reviewers $${ARGS:-}
+
+pr-run-codex:
+	$(PYTHON) scripts/runtime/pr_merge_control.py run-agent --agent codex --pr "$${PR:?set PR=number}" $${ARGS:-}
+
+pr-run-claude:
+	$(PYTHON) scripts/runtime/pr_merge_control.py run-agent --agent claude --pr "$${PR:?set PR=number}" $${ARGS:-}
+
+pr-merge:
+	$(PYTHON) scripts/runtime/pr_merge_control.py merge --pr "$${PR:?set PR=number}" $${ARGS:-}
 
 memory-kernel-readiness:
 	$(REPO_PYTHON) scripts/memory_kernel_readiness.py --repo-root . --dry-run

--- a/docs/architecture/NAVIGATION.md
+++ b/docs/architecture/NAVIGATION.md
@@ -112,6 +112,7 @@ Generated: 2026-03-29 | 500 Python modules | 494 test files | 8,848 tests
 | See subconscious dreams | `dgc hum` |
 | Run the CWT read-only collector v0 | `python3 scripts/runtime/cwt_collect.py` (stdout) or `--out-dir <path>` |
 | Render a CWT v0 report | `python3 scripts/runtime/cwt_report.py` → writes to `reports/control_watch_tower/<ts>/` (doctrine: [`docs/agents/CONTROL_WATCH_TOWER.md`](../agents/CONTROL_WATCH_TOWER.md); schemas: [`schemas/control_watch_tower_*.v0.json`](../../schemas/)) |
+| Govern PR review/merge cleanup | `make pr-queue`, `make pr-packet PR=<n>`, `make pr-run-codex PR=<n>`, `make pr-run-claude PR=<n>`, `make pr-gate PR=<n>`; implementation: `scripts/runtime/pr_merge_control.py`, docs: [`docs/ops/PR_REVIEW_CONTROL.md`](../ops/PR_REVIEW_CONTROL.md), GitHub mention surface: `.github/workflows/codex-mention-router.yml` |
 | Find a module | Search this file or `ls dharma_swarm/dharma_swarm/*.py` |
 | Find the data model | `dharma_swarm/models.py` |
 | Find the config | `dharma_swarm/config.py` (env var overrides) |

--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -9,10 +9,10 @@ Do not hand-edit the generated block.
 | Dharma Python modules | 659 |
 | Top-level Dharma Python modules | 389 |
 | Dharma Python LOC | 277,517 |
-| Test files | 610 |
-| Test function occurrences | 10,639 |
-| Markdown files | 751 |
-| Markdown total lines | 189,509 |
+| Test files | 611 |
+| Test function occurrences | 10,671 |
+| Markdown files | 752 |
+| Markdown total lines | 189,673 |
 | Bridge files | 24 |
 | Adapter files | 20 |
 | Orchestrator files | 4 |

--- a/docs/governance/SOVEREIGN_MANIFEST.md
+++ b/docs/governance/SOVEREIGN_MANIFEST.md
@@ -128,12 +128,12 @@ These are the ground-truth metrics. All other documents citing different numbers
 | Total Python modules | **659** | find dharma_swarm -name "*.py" -type f |
 | Top-level (flat) modules | **389 (59.0%)** | find dharma_swarm -maxdepth 1 -name "*.py" -type f |
 | Total Python LOC | **277,517** | wc -l across dharma_swarm Python modules |
-| Test files | **610** | find tests -name "*.py" -type f |
-| Test functions | **10,639 `def test_` occurrences under tests/** | rg "def test_" tests |
+| Test files | **611** | find tests -name "*.py" -type f |
+| Test functions | **10,671 `def test_` occurrences under tests/** | rg "def test_" tests |
 | Tests collected (pytest) | **Needs write-permitted refresh** | not run during this DocOps count pass |
 | Collection errors | **Historical: 16 on 2026-04-04** | refresh before relying on this count |
-| Markdown files | **751** | find . -name "*.md" -type f |
-| Markdown total lines | **189,509** | wc -l across all .md |
+| Markdown files | **752** | find . -name "*.md" -type f |
+| Markdown total lines | **189,673** | wc -l across all .md |
 | Bridge files | **24** | find dharma_swarm -name "*bridge*.py" |
 | Adapter files | **20 across 8 locations** | find dharma_swarm -type f \| rg -i "adapter" |
 | Orchestrator files | **4** (6,034 LOC total) | find dharma_swarm -name "*orchestrat*" |

--- a/docs/ops/PR_REVIEW_CONTROL.md
+++ b/docs/ops/PR_REVIEW_CONTROL.md
@@ -53,8 +53,8 @@ token:
 make pr-merge PR=397 ARGS="--confirm merge-pr-397 --execute"
 ```
 
-High-risk and critical PRs require `--human-approved` even when Codex and Claude
-both provide review receipts.
+High-risk and critical PRs require `--human-approved` plus
+`--human-approval-note` even when Codex and Claude both provide review receipts.
 
 ## Receipt Layout
 
@@ -96,7 +96,8 @@ The gate blocks when any of these are true:
 - Review-thread lookup fails or review threads are unresolved.
 - `codex_review.md` / `codex_review_receipt.json` is missing, invalid, nonzero-exit, stale-head, or not an `APPROVE` verdict.
 - `claude_review.md` / `claude_review_receipt.json` is missing, invalid, nonzero-exit, stale-head, or not an `APPROVE` verdict.
-- Risk is `HIGH` or `CRITICAL` and no `--human-approved` flag is present.
+- Risk is `HIGH` or `CRITICAL` and no `--human-approved` flag plus
+  `--human-approval-note` receipt is present.
 
 ## Agent Contract
 

--- a/docs/ops/PR_REVIEW_CONTROL.md
+++ b/docs/ops/PR_REVIEW_CONTROL.md
@@ -1,0 +1,128 @@
+# PR Review Control
+
+Status: local operator control surface.
+
+Purpose: make GitHub PR review and merge decisions receipt-backed, dual-agent,
+and fast enough for a large open-PR queue. This does not replace GitHub branch
+protection, CI, AgentOps, or human approval. It gives Codex and Claude Code the
+same packet, then blocks merge unless deterministic gates and both reviews are
+present.
+
+## Why `@terminal-review` Was Brittle
+
+`.github/workflows/codex-mention-router.yml` only forwards a GitHub comment to
+`CODEX_WEBHOOK_URL`. If that secret, token, or local bridge is down, the mention
+does nothing useful. PR Review Control is pull-based from the local operator
+machine: it asks GitHub for live state, writes packets under `~/.dharma`, and
+does not depend on inbound webhooks.
+
+## Commands
+
+```bash
+make pr-queue
+make pr-packet PR=397
+make pr-reviewers
+make pr-run-codex PR=397
+make pr-run-claude PR=397
+make pr-gate PR=397
+make pr-merge PR=397 ARGS="--confirm merge-pr-397"
+```
+
+`make pr-run-claude` prefers `/Users/dhyana/.npm-global/bin/claude` and removes
+`ANTHROPIC_API_KEY` from the Claude process by default. This prevents a depleted
+Anthropic Console key from hijacking Claude Code subscription auth. To force
+API-key billing for a funded key, set:
+
+```bash
+DHARMA_CLAUDE_REVIEW_USE_API_KEY=1 make pr-run-claude PR=397
+```
+
+To override the binary entirely:
+
+```bash
+CLAUDE_REVIEW_COMMAND="/Users/dhyana/.npm-global/bin/claude -p" make pr-run-claude PR=397
+```
+
+`make pr-merge` is dry-run by default. It prints the `gh pr merge` command only
+after the gate passes. To execute, add `--execute` and the exact confirmation
+token:
+
+```bash
+make pr-merge PR=397 ARGS="--confirm merge-pr-397 --execute"
+```
+
+High-risk and critical PRs require `--human-approved` even when Codex and Claude
+both provide review receipts.
+
+## Receipt Layout
+
+```text
+~/.dharma/pr_review/
+  queue/
+    latest.json
+    latest.md
+  pr-397/
+    20260531T000000Z/
+      FACTS.json
+      REVIEW_PACKET.md
+      PR_BODY.md
+      changed_files.txt
+      PROMPT_CODEX.md
+      PROMPT_CLAUDE.md
+      codex_review.md
+      claude_review.md
+      MERGE_GATE.json
+      MERGE_GATE.md
+```
+
+The packet includes current mergeability, CI rollup, Coherence Delta status,
+changed files, hot-path risk, and unresolved review-thread count when GitHub
+GraphQL is available.
+
+## Merge Gate
+
+The gate blocks when any of these are true:
+
+- PR is draft.
+- GitHub says the branch is not mergeable.
+- Any check is failing.
+- Checks are pending, unless `--allow-pending` is explicitly passed.
+- GitHub review decision is `CHANGES_REQUESTED`.
+- Coherence Delta fields are missing or placeholders.
+- Review threads are unresolved.
+- `codex_review.md` is missing.
+- `claude_review.md` is missing.
+- Risk is `HIGH` or `CRITICAL` and no `--human-approved` flag is present.
+
+## Agent Contract
+
+Codex and Claude read the same `REVIEW_PACKET.md` and answer from their own
+fresh context. The generator of a change must not be the only evaluator of that
+change. Each review must put findings first, cite concrete file evidence, and
+state exact merge conditions.
+
+## Non-Interactive Claude Reviews
+
+Claude reviews can run unattended only after one of these credentials is valid:
+
+- Claude Code subscription auth with a long-lived token from
+  `claude setup-token`.
+- A funded Anthropic Console key, explicitly enabled with
+  `DHARMA_CLAUDE_REVIEW_USE_API_KEY=1`.
+
+The first OAuth or token grant must be human-approved. After that, the review
+lane should be non-interactive until the token expires, is revoked, or the
+account runs out of quota.
+
+## Queue Triage
+
+Use `make pr-queue` first. `GITHUB_GREEN_NEEDS_PACKET` means GitHub has no
+obvious blocker; it is not merge permission. Typical ordering:
+
+1. Close or repair `BLOCKED_CONFLICT`, `BLOCKED_CHECKS`, and
+   `BLOCKED_REVIEW`.
+2. Packet and review `GITHUB_GREEN_NEEDS_PACKET` PRs that are low or medium
+   risk.
+3. Packet high-risk PRs only after the active track and hot-path ownership are
+   clear.
+4. Keep large or doctrine-changing PRs out of batch merges.

--- a/docs/ops/PR_REVIEW_CONTROL.md
+++ b/docs/ops/PR_REVIEW_CONTROL.md
@@ -25,16 +25,24 @@ does not depend on inbound webhooks.
 make pr-queue
 make pr-packet PR=397
 make pr-reviewers
-make pr-run-codex PR=397
-make pr-run-claude PR=397
+make pr-run-codex PR=397 ARGS="--timeout-s 240"
+make pr-run-claude PR=397 ARGS="--timeout-s 240"
 make pr-gate PR=397
 make pr-merge PR=397 ARGS="--confirm merge-pr-397"
 ```
 
-`make pr-run-claude` prefers `/Users/dhyana/.npm-global/bin/claude` and removes
-`ANTHROPIC_API_KEY` from the Claude process by default. This prevents a depleted
-Anthropic Console key from hijacking Claude Code subscription auth. To force
-API-key billing for a funded key, set:
+`make pr-run-codex` uses `codex exec --ephemeral` with
+`model_reasoning_effort="medium"` by default so queue reviews do not inherit an
+unbounded xhigh interactive profile. Override with
+`DHARMA_CODEX_REVIEW_REASONING_EFFORT=high` or `CODEX_REVIEW_COMMAND=...` when a
+single PR deserves a slower review.
+
+`make pr-run-claude` prefers `/Users/dhyana/.npm-global/bin/claude -p
+--max-turns 8` and removes `ANTHROPIC_API_KEY` from the Claude process by
+default. This prevents a depleted Anthropic Console key from hijacking Claude
+Code subscription auth, and the max-turn cap makes quota/auth failures surface
+as receipts instead of silent stalls. To force API-key billing for a funded key,
+set:
 
 ```bash
 DHARMA_CLAUDE_REVIEW_USE_API_KEY=1 make pr-run-claude PR=397
@@ -44,6 +52,22 @@ To override the binary entirely:
 
 ```bash
 CLAUDE_REVIEW_COMMAND="/Users/dhyana/.npm-global/bin/claude -p" make pr-run-claude PR=397
+```
+
+Reviewer runs are bounded. The default wall-clock timeout is 600 seconds, or
+`CODEX_REVIEW_TIMEOUT_SECONDS` / `CLAUDE_REVIEW_TIMEOUT_SECONDS` when set. To
+tighten one run:
+
+```bash
+make pr-run-codex PR=397 ARGS="--timeout-s 120"
+make pr-run-claude PR=397 ARGS="--timeout-s 120"
+```
+
+Use a live probe when auth says Claude is logged in but runtime/quota may be
+stale:
+
+```bash
+make pr-reviewers ARGS="--live-probe --probe-timeout-s 20"
 ```
 
 `make pr-merge` is dry-run by default. It prints the `gh pr merge` command only
@@ -68,6 +92,7 @@ High-risk and critical PRs require `--human-approved` plus
     20260531T000000Z/
       FACTS.json
       REVIEW_PACKET.md
+      DIFF.patch
       PR_BODY.md
       changed_files.txt
       PROMPT_CODEX.md
@@ -79,8 +104,9 @@ High-risk and critical PRs require `--human-approved` plus
 ```
 
 The packet includes current mergeability, CI rollup, Coherence Delta status,
-changed files, hot-path risk, and unresolved review-thread count when GitHub
-GraphQL is available.
+changed files, hot-path risk, unresolved review-thread count when GitHub
+GraphQL is available, and a `DIFF.patch` snapshot so reviewers do not need to
+start with broad repository scans.
 
 ## Merge Gate
 

--- a/docs/ops/PR_REVIEW_CONTROL.md
+++ b/docs/ops/PR_REVIEW_CONTROL.md
@@ -10,11 +10,13 @@ present.
 
 ## Why `@terminal-review` Was Brittle
 
-`.github/workflows/codex-mention-router.yml` only forwards a GitHub comment to
-`CODEX_WEBHOOK_URL`. If that secret, token, or local bridge is down, the mention
-does nothing useful. PR Review Control is pull-based from the local operator
-machine: it asks GitHub for live state, writes packets under `~/.dharma`, and
-does not depend on inbound webhooks.
+`.github/workflows/codex-mention-router.yml` now owns the GitHub-side
+`@terminal-review` response: it creates the same deterministic packet/gate
+summary comment that the local CLI prints. The older
+`scripts/codex_mention_bridge.py` remains a local webhook bridge for inbound
+experiments, but it is not the merge authority. PR Review Control is pull-based
+from the local operator machine: it asks GitHub for live state, writes packets
+under `~/.dharma`, and does not depend on inbound webhooks.
 
 ## Commands
 
@@ -89,9 +91,9 @@ The gate blocks when any of these are true:
 - Checks are pending, unless `--allow-pending` is explicitly passed.
 - GitHub review decision is `CHANGES_REQUESTED`.
 - Coherence Delta fields are missing or placeholders.
-- Review threads are unresolved.
-- `codex_review.md` is missing.
-- `claude_review.md` is missing.
+- Review-thread lookup fails or review threads are unresolved.
+- `codex_review.md` is missing, invalid, or not an `APPROVE` verdict.
+- `claude_review.md` is missing, invalid, or not an `APPROVE` verdict.
 - Risk is `HIGH` or `CRITICAL` and no `--human-approved` flag is present.
 
 ## Agent Contract

--- a/docs/ops/PR_REVIEW_CONTROL.md
+++ b/docs/ops/PR_REVIEW_CONTROL.md
@@ -14,9 +14,10 @@ present.
 `@terminal-review` response: it creates the same deterministic packet/gate
 summary comment that the local CLI prints. The older
 `scripts/codex_mention_bridge.py` remains a local webhook bridge for inbound
-experiments, but it is not the merge authority. PR Review Control is pull-based
-from the local operator machine: it asks GitHub for live state, writes packets
-under `~/.dharma`, and does not depend on inbound webhooks.
+experiments and now defaults to `@codex`, not `@terminal-review`. It is not the
+merge authority. PR Review Control is pull-based from the local operator
+machine: it asks GitHub for live state, writes packets under `~/.dharma`, and
+does not depend on inbound webhooks.
 
 ## Commands
 
@@ -96,6 +97,9 @@ The gate blocks when any of these are true:
 - Review-thread lookup fails or review threads are unresolved.
 - `codex_review.md` / `codex_review_receipt.json` is missing, invalid, nonzero-exit, stale-head, or not an `APPROVE` verdict.
 - `claude_review.md` / `claude_review_receipt.json` is missing, invalid, nonzero-exit, stale-head, or not an `APPROVE` verdict.
+- A review receipt lacks the exact `## Verdict`, `## Findings`,
+  `## Missing Tests Or Proof`, and `## Merge Conditions` sections.
+- A review receipt is a shallow approval without concrete file/path evidence.
 - Risk is `HIGH` or `CRITICAL` and no `--human-approved` flag plus
   `--human-approval-note` receipt is present.
 

--- a/docs/ops/PR_REVIEW_CONTROL.md
+++ b/docs/ops/PR_REVIEW_CONTROL.md
@@ -86,14 +86,16 @@ GraphQL is available.
 The gate blocks when any of these are true:
 
 - PR is draft.
+- PR head SHA changed since packet/review generation.
 - GitHub says the branch is not mergeable.
 - Any check is failing.
+- Check rollup is empty or contains an unknown conclusion.
 - Checks are pending, unless `--allow-pending` is explicitly passed.
 - GitHub review decision is `CHANGES_REQUESTED`.
 - Coherence Delta fields are missing or placeholders.
 - Review-thread lookup fails or review threads are unresolved.
-- `codex_review.md` is missing, invalid, or not an `APPROVE` verdict.
-- `claude_review.md` is missing, invalid, or not an `APPROVE` verdict.
+- `codex_review.md` / `codex_review_receipt.json` is missing, invalid, nonzero-exit, stale-head, or not an `APPROVE` verdict.
+- `claude_review.md` / `claude_review_receipt.json` is missing, invalid, nonzero-exit, stale-head, or not an `APPROVE` verdict.
 - Risk is `HIGH` or `CRITICAL` and no `--human-approved` flag is present.
 
 ## Agent Contract

--- a/scripts/codex_mention_bridge.py
+++ b/scripts/codex_mention_bridge.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """Local webhook bridge for GitHub @codex PR comments.
 
-The GitHub workflow forwards mention events here. This server verifies the
-shared token, fetches PR context with gh, runs Codex CLI once, and posts the
-result back to the PR conversation.
+This is a local experiment bridge, not the governed `@terminal-review` merge
+control lane. The GitHub workflow in `.github/workflows/codex-mention-router.yml`
+owns `@terminal-review`; this bridge defaults to `@codex` unless an operator
+explicitly sets CODEX_MENTION_HANDLE.
 """
 
 from __future__ import annotations
@@ -482,7 +483,7 @@ def build_config(argv: list[str]) -> BridgeConfig:
         repo_path=repo_path,
         token=token,
         model=os.environ.get("CODEX_MODEL", "gpt-5.5"),
-        mention_handle=os.environ.get("CODEX_MENTION_HANDLE", "@terminal-review"),
+        mention_handle=os.environ.get("CODEX_MENTION_HANDLE", "@codex"),
         host=args.host,
         port=args.port,
         allowed_repos=parse_allowed_repos(os.environ.get("CODEX_ALLOWED_REPOS"), repo_path),

--- a/scripts/runtime/pr_merge_control.py
+++ b/scripts/runtime/pr_merge_control.py
@@ -807,7 +807,7 @@ def cmd_reviewers(args: argparse.Namespace) -> int:
         "generated_at": utc_now(),
         "claude": {
             "command": claude_command,
-            "anthropic_api_key_scrubbed": "ANTHROPIC_API_KEY" not in claude_env,
+            "credential_env_scrubbed": "ANTHROPIC_API_KEY" not in claude_env,
             "auth_status_exit": claude_proc.returncode,
             "auth_status": claude_payload,
             "ready": bool(isinstance(claude_payload, dict) and claude_payload.get("loggedIn")),
@@ -822,7 +822,7 @@ def cmd_reviewers(args: argparse.Namespace) -> int:
         return 0 if result["claude"]["ready"] else 2
 
     print(f"Claude command: {' '.join(claude_command)}")
-    print(f"Claude ANTHROPIC_API_KEY scrubbed: {result['claude']['anthropic_api_key_scrubbed']}")
+    print(f"Claude credential env scrubbed: {result['claude']['credential_env_scrubbed']}")
     print(f"Claude ready: {result['claude']['ready']}")
     if isinstance(claude_payload, dict):
         print(f"Claude auth: {json.dumps(claude_payload, sort_keys=True)}")

--- a/scripts/runtime/pr_merge_control.py
+++ b/scripts/runtime/pr_merge_control.py
@@ -341,8 +341,11 @@ def coherence_results(body: str) -> dict[str, Any]:
             f"* {field}:",
             f"{field}:",
             f"- **{field}**:",
+            f"- **{field}:**",
             f"* **{field}**:",
+            f"* **{field}:**",
             f"**{field}**:",
+            f"**{field}:**",
         )
         value = None
         for index, line in enumerate(lines):

--- a/scripts/runtime/pr_merge_control.py
+++ b/scripts/runtime/pr_merge_control.py
@@ -574,6 +574,28 @@ def has_review(path: Path) -> bool:
     return path.exists() and len(path.read_text(encoding="utf-8").strip()) >= 40
 
 
+def review_receipt_status(path: Path) -> dict[str, Any]:
+    if not has_review(path):
+        return {"ok": False, "verdict": "", "reason": "missing or too short"}
+    text = path.read_text(encoding="utf-8")
+    lowered = text.lower()
+    if "error:" in lowered or "failed to initialize" in lowered or "traceback" in lowered:
+        return {"ok": False, "verdict": "", "reason": "review command failed"}
+    lines = [line.strip() for line in text.splitlines()]
+    allowed = {"APPROVE", "REQUEST_CHANGES", "BLOCKED", "NEEDS_HUMAN"}
+    for index, line in enumerate(lines):
+        if line.lower() != "## verdict":
+            continue
+        for candidate in lines[index + 1:]:
+            if not candidate:
+                continue
+            verdict = candidate.split()[0].strip("`*_-. ")
+            if verdict in allowed:
+                return {"ok": True, "verdict": verdict, "reason": ""}
+            return {"ok": False, "verdict": verdict, "reason": "invalid verdict"}
+    return {"ok": False, "verdict": "", "reason": "missing ## Verdict section"}
+
+
 def build_gate(args: argparse.Namespace) -> dict[str, Any]:
     out_dir = latest_or_arg_packet(args)
     original = load_json(out_dir / "FACTS.json")
@@ -603,10 +625,12 @@ def build_gate(args: argparse.Namespace) -> dict[str, Any]:
 
     codex_path = out_dir / "codex_review.md"
     claude_path = out_dir / "claude_review.md"
-    if not has_review(codex_path):
-        blockers.append("missing codex_review.md receipt")
-    if not has_review(claude_path):
-        blockers.append("missing claude_review.md receipt")
+    codex_receipt = review_receipt_status(codex_path)
+    claude_receipt = review_receipt_status(claude_path)
+    if not codex_receipt["ok"]:
+        blockers.append(f"invalid codex_review.md receipt: {codex_receipt['reason']}")
+    if not claude_receipt["ok"]:
+        blockers.append(f"invalid claude_review.md receipt: {claude_receipt['reason']}")
 
     original_risk = original.get("risk", {}).get("level", "UNKNOWN")
     if original_risk in {"HIGH", "CRITICAL"} and not args.human_approved:
@@ -632,8 +656,12 @@ def build_gate(args: argparse.Namespace) -> dict[str, Any]:
         "review_receipts": {
             "codex": str(codex_path),
             "codex_present": has_review(codex_path),
+            "codex_valid": codex_receipt["ok"],
+            "codex_verdict": codex_receipt["verdict"],
             "claude": str(claude_path),
             "claude_present": has_review(claude_path),
+            "claude_valid": claude_receipt["ok"],
+            "claude_verdict": claude_receipt["verdict"],
         },
         "risk": original.get("risk", {}),
     }
@@ -662,8 +690,14 @@ def render_gate_markdown(gate: dict[str, Any]) -> str:
         lines.append("- none")
     lines.extend(["", "## Review Receipts", ""])
     receipts = gate["review_receipts"]
-    lines.append(f"- Codex: `{receipts['codex']}` present={receipts['codex_present']}")
-    lines.append(f"- Claude: `{receipts['claude']}` present={receipts['claude_present']}")
+    lines.append(
+        f"- Codex: `{receipts['codex']}` present={receipts['codex_present']} "
+        f"valid={receipts['codex_valid']} verdict={receipts['codex_verdict'] or 'NONE'}"
+    )
+    lines.append(
+        f"- Claude: `{receipts['claude']}` present={receipts['claude_present']} "
+        f"valid={receipts['claude_valid']} verdict={receipts['claude_verdict'] or 'NONE'}"
+    )
     lines.append("")
     return "\n".join(lines)
 

--- a/scripts/runtime/pr_merge_control.py
+++ b/scripts/runtime/pr_merge_control.py
@@ -410,6 +410,14 @@ def fetch_review_threads(pr_number: int, repo: str) -> dict[str, Any]:
     return {"ok": True, "threads": nodes, "unresolved": unresolved, "unresolved_count": len(unresolved)}
 
 
+def fetch_pr_diff(pr_number: int) -> str:
+    result = run(["gh", "pr", "diff", str(pr_number), "--patch"], timeout=180, check=False)
+    if result.code != 0:
+        detail = (result.stderr or result.stdout).strip()
+        return f"# Diff unavailable\n\n`gh pr diff {pr_number} --patch` failed:\n\n```text\n{detail}\n```\n"
+    return result.stdout
+
+
 def coherence_results(body: str) -> dict[str, Any]:
     lines = body.splitlines()
     results: dict[str, dict[str, Any]] = {}
@@ -497,14 +505,25 @@ def risk_from_files(files: list[dict[str, Any]]) -> dict[str, Any]:
 
 
 def render_agent_prompt(agent: str, packet_path: Path, pr_number: int) -> str:
+    packet_dir_path = packet_path.parent
     return f"""You are {agent}, reviewing Dharma Swarm PR #{pr_number}.
 
-Read the packet at:
+This is a bounded queue review, not an open-ended repo exploration. Primary
+context is already prepared for you. Read:
 {packet_path}
+{packet_dir_path / "DIFF.patch"}
+{packet_dir_path / "FACTS.json"}
 
 Then review the PR with a code-review stance: findings first, highest severity
 first, with file/line evidence. Do not approve from vibes. Do not merge. Do not
-modify files. Check:
+modify files.
+
+Keep tool use narrow: do not run broad repository searches, skill discovery, or
+indexing. Read only the packet, diff, and exact changed files needed to validate
+the diff. If the packet is insufficient, return NEEDS_HUMAN or BLOCKED with the
+missing proof instead of expanding indefinitely. Target <= 120 lines.
+
+Check:
 
 - CI/check state and mergeability
 - Coherence Delta fields and PR-body honesty
@@ -547,19 +566,35 @@ def review_command_and_env(
         if override:
             command = shlex.split(override)
         elif CLAUDE_REVIEW_DEFAULT_BIN.exists():
-            command = [CLAUDE_REVIEW_DEFAULT_BIN.as_posix(), "-p"]
+            command = [
+                CLAUDE_REVIEW_DEFAULT_BIN.as_posix(),
+                "-p",
+                "--max-turns",
+                env.get("DHARMA_CLAUDE_REVIEW_MAX_TURNS", "8"),
+            ]
         else:
-            command = ["claude", "-p"]
+            command = ["claude", "-p", "--max-turns", env.get("DHARMA_CLAUDE_REVIEW_MAX_TURNS", "8")]
         if env.get("DHARMA_CLAUDE_REVIEW_USE_API_KEY") != "1":
             env.pop("ANTHROPIC_API_KEY", None)
         return command, env
 
     override = env.get("CODEX_REVIEW_COMMAND", "").strip()
-    command = shlex.split(override) if override else ["codex", "exec"]
+    if override:
+        command = shlex.split(override)
+    else:
+        effort = env.get("DHARMA_CODEX_REVIEW_REASONING_EFFORT", "medium")
+        command = ["codex", "exec", "--ephemeral", "-c", f'model_reasoning_effort="{effort}"']
+        model = env.get("DHARMA_CODEX_REVIEW_MODEL", "").strip()
+        if model:
+            command.extend(["--model", model])
     return command, env
 
 
-def review_timeout_seconds(agent: str, env: dict[str, str]) -> int:
+def review_timeout_seconds(agent: str, env: dict[str, str], override: int | None = None) -> int:
+    if override is not None:
+        if override < 30:
+            raise PRControlError("--timeout-s must be at least 30 seconds")
+        return override
     key = "CLAUDE_REVIEW_TIMEOUT_SECONDS" if agent == "claude" else "CODEX_REVIEW_TIMEOUT_SECONDS"
     raw = env.get(key, "600")
     try:
@@ -619,6 +654,7 @@ def render_packet_markdown(packet: dict[str, Any]) -> str:
         "- `codex_review.md`",
         "- `claude_review.md`",
         "- `MERGE_GATE.md`",
+        "- `DIFF.patch` contains the PR diff for bounded review.",
         "",
         "Generate reviews from `PROMPT_CODEX.md` and `PROMPT_CLAUDE.md` in this directory.",
         "",
@@ -642,6 +678,7 @@ def cmd_packet(args: argparse.Namespace) -> int:
     repo = repo_name()
     files = fetch_pr_files(args.pr, repo)
     threads = fetch_review_threads(args.pr, repo)
+    diff = fetch_pr_diff(args.pr)
     classification = classify_pr(pr)
     coherence = coherence_results(pr.get("body") or "")
     risk = risk_from_files(files)
@@ -660,6 +697,7 @@ def cmd_packet(args: argparse.Namespace) -> int:
     write_json(out_dir / "FACTS.json", packet)
     write_text(out_dir / "PR_BODY.md", pr.get("body") or "")
     write_text(out_dir / "changed_files.txt", "\n".join(str(item.get("filename") or "") for item in files) + "\n")
+    write_text(out_dir / "DIFF.patch", diff)
     write_text(out_dir / "REVIEW_PACKET.md", render_packet_markdown(packet))
     write_text(out_dir / "PROMPT_CODEX.md", render_agent_prompt("Codex", out_dir / "REVIEW_PACKET.md", args.pr))
     write_text(out_dir / "PROMPT_CLAUDE.md", render_agent_prompt("Claude Code Opus", out_dir / "REVIEW_PACKET.md", args.pr))
@@ -996,6 +1034,41 @@ def cmd_reviewers(args: argparse.Namespace) -> int:
         claude_payload = json.loads(claude_proc.stdout)
     except json.JSONDecodeError:
         claude_payload = None
+    claude_auth_ready = bool(isinstance(claude_payload, dict) and claude_payload.get("loggedIn"))
+    claude_probe: dict[str, Any] | None = None
+    if args.live_probe:
+        try:
+            probe = subprocess.run(
+                claude_command,
+                input="Reply with OK only.",
+                text=True,
+                capture_output=True,
+                cwd=str(REPO_ROOT),
+                env=claude_env,
+                timeout=args.probe_timeout_s,
+                check=False,
+            )
+            claude_probe = {
+                "status": "completed" if probe.returncode == 0 else "failed",
+                "exit_code": probe.returncode,
+                "timed_out": False,
+                "stdout_excerpt": (probe.stdout or "")[:500],
+                "stderr_excerpt": (probe.stderr or "")[:500],
+            }
+        except subprocess.TimeoutExpired as exc:
+            stdout = exc.stdout or ""
+            stderr = exc.stderr or ""
+            if isinstance(stdout, bytes):
+                stdout = stdout.decode("utf-8", errors="replace")
+            if isinstance(stderr, bytes):
+                stderr = stderr.decode("utf-8", errors="replace")
+            claude_probe = {
+                "status": "timeout",
+                "exit_code": 124,
+                "timed_out": True,
+                "stdout_excerpt": stdout[:500],
+                "stderr_excerpt": stderr[:500],
+            }
 
     result = {
         "schema": "dharma.pr_review.reviewers.v1",
@@ -1005,7 +1078,9 @@ def cmd_reviewers(args: argparse.Namespace) -> int:
             "credential_env_scrubbed": "ANTHROPIC_API_KEY" not in claude_env,
             "auth_status_exit": claude_proc.returncode,
             "auth_status": claude_payload,
-            "ready": bool(isinstance(claude_payload, dict) and claude_payload.get("loggedIn")),
+            "auth_ready": claude_auth_ready,
+            "live_probe": claude_probe,
+            "ready": claude_auth_ready and (claude_probe is None or claude_probe["exit_code"] == 0),
         },
         "codex": {
             "command": codex_command,
@@ -1018,7 +1093,17 @@ def cmd_reviewers(args: argparse.Namespace) -> int:
 
     print(f"Claude command: {' '.join(claude_command)}")
     print(f"Claude credential env scrubbed: {result['claude']['credential_env_scrubbed']}")
-    print(f"Claude ready: {result['claude']['ready']}")
+    print(f"Claude auth ready: {result['claude']['auth_ready']}")
+    if claude_probe is None:
+        print("Claude live probe: not run (use ARGS='--live-probe' to check quota/runtime)")
+    else:
+        print(
+            f"Claude live probe: status={claude_probe['status']} "
+            f"exit={claude_probe['exit_code']} timed_out={claude_probe['timed_out']}"
+        )
+        probe_output = (claude_probe["stdout_excerpt"] or claude_probe["stderr_excerpt"]).strip()
+        if probe_output:
+            print(f"Claude live probe output: {probe_output}")
     if isinstance(claude_payload, dict):
         print(f"Claude auth: {json.dumps(claude_payload, sort_keys=True)}")
     else:
@@ -1074,7 +1159,7 @@ def cmd_run_agent(args: argparse.Namespace) -> int:
     output_name = "claude_review.md" if args.agent == "claude" else "codex_review.md"
     prompt = (out_dir / prompt_name).read_text(encoding="utf-8")
     command, env = review_command_and_env(args.agent)
-    timeout = review_timeout_seconds(args.agent, env)
+    timeout = review_timeout_seconds(args.agent, env, args.timeout_s)
     timed_out = False
     try:
         result = subprocess.run(
@@ -1159,12 +1244,15 @@ def build_parser() -> argparse.ArgumentParser:
 
     reviewers = sub.add_parser("reviewers", help="Check local reviewer command/auth readiness")
     reviewers.add_argument("--json", action="store_true")
+    reviewers.add_argument("--live-probe", action="store_true", help="Run a tiny Claude command to catch quota/runtime failures")
+    reviewers.add_argument("--probe-timeout-s", type=int, default=45)
     reviewers.set_defaults(func=cmd_reviewers)
 
     run_agent = sub.add_parser("run-agent", help="Run Codex or Claude against an existing packet")
     run_agent.add_argument("--pr", type=int, required=True)
     run_agent.add_argument("--packet-dir")
     run_agent.add_argument("--agent", choices=("codex", "claude"), required=True)
+    run_agent.add_argument("--timeout-s", type=int, default=None, help="Reviewer wall-clock timeout (default: reviewer env timeout or 600)")
     run_agent.set_defaults(func=cmd_run_agent)
 
     return parser

--- a/scripts/runtime/pr_merge_control.py
+++ b/scripts/runtime/pr_merge_control.py
@@ -534,6 +534,18 @@ def review_command_and_env(
     return command, env
 
 
+def review_timeout_seconds(agent: str, env: dict[str, str]) -> int:
+    key = "CLAUDE_REVIEW_TIMEOUT_SECONDS" if agent == "claude" else "CODEX_REVIEW_TIMEOUT_SECONDS"
+    raw = env.get(key, "600")
+    try:
+        timeout = int(raw)
+    except ValueError as exc:
+        raise PRControlError(f"{key} must be an integer number of seconds") from exc
+    if timeout < 30:
+        raise PRControlError(f"{key} must be at least 30 seconds")
+    return timeout
+
+
 def render_packet_markdown(packet: dict[str, Any]) -> str:
     pr = packet["pr"]
     risk = packet["risk"]
@@ -1037,16 +1049,33 @@ def cmd_run_agent(args: argparse.Namespace) -> int:
     output_name = "claude_review.md" if args.agent == "claude" else "codex_review.md"
     prompt = (out_dir / prompt_name).read_text(encoding="utf-8")
     command, env = review_command_and_env(args.agent)
-    result = subprocess.run(
-        command,
-        input=prompt,
-        text=True,
-        capture_output=True,
-        cwd=str(REPO_ROOT),
-        env=env,
-        check=False,
-    )
-    write_text(out_dir / output_name, result.stdout or result.stderr)
+    timeout = review_timeout_seconds(args.agent, env)
+    timed_out = False
+    try:
+        result = subprocess.run(
+            command,
+            input=prompt,
+            text=True,
+            capture_output=True,
+            cwd=str(REPO_ROOT),
+            env=env,
+            timeout=timeout,
+            check=False,
+        )
+        exit_code = result.returncode
+        output = result.stdout or result.stderr
+    except subprocess.TimeoutExpired as exc:
+        timed_out = True
+        exit_code = 124
+        stdout = exc.stdout or ""
+        stderr = exc.stderr or ""
+        if isinstance(stdout, bytes):
+            stdout = stdout.decode("utf-8", errors="replace")
+        if isinstance(stderr, bytes):
+            stderr = stderr.decode("utf-8", errors="replace")
+        output = (stdout or stderr).strip()
+        output = (output + "\n\n" if output else "") + f"ERROR: review command timed out after {timeout} seconds"
+    write_text(out_dir / output_name, output)
     write_json(
         out_dir / f"{args.agent}_review_receipt.json",
         {
@@ -1054,13 +1083,15 @@ def cmd_run_agent(args: argparse.Namespace) -> int:
             "generated_at": utc_now(),
             "agent": args.agent,
             "command": command,
-            "exit_code": result.returncode,
+            "exit_code": exit_code,
+            "timed_out": timed_out,
+            "timeout_seconds": timeout,
             "reviewed_head_sha": reviewed_head_sha,
             "output": str(out_dir / output_name),
         },
     )
-    print(f"agent={args.agent} exit={result.returncode} output={out_dir / output_name}")
-    return result.returncode
+    print(f"agent={args.agent} exit={exit_code} output={out_dir / output_name}")
+    return exit_code
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/scripts/runtime/pr_merge_control.py
+++ b/scripts/runtime/pr_merge_control.py
@@ -54,6 +54,29 @@ HOT_PATH_PATTERNS = (
     "Makefile",
 )
 CLAUDE_REVIEW_DEFAULT_BIN = Path("/Users/dhyana/.npm-global/bin/claude")
+REQUIRED_REVIEW_SECTIONS = (
+    "Verdict",
+    "Findings",
+    "Missing Tests Or Proof",
+    "Merge Conditions",
+)
+REVIEW_TEMPLATE_MARKERS = (
+    "A single line containing exactly one of",
+    "Numbered findings with severity",
+    "Concrete gaps only",
+    "The exact conditions that must be true before merge",
+)
+REVIEW_EVIDENCE_RE = (
+    "Makefile",
+    ".github/",
+    "scripts/",
+    "tests/",
+    "docs/",
+    "dharma_swarm/",
+    "inter_agent/",
+    "api/",
+    "dashboard/",
+)
 
 
 class PRControlError(Exception):
@@ -617,6 +640,65 @@ def has_review(path: Path) -> bool:
     return path.exists() and len(path.read_text(encoding="utf-8").strip()) >= 40
 
 
+def _review_sections(text: str) -> dict[str, str]:
+    sections: dict[str, list[str]] = {}
+    current: str | None = None
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("## "):
+            heading = stripped[3:].strip()
+            current = heading
+            sections.setdefault(current, [])
+            continue
+        if current:
+            sections.setdefault(current, []).append(line)
+    return {name: "\n".join(lines).strip() for name, lines in sections.items()}
+
+
+def _first_nonempty_line(text: str) -> str:
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped:
+            return stripped
+    return ""
+
+
+def _has_concrete_review_evidence(text: str) -> bool:
+    lowered = text.lower()
+    if "file/line evidence" in lowered or "no blocking findings." == text.strip().lower():
+        return False
+    return any(marker in text for marker in REVIEW_EVIDENCE_RE)
+
+
+def review_contract_status(text: str) -> dict[str, str]:
+    sections = _review_sections(text)
+    if "Verdict" not in sections:
+        return {"ok": "false", "verdict": "", "reason": "missing review sections: Verdict"}
+    verdict = _first_nonempty_line(sections["Verdict"]).strip("`*_-. ")
+    allowed = {"APPROVE", "REQUEST_CHANGES", "BLOCKED", "NEEDS_HUMAN"}
+    if verdict not in allowed:
+        return {"ok": "false", "verdict": verdict, "reason": "invalid verdict"}
+
+    missing = [name for name in REQUIRED_REVIEW_SECTIONS if name not in sections]
+    if missing:
+        return {"ok": "false", "verdict": verdict, "reason": f"missing review sections: {', '.join(missing)}"}
+
+    if any(marker in text for marker in REVIEW_TEMPLATE_MARKERS):
+        return {"ok": "false", "verdict": verdict, "reason": "review still contains prompt template text"}
+
+    for section in ("Findings", "Missing Tests Or Proof", "Merge Conditions"):
+        if len(sections[section].strip()) < 40:
+            return {"ok": "false", "verdict": verdict, "reason": f"{section} section is too thin"}
+
+    if not _has_concrete_review_evidence(text):
+        return {"ok": "false", "verdict": verdict, "reason": "review lacks concrete file/path evidence"}
+
+    if verdict == "APPROVE" and "No blocking findings" not in sections["Findings"]:
+        return {"ok": "false", "verdict": verdict, "reason": "APPROVE review must explicitly state no blocking findings"}
+
+    return {"ok": "true", "verdict": verdict, "reason": ""}
+
+
 def review_receipt_status(path: Path, *, expected_head_sha: str = "") -> dict[str, Any]:
     if not has_review(path):
         return {"ok": False, "verdict": "", "reason": "missing or too short", "reviewed_head_sha": ""}
@@ -636,19 +718,15 @@ def review_receipt_status(path: Path, *, expected_head_sha: str = "") -> dict[st
     lowered = text.lower()
     if "error:" in lowered or "failed to initialize" in lowered or "traceback" in lowered:
         return {"ok": False, "verdict": "", "reason": "review command failed", "reviewed_head_sha": reviewed_head_sha}
-    lines = [line.strip() for line in text.splitlines()]
-    allowed = {"APPROVE", "REQUEST_CHANGES", "BLOCKED", "NEEDS_HUMAN"}
-    for index, line in enumerate(lines):
-        if line.lower() != "## verdict":
-            continue
-        for candidate in lines[index + 1:]:
-            if not candidate:
-                continue
-            verdict = candidate.strip("`*_-. ")
-            if verdict in allowed:
-                return {"ok": True, "verdict": verdict, "reason": "", "reviewed_head_sha": reviewed_head_sha}
-            return {"ok": False, "verdict": verdict, "reason": "invalid verdict", "reviewed_head_sha": reviewed_head_sha}
-    return {"ok": False, "verdict": "", "reason": "missing ## Verdict section", "reviewed_head_sha": reviewed_head_sha}
+    contract = review_contract_status(text)
+    if contract["ok"] != "true":
+        return {
+            "ok": False,
+            "verdict": contract["verdict"],
+            "reason": contract["reason"],
+            "reviewed_head_sha": reviewed_head_sha,
+        }
+    return {"ok": True, "verdict": contract["verdict"], "reason": "", "reviewed_head_sha": reviewed_head_sha}
 
 
 def build_gate(args: argparse.Namespace) -> dict[str, Any]:

--- a/scripts/runtime/pr_merge_control.py
+++ b/scripts/runtime/pr_merge_control.py
@@ -28,7 +28,14 @@ REQUIRED_COHERENCE_FIELDS = (
     "Proof that re-reads the map",
     "New drift introduced",
 )
-BAD_CONCLUSIONS = {"FAILURE", "CANCELLED", "TIMED_OUT", "ACTION_REQUIRED"}
+BAD_CONCLUSIONS = {
+    "ACTION_REQUIRED",
+    "CANCELLED",
+    "FAILURE",
+    "STALE",
+    "STARTUP_FAILURE",
+    "TIMED_OUT",
+}
 PASS_CONCLUSIONS = {"SUCCESS", "SKIPPED", "NEUTRAL"}
 HOT_PATH_PATTERNS = (
     ".github/",
@@ -136,7 +143,7 @@ def check_rollup(pr: dict[str, Any]) -> dict[str, Any]:
         elif conclusion in PASS_CONCLUSIONS:
             passing.append(name)
         elif conclusion:
-            unknown.append(f"{name}:{conclusion}")
+            failing.append(f"{name}:{conclusion}")
         else:
             unknown.append(name)
 
@@ -275,11 +282,17 @@ def fetch_pr_files(pr_number: int, repo: str) -> list[dict[str, Any]]:
 
 def fetch_review_threads(pr_number: int, repo: str) -> dict[str, Any]:
     owner, name = repo.split("/", 1)
+    nodes: list[dict[str, Any]] = []
+    cursor = ""
     query = """
-    query($owner: String!, $name: String!, $number: Int!) {
+    query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
       repository(owner: $owner, name: $name) {
         pullRequest(number: $number) {
-          reviewThreads(first: 100) {
+          reviewThreads(first: 100, after: $cursor) {
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
             nodes {
               isResolved
               isOutdated
@@ -298,33 +311,47 @@ def fetch_review_threads(pr_number: int, repo: str) -> dict[str, Any]:
       }
     }
     """
-    result = run(
-        [
-            "gh",
-            "api",
-            "graphql",
-            "-f",
-            f"query={query}",
-            "-F",
-            f"owner={owner}",
-            "-F",
-            f"name={name}",
-            "-F",
-            f"number={pr_number}",
-        ],
-        timeout=120,
-        check=False,
-    )
-    if result.code != 0:
-        return {"ok": False, "error": (result.stderr or result.stdout).strip(), "unresolved": None}
-    payload = json.loads(result.stdout)
-    nodes = (
-        payload.get("data", {})
-        .get("repository", {})
-        .get("pullRequest", {})
-        .get("reviewThreads", {})
-        .get("nodes", [])
-    )
+    while True:
+        result = run(
+            [
+                "gh",
+                "api",
+                "graphql",
+                "-f",
+                f"query={query}",
+                "-F",
+                f"owner={owner}",
+                "-F",
+                f"name={name}",
+                "-F",
+                f"number={pr_number}",
+                "-F",
+                f"cursor={cursor}",
+            ],
+            timeout=120,
+            check=False,
+        )
+        if result.code != 0:
+            return {"ok": False, "error": (result.stderr or result.stdout).strip(), "unresolved": None}
+        try:
+            payload = json.loads(result.stdout)
+        except json.JSONDecodeError:
+            return {"ok": False, "error": "GitHub GraphQL returned non-JSON output", "unresolved": None}
+        threads = (
+            payload.get("data", {})
+            .get("repository", {})
+            .get("pullRequest", {})
+            .get("reviewThreads", {})
+        )
+        if not isinstance(threads, dict):
+            return {"ok": False, "error": "GitHub GraphQL reviewThreads payload missing", "unresolved": None}
+        nodes.extend(threads.get("nodes") or [])
+        page_info = threads.get("pageInfo") or {}
+        if not page_info.get("hasNextPage"):
+            break
+        cursor = str(page_info.get("endCursor") or "")
+        if not cursor:
+            return {"ok": False, "error": "GitHub GraphQL reviewThreads pagination cursor missing", "unresolved": None}
     unresolved = [
         node for node in nodes
         if not node.get("isResolved") and not node.get("isOutdated")
@@ -335,6 +362,21 @@ def fetch_review_threads(pr_number: int, repo: str) -> dict[str, Any]:
 def coherence_results(body: str) -> dict[str, Any]:
     lines = body.splitlines()
     results: dict[str, dict[str, Any]] = {}
+    all_prefix_variants = tuple(
+        prefix
+        for known_field in REQUIRED_COHERENCE_FIELDS
+        for prefix in (
+            f"- {known_field}:",
+            f"* {known_field}:",
+            f"{known_field}:",
+            f"- **{known_field}**:",
+            f"- **{known_field}:**",
+            f"* **{known_field}**:",
+            f"* **{known_field}:**",
+            f"**{known_field}**:",
+            f"**{known_field}:**",
+        )
+    )
     for field in REQUIRED_COHERENCE_FIELDS:
         prefix_variants = (
             f"- {field}:",
@@ -359,9 +401,7 @@ def coherence_results(body: str) -> dict[str, Any]:
                 next_stripped = next_line.strip()
                 if not next_stripped:
                     continue
-                if any(next_stripped.startswith(prefix) for prefix in prefix_variants):
-                    break
-                if any(next_stripped.startswith(f"- {other}:") or next_stripped.startswith(f"- **{other}**:") for other in REQUIRED_COHERENCE_FIELDS):
+                if any(next_stripped.startswith(prefix) for prefix in all_prefix_variants):
                     break
                 if next_stripped.startswith("#"):
                     break
@@ -620,6 +660,8 @@ def build_gate(args: argparse.Namespace) -> dict[str, Any]:
     if not current_coherence["ok"]:
         blockers.append("Coherence Delta fields missing or placeholder")
     unresolved_count = current_threads.get("unresolved_count")
+    if not current_threads.get("ok"):
+        blockers.append(f"could not verify review threads: {current_threads.get('error') or 'unknown error'}")
     if unresolved_count:
         blockers.append(f"{unresolved_count} unresolved review threads")
 

--- a/scripts/runtime/pr_merge_control.py
+++ b/scripts/runtime/pr_merge_control.py
@@ -515,8 +515,10 @@ context is already prepared for you. Read:
 {packet_dir_path / "FACTS.json"}
 
 Then review the PR with a code-review stance: findings first, highest severity
-first, with file/line evidence. Do not approve from vibes. Do not merge. Do not
-modify files.
+first, with repo-relative file/line evidence. Use full repository paths from
+the packet or diff such as `dharma_swarm/ontology.py` or
+`tests/test_ontology_telos_hardwire.py`; bare filenames are not sufficient for
+the merge gate. Do not approve from vibes. Do not merge. Do not modify files.
 
 Keep tool use narrow: do not run broad repository searches, skill discovery, or
 indexing. Read only the packet, diff, and exact changed files needed to validate

--- a/scripts/runtime/pr_merge_control.py
+++ b/scripts/runtime/pr_merge_control.py
@@ -1,0 +1,909 @@
+#!/usr/bin/env python3
+"""Governed PR queue, dual-agent review packets, and merge gates.
+
+This script is intentionally local-first. It uses `gh` for live GitHub state,
+writes receipts under ~/.dharma/pr_review by default, and never merges unless
+an operator passes an explicit confirmation token.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_STATE_ROOT = Path("~/.dharma/pr_review")
+REQUIRED_COHERENCE_FIELDS = (
+    "Organ touched",
+    "Declared-vs-actual gap closed",
+    "Proof that re-reads the map",
+    "New drift introduced",
+)
+BAD_CONCLUSIONS = {"FAILURE", "CANCELLED", "TIMED_OUT", "ACTION_REQUIRED"}
+PASS_CONCLUSIONS = {"SUCCESS", "SKIPPED", "NEUTRAL"}
+HOT_PATH_PATTERNS = (
+    ".github/",
+    "api/",
+    "dashboard/",
+    "dharma_swarm/dharma_kernel.py",
+    "dharma_swarm/telos_gates.py",
+    "dharma_swarm/orchestrator.py",
+    "dharma_swarm/swarm.py",
+    "dharma_swarm/signal_bus.py",
+    "dharma_swarm/vsm_channels.py",
+    "dharma_swarm/runtime_state.py",
+    "dharma_swarm/operator_core/",
+    "scripts/governance/",
+    "scripts/runtime/",
+    "Makefile",
+)
+CLAUDE_REVIEW_DEFAULT_BIN = Path("/Users/dhyana/.npm-global/bin/claude")
+
+
+class PRControlError(Exception):
+    """Raised when PR control cannot safely proceed."""
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    code: int
+    stdout: str
+    stderr: str
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def expand(path: str | Path) -> Path:
+    return Path(os.path.expanduser(str(path))).resolve()
+
+
+def run(cmd: list[str], *, cwd: Path = REPO_ROOT, timeout: int = 120, check: bool = True) -> CommandResult:
+    proc = subprocess.run(
+        cmd,
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    result = CommandResult(proc.returncode, proc.stdout, proc.stderr)
+    if check and result.code != 0:
+        detail = (result.stderr or result.stdout).strip()
+        raise PRControlError(f"{' '.join(cmd)} failed: {detail}")
+    return result
+
+
+def gh_json(args: list[str], *, timeout: int = 120) -> Any:
+    result = run(["gh", *args], timeout=timeout)
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise PRControlError(f"gh returned non-JSON output for {' '.join(args)}") from exc
+
+
+def repo_name() -> str:
+    result = run(["gh", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"], timeout=30)
+    name = result.stdout.strip()
+    if not name or "/" not in name:
+        raise PRControlError("could not determine GitHub repository name")
+    return name
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def check_rollup(pr: dict[str, Any]) -> dict[str, Any]:
+    rollup = pr.get("statusCheckRollup") or []
+    failing: list[str] = []
+    pending: list[str] = []
+    passing: list[str] = []
+    unknown: list[str] = []
+
+    for item in rollup:
+        name = str(item.get("name") or item.get("context") or item.get("workflowName") or "unnamed")
+        conclusion = str(item.get("conclusion") or "").upper()
+        status = str(item.get("status") or "").upper()
+        if conclusion in BAD_CONCLUSIONS:
+            failing.append(name)
+        elif status and status != "COMPLETED":
+            pending.append(name)
+        elif conclusion in PASS_CONCLUSIONS:
+            passing.append(name)
+        elif conclusion:
+            unknown.append(f"{name}:{conclusion}")
+        else:
+            unknown.append(name)
+
+    return {
+        "total": len(rollup),
+        "passing": passing,
+        "failing": failing,
+        "pending": pending,
+        "unknown": unknown,
+    }
+
+
+def classify_pr(pr: dict[str, Any]) -> dict[str, Any]:
+    checks = check_rollup(pr)
+    mergeable = str(pr.get("mergeable") or "UNKNOWN").upper()
+    review_decision = str(pr.get("reviewDecision") or "").upper()
+    reasons: list[str] = []
+
+    if pr.get("isDraft"):
+        reasons.append("draft")
+        status = "DRAFT"
+    elif mergeable == "CONFLICTING":
+        reasons.append("merge conflict")
+        status = "BLOCKED_CONFLICT"
+    elif checks["failing"]:
+        reasons.append(f"{len(checks['failing'])} failing checks")
+        status = "BLOCKED_CHECKS"
+    elif review_decision == "CHANGES_REQUESTED":
+        reasons.append("changes requested")
+        status = "BLOCKED_REVIEW"
+    elif checks["pending"]:
+        reasons.append(f"{len(checks['pending'])} pending checks")
+        status = "WAITING_CHECKS"
+    elif mergeable != "MERGEABLE":
+        reasons.append(f"mergeable={mergeable}")
+        status = "NEEDS_REFRESH"
+    elif review_decision not in {"APPROVED", ""}:
+        reasons.append(f"reviewDecision={review_decision}")
+        status = "NEEDS_AGENT_REVIEW"
+    else:
+        reasons.append("GitHub green; packet, dual review, and merge gate still required")
+        status = "GITHUB_GREEN_NEEDS_PACKET"
+
+    if checks["unknown"]:
+        reasons.append(f"{len(checks['unknown'])} unknown check states")
+
+    return {
+        "number": pr.get("number"),
+        "title": pr.get("title"),
+        "url": pr.get("url"),
+        "author": (pr.get("author") or {}).get("login") if isinstance(pr.get("author"), dict) else pr.get("author"),
+        "headRefName": pr.get("headRefName"),
+        "baseRefName": pr.get("baseRefName"),
+        "updatedAt": pr.get("updatedAt"),
+        "mergeable": mergeable,
+        "reviewDecision": review_decision or "NONE",
+        "checks": checks,
+        "status": status,
+        "reasons": reasons,
+    }
+
+
+def fetch_open_prs(limit: int) -> list[dict[str, Any]]:
+    return gh_json([
+        "pr",
+        "list",
+        "--state",
+        "open",
+        "--limit",
+        str(limit),
+        "--json",
+        "number,title,author,headRefName,baseRefName,isDraft,mergeable,reviewDecision,statusCheckRollup,updatedAt,url",
+    ])
+
+
+def render_queue_markdown(summary: dict[str, Any]) -> str:
+    lines = [
+        "# PR Review Queue",
+        "",
+        f"- Generated: `{summary['generated_at']}`",
+        f"- Repository: `{summary['repo']}`",
+        f"- Open PRs scanned: `{summary['total']}`",
+        "",
+        "## Counts",
+        "",
+    ]
+    for status, count in sorted(summary["counts"].items()):
+        lines.append(f"- `{status}`: {count}")
+    lines.extend(["", "## Queue", ""])
+    for item in summary["items"]:
+        reason = "; ".join(item["reasons"]) if item["reasons"] else "no blocker detected"
+        lines.append(
+            f"- **#{item['number']}** `{item['status']}` "
+            f"{item['title']} — {reason} ({item['url']})"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def cmd_queue(args: argparse.Namespace) -> int:
+    prs = fetch_open_prs(args.limit)
+    items = [classify_pr(pr) for pr in prs]
+    counts: dict[str, int] = {}
+    for item in items:
+        counts[item["status"]] = counts.get(item["status"], 0) + 1
+    summary = {
+        "schema": "dharma.pr_review.queue.v1",
+        "generated_at": utc_now(),
+        "repo": repo_name(),
+        "total": len(items),
+        "counts": counts,
+        "items": items,
+    }
+    out_dir = expand(args.state_root) / "queue"
+    write_json(out_dir / "latest.json", summary)
+    write_text(out_dir / "latest.md", render_queue_markdown(summary))
+    print(f"scanned={len(items)} output={out_dir / 'latest.md'}")
+    for status, count in sorted(counts.items()):
+        print(f"{status}: {count}")
+    return 0
+
+
+def fetch_pr_view(pr_number: int) -> dict[str, Any]:
+    return gh_json([
+        "pr",
+        "view",
+        str(pr_number),
+        "--json",
+        "number,title,body,author,baseRefName,headRefName,isDraft,mergeable,reviewDecision,statusCheckRollup,comments,commits,updatedAt,url",
+    ])
+
+
+def fetch_pr_files(pr_number: int, repo: str) -> list[dict[str, Any]]:
+    return gh_json(["api", f"repos/{repo}/pulls/{pr_number}/files", "--paginate"], timeout=180)
+
+
+def fetch_review_threads(pr_number: int, repo: str) -> dict[str, Any]:
+    owner, name = repo.split("/", 1)
+    query = """
+    query($owner: String!, $name: String!, $number: Int!) {
+      repository(owner: $owner, name: $name) {
+        pullRequest(number: $number) {
+          reviewThreads(first: 100) {
+            nodes {
+              isResolved
+              isOutdated
+              comments(first: 5) {
+                nodes {
+                  author { login }
+                  body
+                  path
+                  line
+                  createdAt
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+    result = run(
+        [
+            "gh",
+            "api",
+            "graphql",
+            "-f",
+            f"query={query}",
+            "-F",
+            f"owner={owner}",
+            "-F",
+            f"name={name}",
+            "-F",
+            f"number={pr_number}",
+        ],
+        timeout=120,
+        check=False,
+    )
+    if result.code != 0:
+        return {"ok": False, "error": (result.stderr or result.stdout).strip(), "unresolved": None}
+    payload = json.loads(result.stdout)
+    nodes = (
+        payload.get("data", {})
+        .get("repository", {})
+        .get("pullRequest", {})
+        .get("reviewThreads", {})
+        .get("nodes", [])
+    )
+    unresolved = [
+        node for node in nodes
+        if not node.get("isResolved") and not node.get("isOutdated")
+    ]
+    return {"ok": True, "threads": nodes, "unresolved": unresolved, "unresolved_count": len(unresolved)}
+
+
+def coherence_results(body: str) -> dict[str, Any]:
+    lines = body.splitlines()
+    results: dict[str, dict[str, Any]] = {}
+    for field in REQUIRED_COHERENCE_FIELDS:
+        prefix_variants = (
+            f"- {field}:",
+            f"* {field}:",
+            f"{field}:",
+            f"- **{field}**:",
+            f"* **{field}**:",
+            f"**{field}**:",
+        )
+        value = None
+        for index, line in enumerate(lines):
+            stripped = line.strip()
+            match = next((prefix for prefix in prefix_variants if stripped.startswith(prefix)), None)
+            if not match:
+                continue
+            first = stripped[len(match):].strip()
+            tail: list[str] = []
+            for next_line in lines[index + 1:]:
+                next_stripped = next_line.strip()
+                if not next_stripped:
+                    continue
+                if any(next_stripped.startswith(prefix) for prefix in prefix_variants):
+                    break
+                if any(next_stripped.startswith(f"- {other}:") or next_stripped.startswith(f"- **{other}**:") for other in REQUIRED_COHERENCE_FIELDS):
+                    break
+                if next_stripped.startswith("#"):
+                    break
+                tail.append(next_stripped)
+            value = "\n".join(part for part in [first, *tail] if part).strip()
+            break
+        normalized = (value or "").strip().lower().strip("`*_-. ")
+        ok = bool(value) and normalized not in {"", "n/a", "na", "none", "none yet", "tbd", "todo", "unknown", "placeholder"}
+        results[field] = {"ok": ok, "value": value or "", "reason": "" if ok else "missing or placeholder"}
+    return {"ok": all(item["ok"] for item in results.values()), "fields": results}
+
+
+def risk_from_files(files: list[dict[str, Any]]) -> dict[str, Any]:
+    names = [str(item.get("filename") or "") for item in files]
+    hot = [name for name in names if any(name == pattern or name.startswith(pattern) for pattern in HOT_PATH_PATTERNS)]
+    deletions = [name for name, item in zip(names, files) if item.get("status") == "removed"]
+    additions = sum(int(item.get("additions") or 0) for item in files)
+    deletions_count = sum(int(item.get("deletions") or 0) for item in files)
+    docs_only = bool(names) and all(name.startswith("docs/") or name.endswith(".md") for name in names)
+
+    if any(name in {"dharma_swarm/dharma_kernel.py", "dharma_swarm/telos_gates.py"} for name in hot):
+        level = "CRITICAL"
+    elif len(names) > 25 or additions + deletions_count > 2000 or hot:
+        level = "HIGH"
+    elif docs_only or len(names) <= 3:
+        level = "LOW"
+    else:
+        level = "MEDIUM"
+
+    return {
+        "level": level,
+        "files_changed": len(names),
+        "additions": additions,
+        "deletions": deletions_count,
+        "docs_only": docs_only,
+        "hot_paths": hot,
+        "removed_files": deletions,
+    }
+
+
+def render_agent_prompt(agent: str, packet_path: Path, pr_number: int) -> str:
+    return f"""You are {agent}, reviewing Dharma Swarm PR #{pr_number}.
+
+Read the packet at:
+{packet_path}
+
+Then review the PR with a code-review stance: findings first, highest severity
+first, with file/line evidence. Do not approve from vibes. Do not merge. Do not
+modify files. Check:
+
+- CI/check state and mergeability
+- Coherence Delta fields and PR-body honesty
+- changed files and hot-path blast radius
+- unresolved review threads
+- tests claimed vs tests actually relevant
+- hidden substrate/adapter/router duplication
+- docs drift, authority overclaiming, and anti-slop violations
+
+Return markdown with exactly:
+
+## Verdict
+APPROVE | REQUEST_CHANGES | BLOCKED | NEEDS_HUMAN
+
+## Findings
+Numbered findings with severity, evidence, and why it matters.
+
+## Missing Tests Or Proof
+Concrete gaps only.
+
+## Merge Conditions
+The exact conditions that must be true before merge.
+"""
+
+
+def review_command_and_env(
+    agent: str,
+    base_env: dict[str, str] | None = None,
+) -> tuple[list[str], dict[str, str]]:
+    """Return a reviewer command and environment.
+
+    Claude Code should not inherit a depleted Anthropic Console key by default.
+    The operator can opt back into API-key mode by setting
+    DHARMA_CLAUDE_REVIEW_USE_API_KEY=1 or by supplying CLAUDE_REVIEW_COMMAND.
+    """
+
+    env = dict(base_env or os.environ)
+    if agent == "claude":
+        override = env.get("CLAUDE_REVIEW_COMMAND", "").strip()
+        if override:
+            command = shlex.split(override)
+        elif CLAUDE_REVIEW_DEFAULT_BIN.exists():
+            command = [CLAUDE_REVIEW_DEFAULT_BIN.as_posix(), "-p"]
+        else:
+            command = ["claude", "-p"]
+        if env.get("DHARMA_CLAUDE_REVIEW_USE_API_KEY") != "1":
+            env.pop("ANTHROPIC_API_KEY", None)
+        return command, env
+
+    override = env.get("CODEX_REVIEW_COMMAND", "").strip()
+    command = shlex.split(override) if override else ["codex", "exec"]
+    return command, env
+
+
+def render_packet_markdown(packet: dict[str, Any]) -> str:
+    pr = packet["pr"]
+    risk = packet["risk"]
+    checks = packet["classification"]["checks"]
+    lines = [
+        f"# PR #{pr['number']} Review Packet",
+        "",
+        f"- Title: {pr['title']}",
+        f"- URL: {pr['url']}",
+        f"- Generated: `{packet['generated_at']}`",
+        f"- Branch: `{pr['headRefName']}` → `{pr['baseRefName']}`",
+        f"- Queue status: `{packet['classification']['status']}`",
+        f"- Mergeable: `{packet['classification']['mergeable']}`",
+        f"- Review decision: `{packet['classification']['reviewDecision']}`",
+        f"- Risk: `{risk['level']}` ({risk['files_changed']} files, +{risk['additions']}/-{risk['deletions']})",
+        f"- Checks: passing={len(checks['passing'])} failing={len(checks['failing'])} pending={len(checks['pending'])} unknown={len(checks['unknown'])}",
+        f"- Coherence Delta: `{'pass' if packet['coherence']['ok'] else 'fail'}`",
+        f"- Unresolved review threads: `{packet['review_threads'].get('unresolved_count')}`",
+        "",
+        "## Hot Paths",
+        "",
+    ]
+    if risk["hot_paths"]:
+        lines.extend(f"- `{path}`" for path in risk["hot_paths"])
+    else:
+        lines.append("- none detected")
+    lines.extend(["", "## Changed Files", ""])
+    for item in packet["files"]:
+        lines.append(
+            f"- `{item.get('filename')}` {item.get('status')} "
+            f"+{item.get('additions', 0)}/-{item.get('deletions', 0)}"
+        )
+    lines.extend([
+        "",
+        "## Queue Reasons",
+        "",
+    ])
+    if packet["classification"]["reasons"]:
+        lines.extend(f"- {reason}" for reason in packet["classification"]["reasons"])
+    else:
+        lines.append("- no automatic blocker detected")
+    lines.extend([
+        "",
+        "## Required Local Outputs",
+        "",
+        "- `codex_review.md`",
+        "- `claude_review.md`",
+        "- `MERGE_GATE.md`",
+        "",
+        "Generate reviews from `PROMPT_CODEX.md` and `PROMPT_CLAUDE.md` in this directory.",
+        "",
+    ])
+    return "\n".join(lines)
+
+
+def packet_dir(state_root: Path, pr_number: int, packet_id: str | None = None) -> Path:
+    base = state_root / f"pr-{pr_number}"
+    if packet_id:
+        return base / packet_id
+    existing = sorted([path for path in base.glob("*") if path.is_dir()])
+    if not existing:
+        raise PRControlError(f"no packet directory exists for PR #{pr_number}; run packet first")
+    return existing[-1]
+
+
+def cmd_packet(args: argparse.Namespace) -> int:
+    root = expand(args.state_root)
+    pr = fetch_pr_view(args.pr)
+    repo = repo_name()
+    files = fetch_pr_files(args.pr, repo)
+    threads = fetch_review_threads(args.pr, repo)
+    classification = classify_pr(pr)
+    coherence = coherence_results(pr.get("body") or "")
+    risk = risk_from_files(files)
+    out_dir = root / f"pr-{args.pr}" / stamp()
+    packet = {
+        "schema": "dharma.pr_review.packet.v1",
+        "generated_at": utc_now(),
+        "repo": repo,
+        "pr": pr,
+        "classification": classification,
+        "coherence": coherence,
+        "risk": risk,
+        "files": files,
+        "review_threads": threads,
+    }
+    write_json(out_dir / "FACTS.json", packet)
+    write_text(out_dir / "PR_BODY.md", pr.get("body") or "")
+    write_text(out_dir / "changed_files.txt", "\n".join(str(item.get("filename") or "") for item in files) + "\n")
+    write_text(out_dir / "REVIEW_PACKET.md", render_packet_markdown(packet))
+    write_text(out_dir / "PROMPT_CODEX.md", render_agent_prompt("Codex", out_dir / "REVIEW_PACKET.md", args.pr))
+    write_text(out_dir / "PROMPT_CLAUDE.md", render_agent_prompt("Claude Code Opus", out_dir / "REVIEW_PACKET.md", args.pr))
+    print(f"packet={out_dir}")
+    print(f"status={classification['status']} risk={risk['level']} coherence={'pass' if coherence['ok'] else 'fail'}")
+    return 0
+
+
+def latest_or_arg_packet(args: argparse.Namespace) -> Path:
+    root = expand(args.state_root)
+    return expand(args.packet_dir) if args.packet_dir else packet_dir(root, args.pr)
+
+
+def has_review(path: Path) -> bool:
+    return path.exists() and len(path.read_text(encoding="utf-8").strip()) >= 40
+
+
+def build_gate(args: argparse.Namespace) -> dict[str, Any]:
+    out_dir = latest_or_arg_packet(args)
+    original = load_json(out_dir / "FACTS.json")
+    current_pr = fetch_pr_view(args.pr)
+    repo = repo_name()
+    current_threads = fetch_review_threads(args.pr, repo)
+    current_classification = classify_pr(current_pr)
+    current_coherence = coherence_results(current_pr.get("body") or "")
+
+    blockers: list[str] = []
+    warnings: list[str] = []
+    if current_pr.get("isDraft"):
+        blockers.append("PR is draft")
+    if current_classification["mergeable"] != "MERGEABLE":
+        blockers.append(f"mergeable={current_classification['mergeable']}")
+    if current_classification["checks"]["failing"]:
+        blockers.append(f"failing checks: {', '.join(current_classification['checks']['failing'])}")
+    if current_classification["checks"]["pending"] and not args.allow_pending:
+        blockers.append(f"pending checks: {', '.join(current_classification['checks']['pending'])}")
+    if current_classification["reviewDecision"] == "CHANGES_REQUESTED":
+        blockers.append("GitHub review decision is CHANGES_REQUESTED")
+    if not current_coherence["ok"]:
+        blockers.append("Coherence Delta fields missing or placeholder")
+    unresolved_count = current_threads.get("unresolved_count")
+    if unresolved_count:
+        blockers.append(f"{unresolved_count} unresolved review threads")
+
+    codex_path = out_dir / "codex_review.md"
+    claude_path = out_dir / "claude_review.md"
+    if not has_review(codex_path):
+        blockers.append("missing codex_review.md receipt")
+    if not has_review(claude_path):
+        blockers.append("missing claude_review.md receipt")
+
+    original_risk = original.get("risk", {}).get("level", "UNKNOWN")
+    if original_risk in {"HIGH", "CRITICAL"} and not args.human_approved:
+        blockers.append(f"{original_risk} risk requires --human-approved")
+    if current_classification["checks"]["unknown"]:
+        warnings.append(f"unknown checks: {', '.join(current_classification['checks']['unknown'])}")
+
+    return {
+        "schema": "dharma.pr_review.merge_gate.v1",
+        "generated_at": utc_now(),
+        "repo": repo,
+        "pr": args.pr,
+        "packet_dir": str(out_dir),
+        "decision": "MERGE_CANDIDATE" if not blockers else "BLOCKED",
+        "blockers": blockers,
+        "warnings": warnings,
+        "classification": current_classification,
+        "coherence": current_coherence,
+        "review_threads": {
+            "ok": current_threads.get("ok"),
+            "unresolved_count": unresolved_count,
+        },
+        "review_receipts": {
+            "codex": str(codex_path),
+            "codex_present": has_review(codex_path),
+            "claude": str(claude_path),
+            "claude_present": has_review(claude_path),
+        },
+        "risk": original.get("risk", {}),
+    }
+
+
+def render_gate_markdown(gate: dict[str, Any]) -> str:
+    lines = [
+        f"# PR #{gate['pr']} Merge Gate",
+        "",
+        f"- Generated: `{gate['generated_at']}`",
+        f"- Decision: `{gate['decision']}`",
+        f"- Packet: `{gate['packet_dir']}`",
+        f"- Risk: `{gate.get('risk', {}).get('level', 'UNKNOWN')}`",
+        "",
+        "## Blockers",
+        "",
+    ]
+    if gate["blockers"]:
+        lines.extend(f"- {blocker}" for blocker in gate["blockers"])
+    else:
+        lines.append("- none")
+    lines.extend(["", "## Warnings", ""])
+    if gate["warnings"]:
+        lines.extend(f"- {warning}" for warning in gate["warnings"])
+    else:
+        lines.append("- none")
+    lines.extend(["", "## Review Receipts", ""])
+    receipts = gate["review_receipts"]
+    lines.append(f"- Codex: `{receipts['codex']}` present={receipts['codex_present']}")
+    lines.append(f"- Claude: `{receipts['claude']}` present={receipts['claude_present']}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def render_github_comment(packet: dict[str, Any], gate: dict[str, Any] | None) -> str:
+    pr = packet["pr"]
+    classification = packet["classification"]
+    risk = packet["risk"]
+    coherence = packet["coherence"]
+    decision = gate.get("decision") if gate else "PACKET_ONLY"
+    blockers = gate.get("blockers", []) if gate else []
+    warnings = gate.get("warnings", []) if gate else []
+
+    lines = [
+        "<!-- dharma-pr-review-control:auto -->",
+        "## Dharma PR Review Control",
+        "",
+        f"- PR: `#{pr['number']}`",
+        f"- Decision: `{decision}`",
+        f"- Queue status: `{classification['status']}`",
+        f"- Mergeable: `{classification['mergeable']}`",
+        f"- Risk: `{risk['level']}` ({risk['files_changed']} files, +{risk['additions']}/-{risk['deletions']})",
+        f"- Coherence Delta: `{'pass' if coherence['ok'] else 'fail'}`",
+        "",
+        "### Blockers",
+        "",
+    ]
+    if blockers:
+        lines.extend(f"- {blocker}" for blocker in blockers)
+    else:
+        lines.append("- none from deterministic gate")
+    lines.extend(["", "### Warnings", ""])
+    if warnings:
+        lines.extend(f"- {warning}" for warning in warnings)
+    else:
+        lines.append("- none")
+    lines.extend([
+        "",
+        "### Required Local Review Receipts",
+        "",
+        "Run these from the repo root on the operator machine:",
+        "",
+        "```bash",
+        f"make pr-packet PR={pr['number']}",
+        f"make pr-run-codex PR={pr['number']}",
+        f"make pr-run-claude PR={pr['number']}",
+        f"make pr-gate PR={pr['number']}",
+        "```",
+        "",
+        "Merge remains local and confirmation-gated:",
+        "",
+        "```bash",
+        f"make pr-merge PR={pr['number']} ARGS=\"--confirm merge-pr-{pr['number']}\"",
+        "```",
+    ])
+    return "\n".join(lines) + "\n"
+
+
+def cmd_gate(args: argparse.Namespace) -> int:
+    gate = build_gate(args)
+    out_dir = Path(gate["packet_dir"])
+    write_json(out_dir / "MERGE_GATE.json", gate)
+    write_text(out_dir / "MERGE_GATE.md", render_gate_markdown(gate))
+    print(f"decision={gate['decision']} gate={out_dir / 'MERGE_GATE.md'}")
+    if gate["blockers"]:
+        for blocker in gate["blockers"]:
+            print(f"BLOCKER: {blocker}")
+        return 2
+    return 0
+
+
+def cmd_comment(args: argparse.Namespace) -> int:
+    out_dir = latest_or_arg_packet(args)
+    packet = load_json(out_dir / "FACTS.json")
+    gate_path = out_dir / "MERGE_GATE.json"
+    gate = load_json(gate_path) if gate_path.exists() else None
+    comment = render_github_comment(packet, gate)
+    if args.output:
+        write_text(expand(args.output), comment)
+        print(args.output)
+    else:
+        print(comment)
+    return 0
+
+
+def cmd_reviewers(args: argparse.Namespace) -> int:
+    claude_command, claude_env = review_command_and_env("claude")
+    codex_command, _ = review_command_and_env("codex")
+
+    claude_proc = subprocess.run(
+        [claude_command[0], "auth", "status", "--json"],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        env=claude_env,
+        timeout=30,
+        check=False,
+    )
+    claude_payload: dict[str, Any] | None = None
+    try:
+        claude_payload = json.loads(claude_proc.stdout)
+    except json.JSONDecodeError:
+        claude_payload = None
+
+    result = {
+        "schema": "dharma.pr_review.reviewers.v1",
+        "generated_at": utc_now(),
+        "claude": {
+            "command": claude_command,
+            "anthropic_api_key_scrubbed": "ANTHROPIC_API_KEY" not in claude_env,
+            "auth_status_exit": claude_proc.returncode,
+            "auth_status": claude_payload,
+            "ready": bool(isinstance(claude_payload, dict) and claude_payload.get("loggedIn")),
+        },
+        "codex": {
+            "command": codex_command,
+            "ready": True,
+        },
+    }
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 0 if result["claude"]["ready"] else 2
+
+    print(f"Claude command: {' '.join(claude_command)}")
+    print(f"Claude ANTHROPIC_API_KEY scrubbed: {result['claude']['anthropic_api_key_scrubbed']}")
+    print(f"Claude ready: {result['claude']['ready']}")
+    if isinstance(claude_payload, dict):
+        print(f"Claude auth: {json.dumps(claude_payload, sort_keys=True)}")
+    else:
+        print("Claude auth: unavailable")
+    print(f"Codex command: {' '.join(codex_command)}")
+    print(f"Codex ready: {result['codex']['ready']}")
+    return 0 if result["claude"]["ready"] else 2
+
+
+def cmd_merge(args: argparse.Namespace) -> int:
+    expected = f"merge-pr-{args.pr}"
+    if args.confirm != expected:
+        raise PRControlError(f"merge requires --confirm {expected!r}")
+    gate = build_gate(args)
+    out_dir = Path(gate["packet_dir"])
+    write_json(out_dir / "MERGE_GATE.json", gate)
+    write_text(out_dir / "MERGE_GATE.md", render_gate_markdown(gate))
+    if gate["blockers"]:
+        print(f"decision=BLOCKED gate={out_dir / 'MERGE_GATE.md'}")
+        for blocker in gate["blockers"]:
+            print(f"BLOCKER: {blocker}")
+        return 2
+    if not args.execute:
+        print("decision=MERGE_CANDIDATE")
+        print(f"dry_run=true command=gh pr merge {args.pr} --{args.method} --delete-branch")
+        return 0
+    run(["gh", "pr", "merge", str(args.pr), f"--{args.method}", "--delete-branch"], timeout=300)
+    print(f"merged=pr-{args.pr} method={args.method}")
+    return 0
+
+
+def cmd_run_agent(args: argparse.Namespace) -> int:
+    out_dir = latest_or_arg_packet(args)
+    prompt_name = "PROMPT_CLAUDE.md" if args.agent == "claude" else "PROMPT_CODEX.md"
+    output_name = "claude_review.md" if args.agent == "claude" else "codex_review.md"
+    prompt = (out_dir / prompt_name).read_text(encoding="utf-8")
+    command, env = review_command_and_env(args.agent)
+    result = subprocess.run(
+        command,
+        input=prompt,
+        text=True,
+        capture_output=True,
+        cwd=str(REPO_ROOT),
+        env=env,
+        check=False,
+    )
+    write_text(out_dir / output_name, result.stdout or result.stderr)
+    write_json(
+        out_dir / f"{args.agent}_review_receipt.json",
+        {
+            "schema": "dharma.pr_review.agent_receipt.v1",
+            "generated_at": utc_now(),
+            "agent": args.agent,
+            "command": command,
+            "exit_code": result.returncode,
+            "output": str(out_dir / output_name),
+        },
+    )
+    print(f"agent={args.agent} exit={result.returncode} output={out_dir / output_name}")
+    return result.returncode
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--state-root", default=str(DEFAULT_STATE_ROOT), help="Receipt root (default: ~/.dharma/pr_review)")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    queue = sub.add_parser("queue", help="Classify all open PRs")
+    queue.add_argument("--limit", type=int, default=100)
+    queue.set_defaults(func=cmd_queue)
+
+    packet = sub.add_parser("packet", help="Create a dual-agent review packet for one PR")
+    packet.add_argument("--pr", type=int, required=True)
+    packet.set_defaults(func=cmd_packet)
+
+    gate = sub.add_parser("gate", help="Run the merge gate for one PR")
+    gate.add_argument("--pr", type=int, required=True)
+    gate.add_argument("--packet-dir")
+    gate.add_argument("--allow-pending", action="store_true")
+    gate.add_argument("--human-approved", action="store_true")
+    gate.set_defaults(func=cmd_gate)
+
+    merge = sub.add_parser("merge", help="Dry-run or execute a gated merge")
+    merge.add_argument("--pr", type=int, required=True)
+    merge.add_argument("--packet-dir")
+    merge.add_argument("--allow-pending", action="store_true")
+    merge.add_argument("--human-approved", action="store_true")
+    merge.add_argument("--method", choices=("squash", "merge", "rebase"), default="squash")
+    merge.add_argument("--confirm", required=True)
+    merge.add_argument("--execute", action="store_true")
+    merge.set_defaults(func=cmd_merge)
+
+    comment = sub.add_parser("comment", help="Render a GitHub comment for the latest packet/gate")
+    comment.add_argument("--pr", type=int, required=True)
+    comment.add_argument("--packet-dir")
+    comment.add_argument("--output")
+    comment.set_defaults(func=cmd_comment)
+
+    reviewers = sub.add_parser("reviewers", help="Check local reviewer command/auth readiness")
+    reviewers.add_argument("--json", action="store_true")
+    reviewers.set_defaults(func=cmd_reviewers)
+
+    run_agent = sub.add_parser("run-agent", help="Run Codex or Claude against an existing packet")
+    run_agent.add_argument("--pr", type=int, required=True)
+    run_agent.add_argument("--packet-dir")
+    run_agent.add_argument("--agent", choices=("codex", "claude"), required=True)
+    run_agent.set_defaults(func=cmd_run_agent)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return args.func(args)
+    except PRControlError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/runtime/pr_merge_control.py
+++ b/scripts/runtime/pr_merge_control.py
@@ -548,6 +548,11 @@ Concrete gaps only.
 
 ## Merge Conditions
 The exact conditions that must be true before merge.
+
+If your verdict is APPROVE, the Findings section must explicitly include the
+phrase "No blocking findings" and still cite repo-relative path evidence.
+If your only hold is human/operator approval for a high-risk PR, use
+NEEDS_HUMAN and describe the exact approval condition.
 """
 
 
@@ -806,6 +811,27 @@ def review_receipt_status(path: Path, *, expected_head_sha: str = "") -> dict[st
     return {"ok": True, "verdict": contract["verdict"], "reason": "", "reviewed_head_sha": reviewed_head_sha}
 
 
+def apply_review_gate(
+    blockers: list[str],
+    warnings: list[str],
+    *,
+    name: str,
+    receipt: dict[str, Any],
+    review_file: str,
+    human_approved: bool,
+) -> None:
+    if not receipt["ok"]:
+        blockers.append(f"invalid {review_file} receipt: {receipt['reason']}")
+        return
+    verdict = receipt["verdict"]
+    if verdict == "APPROVE":
+        return
+    if verdict == "NEEDS_HUMAN" and human_approved:
+        warnings.append(f"{name} review returned NEEDS_HUMAN; satisfied by recorded human approval")
+        return
+    blockers.append(f"{review_file} verdict is {verdict}")
+
+
 def build_gate(args: argparse.Namespace) -> dict[str, Any]:
     out_dir = latest_or_arg_packet(args)
     original = load_json(out_dir / "FACTS.json")
@@ -847,14 +873,22 @@ def build_gate(args: argparse.Namespace) -> dict[str, Any]:
     claude_path = out_dir / "claude_review.md"
     codex_receipt = review_receipt_status(codex_path, expected_head_sha=current_head_sha)
     claude_receipt = review_receipt_status(claude_path, expected_head_sha=current_head_sha)
-    if not codex_receipt["ok"]:
-        blockers.append(f"invalid codex_review.md receipt: {codex_receipt['reason']}")
-    elif codex_receipt["verdict"] != "APPROVE":
-        blockers.append(f"codex_review.md verdict is {codex_receipt['verdict']}")
-    if not claude_receipt["ok"]:
-        blockers.append(f"invalid claude_review.md receipt: {claude_receipt['reason']}")
-    elif claude_receipt["verdict"] != "APPROVE":
-        blockers.append(f"claude_review.md verdict is {claude_receipt['verdict']}")
+    apply_review_gate(
+        blockers,
+        warnings,
+        name="Codex",
+        receipt=codex_receipt,
+        review_file="codex_review.md",
+        human_approved=args.human_approved,
+    )
+    apply_review_gate(
+        blockers,
+        warnings,
+        name="Claude",
+        receipt=claude_receipt,
+        review_file="claude_review.md",
+        human_approved=args.human_approved,
+    )
 
     original_risk = original.get("risk", {}).get("level", "UNKNOWN")
     if original_risk in {"HIGH", "CRITICAL"} and not args.human_approved:

--- a/scripts/runtime/pr_merge_control.py
+++ b/scripts/runtime/pr_merge_control.py
@@ -629,8 +629,12 @@ def build_gate(args: argparse.Namespace) -> dict[str, Any]:
     claude_receipt = review_receipt_status(claude_path)
     if not codex_receipt["ok"]:
         blockers.append(f"invalid codex_review.md receipt: {codex_receipt['reason']}")
+    elif codex_receipt["verdict"] != "APPROVE":
+        blockers.append(f"codex_review.md verdict is {codex_receipt['verdict']}")
     if not claude_receipt["ok"]:
         blockers.append(f"invalid claude_review.md receipt: {claude_receipt['reason']}")
+    elif claude_receipt["verdict"] != "APPROVE":
+        blockers.append(f"claude_review.md verdict is {claude_receipt['verdict']}")
 
     original_risk = original.get("risk", {}).get("level", "UNKNOWN")
     if original_risk in {"HIGH", "CRITICAL"} and not args.human_approved:

--- a/scripts/runtime/pr_merge_control.py
+++ b/scripts/runtime/pr_merge_control.py
@@ -132,6 +132,9 @@ def check_rollup(pr: dict[str, Any]) -> dict[str, Any]:
     passing: list[str] = []
     unknown: list[str] = []
 
+    if not rollup:
+        unknown.append("no status checks reported")
+
     for item in rollup:
         name = str(item.get("name") or item.get("context") or item.get("workflowName") or "unnamed")
         conclusion = str(item.get("conclusion") or "").upper()
@@ -171,6 +174,9 @@ def classify_pr(pr: dict[str, Any]) -> dict[str, Any]:
     elif checks["failing"]:
         reasons.append(f"{len(checks['failing'])} failing checks")
         status = "BLOCKED_CHECKS"
+    elif checks["unknown"]:
+        reasons.append(f"{len(checks['unknown'])} unknown check states")
+        status = "BLOCKED_CHECKS"
     elif review_decision == "CHANGES_REQUESTED":
         reasons.append("changes requested")
         status = "BLOCKED_REVIEW"
@@ -186,9 +192,6 @@ def classify_pr(pr: dict[str, Any]) -> dict[str, Any]:
     else:
         reasons.append("GitHub green; packet, dual review, and merge gate still required")
         status = "GITHUB_GREEN_NEEDS_PACKET"
-
-    if checks["unknown"]:
-        reasons.append(f"{len(checks['unknown'])} unknown check states")
 
     return {
         "number": pr.get("number"),
@@ -271,8 +274,8 @@ def fetch_pr_view(pr_number: int) -> dict[str, Any]:
         "pr",
         "view",
         str(pr_number),
-        "--json",
-        "number,title,body,author,baseRefName,headRefName,isDraft,mergeable,reviewDecision,statusCheckRollup,comments,commits,updatedAt,url",
+            "--json",
+            "number,title,body,author,baseRefName,headRefName,headRefOid,isDraft,mergeable,reviewDecision,statusCheckRollup,comments,commits,updatedAt,url",
     ])
 
 
@@ -614,13 +617,25 @@ def has_review(path: Path) -> bool:
     return path.exists() and len(path.read_text(encoding="utf-8").strip()) >= 40
 
 
-def review_receipt_status(path: Path) -> dict[str, Any]:
+def review_receipt_status(path: Path, *, expected_head_sha: str = "") -> dict[str, Any]:
     if not has_review(path):
-        return {"ok": False, "verdict": "", "reason": "missing or too short"}
+        return {"ok": False, "verdict": "", "reason": "missing or too short", "reviewed_head_sha": ""}
+    receipt_path = path.with_name(path.stem.replace("_review", "_review_receipt") + ".json")
+    if not receipt_path.exists():
+        return {"ok": False, "verdict": "", "reason": "missing reviewer receipt JSON", "reviewed_head_sha": ""}
+    try:
+        receipt = load_json(receipt_path)
+    except (OSError, json.JSONDecodeError):
+        return {"ok": False, "verdict": "", "reason": "invalid reviewer receipt JSON", "reviewed_head_sha": ""}
+    reviewed_head_sha = str(receipt.get("reviewed_head_sha") or "")
+    if receipt.get("exit_code") != 0:
+        return {"ok": False, "verdict": "", "reason": f"review command exited {receipt.get('exit_code')}", "reviewed_head_sha": reviewed_head_sha}
+    if expected_head_sha and reviewed_head_sha != expected_head_sha:
+        return {"ok": False, "verdict": "", "reason": "reviewed head SHA mismatch", "reviewed_head_sha": reviewed_head_sha}
     text = path.read_text(encoding="utf-8")
     lowered = text.lower()
     if "error:" in lowered or "failed to initialize" in lowered or "traceback" in lowered:
-        return {"ok": False, "verdict": "", "reason": "review command failed"}
+        return {"ok": False, "verdict": "", "reason": "review command failed", "reviewed_head_sha": reviewed_head_sha}
     lines = [line.strip() for line in text.splitlines()]
     allowed = {"APPROVE", "REQUEST_CHANGES", "BLOCKED", "NEEDS_HUMAN"}
     for index, line in enumerate(lines):
@@ -631,9 +646,9 @@ def review_receipt_status(path: Path) -> dict[str, Any]:
                 continue
             verdict = candidate.split()[0].strip("`*_-. ")
             if verdict in allowed:
-                return {"ok": True, "verdict": verdict, "reason": ""}
-            return {"ok": False, "verdict": verdict, "reason": "invalid verdict"}
-    return {"ok": False, "verdict": "", "reason": "missing ## Verdict section"}
+                return {"ok": True, "verdict": verdict, "reason": "", "reviewed_head_sha": reviewed_head_sha}
+            return {"ok": False, "verdict": verdict, "reason": "invalid verdict", "reviewed_head_sha": reviewed_head_sha}
+    return {"ok": False, "verdict": "", "reason": "missing ## Verdict section", "reviewed_head_sha": reviewed_head_sha}
 
 
 def build_gate(args: argparse.Namespace) -> dict[str, Any]:
@@ -644,15 +659,23 @@ def build_gate(args: argparse.Namespace) -> dict[str, Any]:
     current_threads = fetch_review_threads(args.pr, repo)
     current_classification = classify_pr(current_pr)
     current_coherence = coherence_results(current_pr.get("body") or "")
+    packet_head_sha = str((original.get("pr") or {}).get("headRefOid") or "")
+    current_head_sha = str(current_pr.get("headRefOid") or "")
 
     blockers: list[str] = []
     warnings: list[str] = []
+    if not packet_head_sha:
+        blockers.append("packet is missing reviewed head SHA")
+    if current_head_sha and packet_head_sha and current_head_sha != packet_head_sha:
+        blockers.append("PR head changed since packet generation")
     if current_pr.get("isDraft"):
         blockers.append("PR is draft")
     if current_classification["mergeable"] != "MERGEABLE":
         blockers.append(f"mergeable={current_classification['mergeable']}")
     if current_classification["checks"]["failing"]:
         blockers.append(f"failing checks: {', '.join(current_classification['checks']['failing'])}")
+    if current_classification["checks"]["unknown"]:
+        blockers.append(f"unknown checks: {', '.join(current_classification['checks']['unknown'])}")
     if current_classification["checks"]["pending"] and not args.allow_pending:
         blockers.append(f"pending checks: {', '.join(current_classification['checks']['pending'])}")
     if current_classification["reviewDecision"] == "CHANGES_REQUESTED":
@@ -667,8 +690,8 @@ def build_gate(args: argparse.Namespace) -> dict[str, Any]:
 
     codex_path = out_dir / "codex_review.md"
     claude_path = out_dir / "claude_review.md"
-    codex_receipt = review_receipt_status(codex_path)
-    claude_receipt = review_receipt_status(claude_path)
+    codex_receipt = review_receipt_status(codex_path, expected_head_sha=current_head_sha)
+    claude_receipt = review_receipt_status(claude_path, expected_head_sha=current_head_sha)
     if not codex_receipt["ok"]:
         blockers.append(f"invalid codex_review.md receipt: {codex_receipt['reason']}")
     elif codex_receipt["verdict"] != "APPROVE":
@@ -681,9 +704,6 @@ def build_gate(args: argparse.Namespace) -> dict[str, Any]:
     original_risk = original.get("risk", {}).get("level", "UNKNOWN")
     if original_risk in {"HIGH", "CRITICAL"} and not args.human_approved:
         blockers.append(f"{original_risk} risk requires --human-approved")
-    if current_classification["checks"]["unknown"]:
-        warnings.append(f"unknown checks: {', '.join(current_classification['checks']['unknown'])}")
-
     return {
         "schema": "dharma.pr_review.merge_gate.v1",
         "generated_at": utc_now(),
@@ -704,10 +724,16 @@ def build_gate(args: argparse.Namespace) -> dict[str, Any]:
             "codex_present": has_review(codex_path),
             "codex_valid": codex_receipt["ok"],
             "codex_verdict": codex_receipt["verdict"],
+            "codex_reviewed_head_sha": codex_receipt["reviewed_head_sha"],
             "claude": str(claude_path),
             "claude_present": has_review(claude_path),
             "claude_valid": claude_receipt["ok"],
             "claude_verdict": claude_receipt["verdict"],
+            "claude_reviewed_head_sha": claude_receipt["reviewed_head_sha"],
+        },
+        "head_sha": {
+            "packet": packet_head_sha,
+            "current": current_head_sha,
         },
         "risk": original.get("risk", {}),
     }
@@ -738,11 +764,13 @@ def render_gate_markdown(gate: dict[str, Any]) -> str:
     receipts = gate["review_receipts"]
     lines.append(
         f"- Codex: `{receipts['codex']}` present={receipts['codex_present']} "
-        f"valid={receipts['codex_valid']} verdict={receipts['codex_verdict'] or 'NONE'}"
+        f"valid={receipts['codex_valid']} verdict={receipts['codex_verdict'] or 'NONE'} "
+        f"head={receipts['codex_reviewed_head_sha'] or 'NONE'}"
     )
     lines.append(
         f"- Claude: `{receipts['claude']}` present={receipts['claude_present']} "
-        f"valid={receipts['claude_valid']} verdict={receipts['claude_verdict'] or 'NONE'}"
+        f"valid={receipts['claude_valid']} verdict={receipts['claude_verdict'] or 'NONE'} "
+        f"head={receipts['claude_reviewed_head_sha'] or 'NONE'}"
     )
     lines.append("")
     return "\n".join(lines)
@@ -894,15 +922,33 @@ def cmd_merge(args: argparse.Namespace) -> int:
         return 2
     if not args.execute:
         print("decision=MERGE_CANDIDATE")
-        print(f"dry_run=true command=gh pr merge {args.pr} --{args.method} --delete-branch")
+        print(
+            "dry_run=true command="
+            f"gh pr merge {args.pr} --{args.method} --delete-branch "
+            f"--match-head-commit {gate['head_sha']['current']}"
+        )
         return 0
-    run(["gh", "pr", "merge", str(args.pr), f"--{args.method}", "--delete-branch"], timeout=300)
+    run(
+        [
+            "gh",
+            "pr",
+            "merge",
+            str(args.pr),
+            f"--{args.method}",
+            "--delete-branch",
+            "--match-head-commit",
+            gate["head_sha"]["current"],
+        ],
+        timeout=300,
+    )
     print(f"merged=pr-{args.pr} method={args.method}")
     return 0
 
 
 def cmd_run_agent(args: argparse.Namespace) -> int:
     out_dir = latest_or_arg_packet(args)
+    packet = load_json(out_dir / "FACTS.json")
+    reviewed_head_sha = str((packet.get("pr") or {}).get("headRefOid") or "")
     prompt_name = "PROMPT_CLAUDE.md" if args.agent == "claude" else "PROMPT_CODEX.md"
     output_name = "claude_review.md" if args.agent == "claude" else "codex_review.md"
     prompt = (out_dir / prompt_name).read_text(encoding="utf-8")
@@ -925,6 +971,7 @@ def cmd_run_agent(args: argparse.Namespace) -> int:
             "agent": args.agent,
             "command": command,
             "exit_code": result.returncode,
+            "reviewed_head_sha": reviewed_head_sha,
             "output": str(out_dir / output_name),
         },
     )

--- a/scripts/runtime/pr_merge_control.py
+++ b/scripts/runtime/pr_merge_control.py
@@ -469,7 +469,7 @@ modify files. Check:
 Return markdown with exactly:
 
 ## Verdict
-APPROVE | REQUEST_CHANGES | BLOCKED | NEEDS_HUMAN
+A single line containing exactly one of: APPROVE, REQUEST_CHANGES, BLOCKED, NEEDS_HUMAN.
 
 ## Findings
 Numbered findings with severity, evidence, and why it matters.
@@ -644,7 +644,7 @@ def review_receipt_status(path: Path, *, expected_head_sha: str = "") -> dict[st
         for candidate in lines[index + 1:]:
             if not candidate:
                 continue
-            verdict = candidate.split()[0].strip("`*_-. ")
+            verdict = candidate.strip("`*_-. ")
             if verdict in allowed:
                 return {"ok": True, "verdict": verdict, "reason": "", "reviewed_head_sha": reviewed_head_sha}
             return {"ok": False, "verdict": verdict, "reason": "invalid verdict", "reviewed_head_sha": reviewed_head_sha}
@@ -704,6 +704,8 @@ def build_gate(args: argparse.Namespace) -> dict[str, Any]:
     original_risk = original.get("risk", {}).get("level", "UNKNOWN")
     if original_risk in {"HIGH", "CRITICAL"} and not args.human_approved:
         blockers.append(f"{original_risk} risk requires --human-approved")
+    if original_risk in {"HIGH", "CRITICAL"} and args.human_approved and not args.human_approval_note.strip():
+        blockers.append(f"{original_risk} risk requires --human-approval-note")
     return {
         "schema": "dharma.pr_review.merge_gate.v1",
         "generated_at": utc_now(),
@@ -736,6 +738,10 @@ def build_gate(args: argparse.Namespace) -> dict[str, Any]:
             "current": current_head_sha,
         },
         "risk": original.get("risk", {}),
+        "human_approval": {
+            "approved": bool(args.human_approved),
+            "note": args.human_approval_note.strip(),
+        },
     }
 
 
@@ -781,8 +787,8 @@ def render_github_comment(packet: dict[str, Any], gate: dict[str, Any] | None) -
     classification = packet["classification"]
     risk = packet["risk"]
     coherence = packet["coherence"]
-    decision = gate.get("decision") if gate else "PACKET_ONLY"
-    blockers = gate.get("blockers", []) if gate else []
+    decision = gate.get("decision") if gate else "GATE_MISSING"
+    blockers = gate.get("blockers", []) if gate else ["merge gate output missing or gate execution failed"]
     warnings = gate.get("warnings", []) if gate else []
 
     lines = [
@@ -997,6 +1003,7 @@ def build_parser() -> argparse.ArgumentParser:
     gate.add_argument("--packet-dir")
     gate.add_argument("--allow-pending", action="store_true")
     gate.add_argument("--human-approved", action="store_true")
+    gate.add_argument("--human-approval-note", default="")
     gate.set_defaults(func=cmd_gate)
 
     merge = sub.add_parser("merge", help="Dry-run or execute a gated merge")
@@ -1004,6 +1011,7 @@ def build_parser() -> argparse.ArgumentParser:
     merge.add_argument("--packet-dir")
     merge.add_argument("--allow-pending", action="store_true")
     merge.add_argument("--human-approved", action="store_true")
+    merge.add_argument("--human-approval-note", default="")
     merge.add_argument("--method", choices=("squash", "merge", "rebase"), default="squash")
     merge.add_argument("--confirm", required=True)
     merge.add_argument("--execute", action="store_true")

--- a/scripts/runtime/pr_merge_control.py
+++ b/scripts/runtime/pr_merge_control.py
@@ -148,6 +148,31 @@ def load_json(path: Path) -> Any:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+def check_name(item: dict[str, Any]) -> str:
+    return str(item.get("name") or item.get("context") or item.get("workflowName") or "unnamed")
+
+
+def latest_check_items(rollup: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Collapse duplicate check names to the newest reported check.
+
+    GitHub can leave a cancelled superseded run in statusCheckRollup next to the
+    successful replacement for the same check name. Treating both as live makes
+    the queue disagree with `gh pr checks`.
+    """
+
+    latest: dict[str, tuple[tuple[str, str, int], dict[str, Any]]] = {}
+    for index, item in enumerate(rollup):
+        name = check_name(item)
+        key = (
+            str(item.get("completedAt") or ""),
+            str(item.get("startedAt") or ""),
+            index,
+        )
+        if name not in latest or key >= latest[name][0]:
+            latest[name] = (key, item)
+    return [payload for _, payload in latest.values()]
+
+
 def check_rollup(pr: dict[str, Any]) -> dict[str, Any]:
     rollup = pr.get("statusCheckRollup") or []
     failing: list[str] = []
@@ -158,8 +183,8 @@ def check_rollup(pr: dict[str, Any]) -> dict[str, Any]:
     if not rollup:
         unknown.append("no status checks reported")
 
-    for item in rollup:
-        name = str(item.get("name") or item.get("context") or item.get("workflowName") or "unnamed")
+    for item in latest_check_items(rollup):
+        name = check_name(item)
         conclusion = str(item.get("conclusion") or "").upper()
         status = str(item.get("status") or "").upper()
         if conclusion in BAD_CONCLUSIONS:

--- a/scripts/runtime/pr_merge_control.py
+++ b/scripts/runtime/pr_merge_control.py
@@ -369,7 +369,10 @@ def coherence_results(body: str) -> dict[str, Any]:
             value = "\n".join(part for part in [first, *tail] if part).strip()
             break
         normalized = (value or "").strip().lower().strip("`*_-. ")
-        ok = bool(value) and normalized not in {"", "n/a", "na", "none", "none yet", "tbd", "todo", "unknown", "placeholder"}
+        placeholder_values = {"", "n/a", "na", "tbd", "todo", "unknown", "placeholder"}
+        if field != "New drift introduced":
+            placeholder_values.update({"none", "none yet"})
+        ok = bool(value) and normalized not in placeholder_values
         results[field] = {"ok": ok, "value": value or "", "reason": "" if ok else "missing or placeholder"}
     return {"ok": all(item["ok"] for item in results.values()), "fields": results}
 

--- a/tests/test_pr_merge_control.py
+++ b/tests/test_pr_merge_control.py
@@ -242,8 +242,17 @@ def test_claude_review_env_scrubs_anthropic_api_key_by_default():
         },
     )
 
-    assert command[-1] == "-p"
+    assert "-p" in command
+    assert "--max-turns" in command
     assert "ANTHROPIC_API_KEY" not in env
+
+
+def test_codex_review_defaults_to_bounded_reasoning():
+    command, _ = prc.review_command_and_env("codex", {"PATH": "/usr/bin"})
+
+    assert command[:2] == ["codex", "exec"]
+    assert "--ephemeral" in command
+    assert "model_reasoning_effort=\"medium\"" in command
 
 
 def test_review_receipt_status_rejects_command_error(tmp_path):

--- a/tests/test_pr_merge_control.py
+++ b/tests/test_pr_merge_control.py
@@ -75,6 +75,22 @@ def test_classify_pr_blocks_unrecognized_completed_conclusion():
     assert result["checks"]["failing"] == ["custom:BOGUS"]
 
 
+def test_classify_pr_blocks_empty_check_rollup():
+    pr = {
+        "number": 5,
+        "title": "no checks",
+        "isDraft": False,
+        "mergeable": "MERGEABLE",
+        "reviewDecision": "APPROVED",
+        "statusCheckRollup": [],
+    }
+
+    result = prc.classify_pr(pr)
+
+    assert result["status"] == "BLOCKED_CHECKS"
+    assert result["checks"]["unknown"] == ["no status checks reported"]
+
+
 def test_coherence_results_rejects_placeholder_field():
     body = """
 - Organ touched: docs/governance
@@ -174,8 +190,9 @@ def test_review_receipt_status_rejects_command_error(tmp_path):
         "Error: failed to initialize in-process app-server client\n",
         encoding="utf-8",
     )
+    prc.write_json(path.with_name("codex_review_receipt.json"), {"exit_code": 0, "reviewed_head_sha": "abc"})
 
-    result = prc.review_receipt_status(path)
+    result = prc.review_receipt_status(path, expected_head_sha="abc")
 
     assert result["ok"] is False
     assert result["reason"] == "review command failed"
@@ -190,8 +207,9 @@ def test_review_receipt_status_accepts_verdict(tmp_path):
         "No blocking findings.\n",
         encoding="utf-8",
     )
+    prc.write_json(path.with_name("claude_review_receipt.json"), {"exit_code": 0, "reviewed_head_sha": "abc"})
 
-    result = prc.review_receipt_status(path)
+    result = prc.review_receipt_status(path, expected_head_sha="abc")
 
     assert result["ok"] is True
     assert result["verdict"] == "APPROVE"
@@ -206,11 +224,40 @@ def test_review_receipt_status_accepts_request_changes_for_gate_to_block(tmp_pat
         "1. Blocking issue.\n",
         encoding="utf-8",
     )
+    prc.write_json(path.with_name("codex_review_receipt.json"), {"exit_code": 0, "reviewed_head_sha": "abc"})
 
-    result = prc.review_receipt_status(path)
+    result = prc.review_receipt_status(path, expected_head_sha="abc")
 
     assert result["ok"] is True
     assert result["verdict"] == "REQUEST_CHANGES"
+
+
+def test_review_receipt_status_rejects_nonzero_exit(tmp_path):
+    path = tmp_path / "codex_review.md"
+    path.write_text(
+        "## Verdict\nAPPROVE\n\n## Findings\nNo blocking findings.\n",
+        encoding="utf-8",
+    )
+    prc.write_json(path.with_name("codex_review_receipt.json"), {"exit_code": 1, "reviewed_head_sha": "abc"})
+
+    result = prc.review_receipt_status(path, expected_head_sha="abc")
+
+    assert result["ok"] is False
+    assert result["reason"] == "review command exited 1"
+
+
+def test_review_receipt_status_rejects_stale_head(tmp_path):
+    path = tmp_path / "claude_review.md"
+    path.write_text(
+        "## Verdict\nAPPROVE\n\n## Findings\nNo blocking findings.\n",
+        encoding="utf-8",
+    )
+    prc.write_json(path.with_name("claude_review_receipt.json"), {"exit_code": 0, "reviewed_head_sha": "old"})
+
+    result = prc.review_receipt_status(path, expected_head_sha="new")
+
+    assert result["ok"] is False
+    assert result["reason"] == "reviewed head SHA mismatch"
 
 
 def test_build_gate_blocks_when_review_thread_lookup_fails(tmp_path, monkeypatch):
@@ -221,6 +268,10 @@ def test_build_gate_blocks_when_review_thread_lookup_fails(tmp_path, monkeypatch
         (packet_dir / name).write_text(
             "## Verdict\nAPPROVE\n\n## Findings\nNo blocking findings.\n",
             encoding="utf-8",
+        )
+        prc.write_json(
+            packet_dir / name.replace(".md", "_receipt.json"),
+            {"exit_code": 0, "reviewed_head_sha": "abc"},
         )
 
     args = SimpleNamespace(
@@ -237,6 +288,7 @@ def test_build_gate_blocks_when_review_thread_lookup_fails(tmp_path, monkeypatch
         lambda _pr: {
             "number": 42,
             "title": "ok",
+            "headRefOid": "abc",
             "body": """
 - Organ touched: docs
 - Declared-vs-actual gap closed: reviewer proof is now strict.
@@ -260,6 +312,56 @@ def test_build_gate_blocks_when_review_thread_lookup_fails(tmp_path, monkeypatch
 
     assert gate["decision"] == "BLOCKED"
     assert "could not verify review threads: rate limited" in gate["blockers"]
+
+
+def test_build_gate_blocks_when_head_changed_after_packet(tmp_path, monkeypatch):
+    packet_dir = tmp_path / "packet"
+    packet_dir.mkdir()
+    prc.write_json(packet_dir / "FACTS.json", {"risk": {"level": "LOW"}, "pr": {"headRefOid": "old"}})
+    for name in ("codex_review.md", "claude_review.md"):
+        (packet_dir / name).write_text(
+            "## Verdict\nAPPROVE\n\n## Findings\nNo blocking findings.\n",
+            encoding="utf-8",
+        )
+        prc.write_json(
+            packet_dir / name.replace(".md", "_receipt.json"),
+            {"exit_code": 0, "reviewed_head_sha": "old"},
+        )
+
+    args = SimpleNamespace(
+        packet_dir=str(packet_dir),
+        state_root=str(tmp_path),
+        pr=42,
+        allow_pending=False,
+        human_approved=False,
+    )
+
+    monkeypatch.setattr(
+        prc,
+        "fetch_pr_view",
+        lambda _pr: {
+            "number": 42,
+            "title": "changed",
+            "headRefOid": "new",
+            "body": """
+- Organ touched: docs
+- Declared-vs-actual gap closed: reviewer proof is now strict.
+- Proof that re-reads the map: packet and gate both load.
+- New drift introduced: None
+""",
+            "isDraft": False,
+            "mergeable": "MERGEABLE",
+            "reviewDecision": "APPROVED",
+            "statusCheckRollup": [{"name": "tests", "status": "COMPLETED", "conclusion": "SUCCESS"}],
+        },
+    )
+    monkeypatch.setattr(prc, "repo_name", lambda: "owner/repo")
+    monkeypatch.setattr(prc, "fetch_review_threads", lambda _pr, _repo: {"ok": True, "unresolved_count": 0})
+
+    gate = prc.build_gate(args)
+
+    assert gate["decision"] == "BLOCKED"
+    assert "PR head changed since packet generation" in gate["blockers"]
 
 
 def test_claude_review_env_can_opt_into_api_key():

--- a/tests/test_pr_merge_control.py
+++ b/tests/test_pr_merge_control.py
@@ -232,6 +232,23 @@ def test_review_receipt_status_accepts_request_changes_for_gate_to_block(tmp_pat
     assert result["verdict"] == "REQUEST_CHANGES"
 
 
+def test_review_receipt_status_rejects_unedited_verdict_template(tmp_path):
+    path = tmp_path / "codex_review.md"
+    path.write_text(
+        "## Verdict\n"
+        "APPROVE | REQUEST_CHANGES | BLOCKED | NEEDS_HUMAN\n\n"
+        "## Findings\n"
+        "Template was not edited.\n",
+        encoding="utf-8",
+    )
+    prc.write_json(path.with_name("codex_review_receipt.json"), {"exit_code": 0, "reviewed_head_sha": "abc"})
+
+    result = prc.review_receipt_status(path, expected_head_sha="abc")
+
+    assert result["ok"] is False
+    assert result["reason"] == "invalid verdict"
+
+
 def test_review_receipt_status_rejects_nonzero_exit(tmp_path):
     path = tmp_path / "codex_review.md"
     path.write_text(
@@ -280,6 +297,7 @@ def test_build_gate_blocks_when_review_thread_lookup_fails(tmp_path, monkeypatch
         pr=42,
         allow_pending=False,
         human_approved=False,
+        human_approval_note="",
     )
 
     monkeypatch.setattr(
@@ -334,6 +352,7 @@ def test_build_gate_blocks_when_head_changed_after_packet(tmp_path, monkeypatch)
         pr=42,
         allow_pending=False,
         human_approved=False,
+        human_approval_note="",
     )
 
     monkeypatch.setattr(
@@ -362,6 +381,70 @@ def test_build_gate_blocks_when_head_changed_after_packet(tmp_path, monkeypatch)
 
     assert gate["decision"] == "BLOCKED"
     assert "PR head changed since packet generation" in gate["blockers"]
+
+
+def test_build_gate_requires_note_for_high_risk_human_approval(tmp_path, monkeypatch):
+    packet_dir = tmp_path / "packet"
+    packet_dir.mkdir()
+    prc.write_json(packet_dir / "FACTS.json", {"risk": {"level": "HIGH"}, "pr": {"headRefOid": "abc"}})
+    for name in ("codex_review.md", "claude_review.md"):
+        (packet_dir / name).write_text(
+            "## Verdict\nAPPROVE\n\n## Findings\nNo blocking findings.\n",
+            encoding="utf-8",
+        )
+        prc.write_json(
+            packet_dir / name.replace(".md", "_receipt.json"),
+            {"exit_code": 0, "reviewed_head_sha": "abc"},
+        )
+
+    args = SimpleNamespace(
+        packet_dir=str(packet_dir),
+        state_root=str(tmp_path),
+        pr=42,
+        allow_pending=False,
+        human_approved=True,
+        human_approval_note="",
+    )
+    monkeypatch.setattr(
+        prc,
+        "fetch_pr_view",
+        lambda _pr: {
+            "number": 42,
+            "title": "high",
+            "headRefOid": "abc",
+            "body": """
+- Organ touched: scripts/runtime
+- Declared-vs-actual gap closed: high risk merge proof is receipt backed.
+- Proof that re-reads the map: packet and gate both load.
+- New drift introduced: None
+""",
+            "isDraft": False,
+            "mergeable": "MERGEABLE",
+            "reviewDecision": "APPROVED",
+            "statusCheckRollup": [{"name": "tests", "status": "COMPLETED", "conclusion": "SUCCESS"}],
+        },
+    )
+    monkeypatch.setattr(prc, "repo_name", lambda: "owner/repo")
+    monkeypatch.setattr(prc, "fetch_review_threads", lambda _pr, _repo: {"ok": True, "unresolved_count": 0})
+
+    gate = prc.build_gate(args)
+
+    assert gate["decision"] == "BLOCKED"
+    assert "HIGH risk requires --human-approval-note" in gate["blockers"]
+
+
+def test_render_github_comment_blocks_when_gate_missing():
+    packet = {
+        "pr": {"number": 42},
+        "classification": {"status": "GITHUB_GREEN_NEEDS_PACKET", "mergeable": "MERGEABLE"},
+        "risk": {"level": "LOW", "files_changed": 1, "additions": 1, "deletions": 0},
+        "coherence": {"ok": True},
+    }
+
+    comment = prc.render_github_comment(packet, None)
+
+    assert "Decision: `GATE_MISSING`" in comment
+    assert "merge gate output missing or gate execution failed" in comment
 
 
 def test_claude_review_env_can_opt_into_api_key():

--- a/tests/test_pr_merge_control.py
+++ b/tests/test_pr_merge_control.py
@@ -145,6 +145,22 @@ def test_review_receipt_status_accepts_verdict(tmp_path):
     assert result["verdict"] == "APPROVE"
 
 
+def test_review_receipt_status_accepts_request_changes_for_gate_to_block(tmp_path):
+    path = tmp_path / "codex_review.md"
+    path.write_text(
+        "## Verdict\n"
+        "REQUEST_CHANGES\n\n"
+        "## Findings\n"
+        "1. Blocking issue.\n",
+        encoding="utf-8",
+    )
+
+    result = prc.review_receipt_status(path)
+
+    assert result["ok"] is True
+    assert result["verdict"] == "REQUEST_CHANGES"
+
+
 def test_claude_review_env_can_opt_into_api_key():
     _, env = prc.review_command_and_env(
         "claude",

--- a/tests/test_pr_merge_control.py
+++ b/tests/test_pr_merge_control.py
@@ -261,6 +261,8 @@ def test_render_agent_prompt_requires_repo_relative_paths(tmp_path):
     assert "repo-relative file/line evidence" in prompt
     assert "`dharma_swarm/ontology.py`" in prompt
     assert "bare filenames are not sufficient" in prompt
+    assert 'phrase "No blocking findings"' in prompt
+    assert "If your only hold is human/operator approval" in prompt
 
 
 def test_review_receipt_status_rejects_command_error(tmp_path):
@@ -537,6 +539,69 @@ def test_build_gate_requires_note_for_high_risk_human_approval(tmp_path, monkeyp
 
     assert gate["decision"] == "BLOCKED"
     assert "HIGH risk requires --human-approval-note" in gate["blockers"]
+
+
+def test_build_gate_allows_needs_human_when_human_approval_recorded(tmp_path, monkeypatch):
+    packet_dir = tmp_path / "packet"
+    packet_dir.mkdir()
+    prc.write_json(packet_dir / "FACTS.json", {"risk": {"level": "CRITICAL"}, "pr": {"headRefOid": "abc"}})
+    (packet_dir / "codex_review.md").write_text(
+        "## Verdict\nAPPROVE\n\n"
+        "## Findings\nNo blocking findings after reading `scripts/runtime/pr_merge_control.py`.\n\n"
+        "## Missing Tests Or Proof\nNo missing local proof for this bounded check.\n\n"
+        "## Merge Conditions\nCI must stay green and the reviewed head must match.\n",
+        encoding="utf-8",
+    )
+    prc.write_json(
+        packet_dir / "codex_review_receipt.json",
+        {"exit_code": 0, "reviewed_head_sha": "abc"},
+    )
+    (packet_dir / "claude_review.md").write_text(
+        "## Verdict\nNEEDS_HUMAN\n\n"
+        "## Findings\nCritical risk needs operator approval after reviewing `dharma_swarm/ontology.py`.\n\n"
+        "## Missing Tests Or Proof\nNo missing local proof beyond human approval for this critical path.\n\n"
+        "## Merge Conditions\nHuman approval must be recorded before merge.\n",
+        encoding="utf-8",
+    )
+    prc.write_json(
+        packet_dir / "claude_review_receipt.json",
+        {"exit_code": 0, "reviewed_head_sha": "abc"},
+    )
+
+    args = SimpleNamespace(
+        packet_dir=str(packet_dir),
+        state_root=str(tmp_path),
+        pr=42,
+        allow_pending=False,
+        human_approved=True,
+        human_approval_note="Operator approved the critical hot-path merge after dual-agent review.",
+    )
+    monkeypatch.setattr(
+        prc,
+        "fetch_pr_view",
+        lambda _pr: {
+            "number": 42,
+            "title": "critical",
+            "headRefOid": "abc",
+            "body": """
+- Organ touched: dharma_swarm/ontology.py
+- Declared-vs-actual gap closed: critical path now has explicit review receipts.
+- Proof that re-reads the map: packet and gate both load.
+- New drift introduced: None
+""",
+            "isDraft": False,
+            "mergeable": "MERGEABLE",
+            "reviewDecision": "APPROVED",
+            "statusCheckRollup": [{"name": "tests", "status": "COMPLETED", "conclusion": "SUCCESS"}],
+        },
+    )
+    monkeypatch.setattr(prc, "repo_name", lambda: "owner/repo")
+    monkeypatch.setattr(prc, "fetch_review_threads", lambda _pr, _repo: {"ok": True, "unresolved_count": 0})
+
+    gate = prc.build_gate(args)
+
+    assert gate["decision"] == "MERGE_CANDIDATE"
+    assert "Claude review returned NEEDS_HUMAN; satisfied by recorded human approval" in gate["warnings"]
 
 
 def test_render_github_comment_blocks_when_gate_missing():

--- a/tests/test_pr_merge_control.py
+++ b/tests/test_pr_merge_control.py
@@ -1,0 +1,102 @@
+from scripts.runtime import pr_merge_control as prc
+
+
+def test_classify_pr_blocks_failing_checks():
+    pr = {
+        "number": 1,
+        "title": "bad",
+        "isDraft": False,
+        "mergeable": "MERGEABLE",
+        "reviewDecision": "APPROVED",
+        "statusCheckRollup": [
+            {"name": "tests", "status": "COMPLETED", "conclusion": "FAILURE"},
+        ],
+    }
+
+    result = prc.classify_pr(pr)
+
+    assert result["status"] == "BLOCKED_CHECKS"
+    assert result["checks"]["failing"] == ["tests"]
+
+
+def test_classify_pr_requires_packet_when_github_green():
+    pr = {
+        "number": 2,
+        "title": "good",
+        "isDraft": False,
+        "mergeable": "MERGEABLE",
+        "reviewDecision": "APPROVED",
+        "statusCheckRollup": [
+            {"name": "tests", "status": "COMPLETED", "conclusion": "SUCCESS"},
+        ],
+    }
+
+    result = prc.classify_pr(pr)
+
+    assert result["status"] == "GITHUB_GREEN_NEEDS_PACKET"
+    assert result["checks"]["passing"] == ["tests"]
+
+
+def test_coherence_results_rejects_placeholder_field():
+    body = """
+- Organ touched: docs/governance
+- Declared-vs-actual gap closed: TODO
+- Proof that re-reads the map: read COHERENCE_DELTA.md
+- New drift introduced: none
+"""
+
+    result = prc.coherence_results(body)
+
+    assert result["ok"] is False
+    assert result["fields"]["Declared-vs-actual gap closed"]["ok"] is False
+
+
+def test_coherence_results_accepts_substantive_fields():
+    body = """
+- Organ touched: `scripts/runtime/pr_merge_control.py` (operator review lane)
+- Declared-vs-actual gap closed: makes PR review receipts explicit before merge.
+- Proof that re-reads the map: checked COHERENCE_DELTA.md and AgentOps boundary.
+- New drift introduced: no runtime authority change; merge command stays confirmation-gated.
+"""
+
+    result = prc.coherence_results(body)
+
+    assert result["ok"] is True
+
+
+def test_risk_from_files_flags_hot_paths():
+    files = [
+        {"filename": "dharma_swarm/telos_gates.py", "additions": 3, "deletions": 1},
+        {"filename": "tests/test_telos.py", "additions": 5, "deletions": 0},
+    ]
+
+    result = prc.risk_from_files(files)
+
+    assert result["level"] == "CRITICAL"
+    assert "dharma_swarm/telos_gates.py" in result["hot_paths"]
+
+
+def test_claude_review_env_scrubs_anthropic_api_key_by_default():
+    command, env = prc.review_command_and_env(
+        "claude",
+        {
+            "ANTHROPIC_API_KEY": "depleted",
+            "PATH": "/usr/bin",
+        },
+    )
+
+    assert command[-1] == "-p"
+    assert "ANTHROPIC_API_KEY" not in env
+
+
+def test_claude_review_env_can_opt_into_api_key():
+    _, env = prc.review_command_and_env(
+        "claude",
+        {
+            "ANTHROPIC_API_KEY": "funded",
+            "DHARMA_CLAUDE_REVIEW_USE_API_KEY": "1",
+            "PATH": "/usr/bin",
+        },
+    )
+
+    assert env["ANTHROPIC_API_KEY"] == "funded"

--- a/tests/test_pr_merge_control.py
+++ b/tests/test_pr_merge_control.py
@@ -64,6 +64,19 @@ def test_coherence_results_accepts_substantive_fields():
     assert result["ok"] is True
 
 
+def test_coherence_results_accepts_bold_field_with_colon_inside_bold():
+    body = """
+- **Organ touched:** `inter_agent/devin/outbound/` additive rendezvous surface.
+- **Declared-vs-actual gap closed:** merged outbound response now exists.
+- **Proof that re-reads the map:** rechecked spine imports and loop map.
+- **New drift introduced:** two markdown receipts; no runtime path changed.
+"""
+
+    result = prc.coherence_results(body)
+
+    assert result["ok"] is True
+
+
 def test_risk_from_files_flags_hot_paths():
     files = [
         {"filename": "dharma_swarm/telos_gates.py", "additions": 3, "deletions": 1},

--- a/tests/test_pr_merge_control.py
+++ b/tests/test_pr_merge_control.py
@@ -255,6 +255,14 @@ def test_codex_review_defaults_to_bounded_reasoning():
     assert "model_reasoning_effort=\"medium\"" in command
 
 
+def test_render_agent_prompt_requires_repo_relative_paths(tmp_path):
+    prompt = prc.render_agent_prompt("Claude", tmp_path / "REVIEW_PACKET.md", 406)
+
+    assert "repo-relative file/line evidence" in prompt
+    assert "`dharma_swarm/ontology.py`" in prompt
+    assert "bare filenames are not sufficient" in prompt
+
+
 def test_review_receipt_status_rejects_command_error(tmp_path):
     path = tmp_path / "codex_review.md"
     path.write_text(

--- a/tests/test_pr_merge_control.py
+++ b/tests/test_pr_merge_control.py
@@ -486,6 +486,20 @@ def test_claude_review_env_can_opt_into_api_key():
     assert env["ANTHROPIC_API_KEY"] == "funded"
 
 
+def test_review_timeout_seconds_defaults_and_validates():
+    assert prc.review_timeout_seconds("codex", {}) == 600
+    assert prc.review_timeout_seconds("claude", {"CLAUDE_REVIEW_TIMEOUT_SECONDS": "90"}) == 90
+
+
+def test_review_timeout_seconds_rejects_too_short():
+    try:
+        prc.review_timeout_seconds("codex", {"CODEX_REVIEW_TIMEOUT_SECONDS": "5"})
+    except prc.PRControlError as exc:
+        assert "at least 30 seconds" in str(exc)
+    else:
+        raise AssertionError("expected PRControlError")
+
+
 def test_review_receipt_status_rejects_shallow_approval(tmp_path):
     path = tmp_path / "codex_review.md"
     path.write_text(

--- a/tests/test_pr_merge_control.py
+++ b/tests/test_pr_merge_control.py
@@ -91,6 +91,69 @@ def test_classify_pr_blocks_empty_check_rollup():
     assert result["checks"]["unknown"] == ["no status checks reported"]
 
 
+def test_classify_pr_ignores_superseded_cancelled_duplicate_check():
+    pr = {
+        "number": 6,
+        "title": "rerun",
+        "isDraft": False,
+        "mergeable": "MERGEABLE",
+        "reviewDecision": "APPROVED",
+        "statusCheckRollup": [
+            {
+                "name": "Coherence Delta PR body",
+                "status": "COMPLETED",
+                "conclusion": "CANCELLED",
+                "startedAt": "2026-05-31T12:13:36Z",
+                "completedAt": "2026-05-31T12:13:41Z",
+            },
+            {
+                "name": "Coherence Delta PR body",
+                "status": "COMPLETED",
+                "conclusion": "SUCCESS",
+                "startedAt": "2026-05-31T12:13:44Z",
+                "completedAt": "2026-05-31T12:13:51Z",
+            },
+        ],
+    }
+
+    result = prc.classify_pr(pr)
+
+    assert result["status"] == "GITHUB_GREEN_NEEDS_PACKET"
+    assert result["checks"]["failing"] == []
+    assert result["checks"]["passing"] == ["Coherence Delta PR body"]
+
+
+def test_classify_pr_blocks_latest_duplicate_check_failure():
+    pr = {
+        "number": 7,
+        "title": "rerun failed",
+        "isDraft": False,
+        "mergeable": "MERGEABLE",
+        "reviewDecision": "APPROVED",
+        "statusCheckRollup": [
+            {
+                "name": "DocOps integrity gate",
+                "status": "COMPLETED",
+                "conclusion": "SUCCESS",
+                "startedAt": "2026-05-31T12:13:36Z",
+                "completedAt": "2026-05-31T12:13:41Z",
+            },
+            {
+                "name": "DocOps integrity gate",
+                "status": "COMPLETED",
+                "conclusion": "FAILURE",
+                "startedAt": "2026-05-31T12:13:44Z",
+                "completedAt": "2026-05-31T12:13:51Z",
+            },
+        ],
+    }
+
+    result = prc.classify_pr(pr)
+
+    assert result["status"] == "BLOCKED_CHECKS"
+    assert result["checks"]["failing"] == ["DocOps integrity gate"]
+
+
 def test_coherence_results_rejects_placeholder_field():
     body = """
 - Organ touched: docs/governance

--- a/tests/test_pr_merge_control.py
+++ b/tests/test_pr_merge_control.py
@@ -204,7 +204,13 @@ def test_review_receipt_status_accepts_verdict(tmp_path):
         "## Verdict\n"
         "APPROVE\n\n"
         "## Findings\n"
-        "No blocking findings.\n",
+        "No blocking findings after checking `scripts/runtime/pr_merge_control.py` "
+        "and `tests/test_pr_merge_control.py` for gate behavior.\n\n"
+        "## Missing Tests Or Proof\n"
+        "No missing proof for this bounded change; `tests/test_pr_merge_control.py` "
+        "covers the receipt path.\n\n"
+        "## Merge Conditions\n"
+        "Merge only after CI is green and the reviewed head SHA still matches.",
         encoding="utf-8",
     )
     prc.write_json(path.with_name("claude_review_receipt.json"), {"exit_code": 0, "reviewed_head_sha": "abc"})
@@ -221,7 +227,12 @@ def test_review_receipt_status_accepts_request_changes_for_gate_to_block(tmp_pat
         "## Verdict\n"
         "REQUEST_CHANGES\n\n"
         "## Findings\n"
-        "1. Blocking issue.\n",
+        "1. HIGH - `scripts/runtime/pr_merge_control.py` still accepts a shallow "
+        "review receipt, so the merge gate can be bypassed.\n\n"
+        "## Missing Tests Or Proof\n"
+        "`tests/test_pr_merge_control.py` needs a negative test for shallow approvals.\n\n"
+        "## Merge Conditions\n"
+        "Add the negative test and rerun `pytest -q tests/test_pr_merge_control.py`.",
         encoding="utf-8",
     )
     prc.write_json(path.with_name("codex_review_receipt.json"), {"exit_code": 0, "reviewed_head_sha": "abc"})
@@ -252,7 +263,10 @@ def test_review_receipt_status_rejects_unedited_verdict_template(tmp_path):
 def test_review_receipt_status_rejects_nonzero_exit(tmp_path):
     path = tmp_path / "codex_review.md"
     path.write_text(
-        "## Verdict\nAPPROVE\n\n## Findings\nNo blocking findings.\n",
+        "## Verdict\nAPPROVE\n\n"
+        "## Findings\nNo blocking findings after reading `scripts/runtime/pr_merge_control.py`.\n\n"
+        "## Missing Tests Or Proof\nNo missing local proof for this bounded check.\n\n"
+        "## Merge Conditions\nCI must stay green and the reviewed head must match.\n",
         encoding="utf-8",
     )
     prc.write_json(path.with_name("codex_review_receipt.json"), {"exit_code": 1, "reviewed_head_sha": "abc"})
@@ -266,7 +280,10 @@ def test_review_receipt_status_rejects_nonzero_exit(tmp_path):
 def test_review_receipt_status_rejects_stale_head(tmp_path):
     path = tmp_path / "claude_review.md"
     path.write_text(
-        "## Verdict\nAPPROVE\n\n## Findings\nNo blocking findings.\n",
+        "## Verdict\nAPPROVE\n\n"
+        "## Findings\nNo blocking findings after reading `scripts/runtime/pr_merge_control.py`.\n\n"
+        "## Missing Tests Or Proof\nNo missing local proof for this bounded check.\n\n"
+        "## Merge Conditions\nCI must stay green and the reviewed head must match.\n",
         encoding="utf-8",
     )
     prc.write_json(path.with_name("claude_review_receipt.json"), {"exit_code": 0, "reviewed_head_sha": "old"})
@@ -283,7 +300,10 @@ def test_build_gate_blocks_when_review_thread_lookup_fails(tmp_path, monkeypatch
     prc.write_json(packet_dir / "FACTS.json", {"risk": {"level": "LOW"}})
     for name in ("codex_review.md", "claude_review.md"):
         (packet_dir / name).write_text(
-            "## Verdict\nAPPROVE\n\n## Findings\nNo blocking findings.\n",
+            "## Verdict\nAPPROVE\n\n"
+            "## Findings\nNo blocking findings after reading `scripts/runtime/pr_merge_control.py`.\n\n"
+            "## Missing Tests Or Proof\nNo missing local proof for this bounded check.\n\n"
+            "## Merge Conditions\nCI must stay green and the reviewed head must match.\n",
             encoding="utf-8",
         )
         prc.write_json(
@@ -338,7 +358,10 @@ def test_build_gate_blocks_when_head_changed_after_packet(tmp_path, monkeypatch)
     prc.write_json(packet_dir / "FACTS.json", {"risk": {"level": "LOW"}, "pr": {"headRefOid": "old"}})
     for name in ("codex_review.md", "claude_review.md"):
         (packet_dir / name).write_text(
-            "## Verdict\nAPPROVE\n\n## Findings\nNo blocking findings.\n",
+            "## Verdict\nAPPROVE\n\n"
+            "## Findings\nNo blocking findings after reading `scripts/runtime/pr_merge_control.py`.\n\n"
+            "## Missing Tests Or Proof\nNo missing local proof for this bounded check.\n\n"
+            "## Merge Conditions\nCI must stay green and the reviewed head must match.\n",
             encoding="utf-8",
         )
         prc.write_json(
@@ -389,7 +412,10 @@ def test_build_gate_requires_note_for_high_risk_human_approval(tmp_path, monkeyp
     prc.write_json(packet_dir / "FACTS.json", {"risk": {"level": "HIGH"}, "pr": {"headRefOid": "abc"}})
     for name in ("codex_review.md", "claude_review.md"):
         (packet_dir / name).write_text(
-            "## Verdict\nAPPROVE\n\n## Findings\nNo blocking findings.\n",
+            "## Verdict\nAPPROVE\n\n"
+            "## Findings\nNo blocking findings after reading `scripts/runtime/pr_merge_control.py`.\n\n"
+            "## Missing Tests Or Proof\nNo missing local proof for this bounded check.\n\n"
+            "## Merge Conditions\nCI must stay green and the reviewed head must match.\n",
             encoding="utf-8",
         )
         prc.write_json(
@@ -458,3 +484,46 @@ def test_claude_review_env_can_opt_into_api_key():
     )
 
     assert env["ANTHROPIC_API_KEY"] == "funded"
+
+
+def test_review_receipt_status_rejects_shallow_approval(tmp_path):
+    path = tmp_path / "codex_review.md"
+    path.write_text(
+        "## Verdict\n"
+        "APPROVE\n\n"
+        "## Findings\n"
+        "No blocking findings.\n\n"
+        "## Missing Tests Or Proof\n"
+        "None.\n\n"
+        "## Merge Conditions\n"
+        "Ready.\n",
+        encoding="utf-8",
+    )
+    prc.write_json(path.with_name("codex_review_receipt.json"), {"exit_code": 0, "reviewed_head_sha": "abc"})
+
+    result = prc.review_receipt_status(path, expected_head_sha="abc")
+
+    assert result["ok"] is False
+    assert result["reason"] in {
+        "Findings section is too thin",
+        "Missing Tests Or Proof section is too thin",
+        "Merge Conditions section is too thin",
+        "review lacks concrete file/path evidence",
+    }
+
+
+def test_review_receipt_status_rejects_missing_review_sections(tmp_path):
+    path = tmp_path / "codex_review.md"
+    path.write_text(
+        "## Verdict\n"
+        "APPROVE\n\n"
+        "## Findings\n"
+        "No blocking findings after reading `scripts/runtime/pr_merge_control.py`.\n",
+        encoding="utf-8",
+    )
+    prc.write_json(path.with_name("codex_review_receipt.json"), {"exit_code": 0, "reviewed_head_sha": "abc"})
+
+    result = prc.review_receipt_status(path, expected_head_sha="abc")
+
+    assert result["ok"] is False
+    assert result["reason"].startswith("missing review sections:")

--- a/tests/test_pr_merge_control.py
+++ b/tests/test_pr_merge_control.py
@@ -115,6 +115,36 @@ def test_claude_review_env_scrubs_anthropic_api_key_by_default():
     assert "ANTHROPIC_API_KEY" not in env
 
 
+def test_review_receipt_status_rejects_command_error(tmp_path):
+    path = tmp_path / "codex_review.md"
+    path.write_text(
+        "Reading prompt from stdin...\n"
+        "Error: failed to initialize in-process app-server client\n",
+        encoding="utf-8",
+    )
+
+    result = prc.review_receipt_status(path)
+
+    assert result["ok"] is False
+    assert result["reason"] == "review command failed"
+
+
+def test_review_receipt_status_accepts_verdict(tmp_path):
+    path = tmp_path / "claude_review.md"
+    path.write_text(
+        "## Verdict\n"
+        "APPROVE\n\n"
+        "## Findings\n"
+        "No blocking findings.\n",
+        encoding="utf-8",
+    )
+
+    result = prc.review_receipt_status(path)
+
+    assert result["ok"] is True
+    assert result["verdict"] == "APPROVE"
+
+
 def test_claude_review_env_can_opt_into_api_key():
     _, env = prc.review_command_and_env(
         "claude",

--- a/tests/test_pr_merge_control.py
+++ b/tests/test_pr_merge_control.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 from scripts.runtime import pr_merge_control as prc
 
 
@@ -37,6 +39,42 @@ def test_classify_pr_requires_packet_when_github_green():
     assert result["checks"]["passing"] == ["tests"]
 
 
+def test_classify_pr_blocks_unknown_non_success_conclusion():
+    pr = {
+        "number": 3,
+        "title": "startup failed",
+        "isDraft": False,
+        "mergeable": "MERGEABLE",
+        "reviewDecision": "APPROVED",
+        "statusCheckRollup": [
+            {"name": "CodeQL", "status": "COMPLETED", "conclusion": "STARTUP_FAILURE"},
+        ],
+    }
+
+    result = prc.classify_pr(pr)
+
+    assert result["status"] == "BLOCKED_CHECKS"
+    assert result["checks"]["failing"] == ["CodeQL"]
+
+
+def test_classify_pr_blocks_unrecognized_completed_conclusion():
+    pr = {
+        "number": 4,
+        "title": "weird",
+        "isDraft": False,
+        "mergeable": "MERGEABLE",
+        "reviewDecision": "APPROVED",
+        "statusCheckRollup": [
+            {"name": "custom", "status": "COMPLETED", "conclusion": "BOGUS"},
+        ],
+    }
+
+    result = prc.classify_pr(pr)
+
+    assert result["status"] == "BLOCKED_CHECKS"
+    assert result["checks"]["failing"] == ["custom:BOGUS"]
+
+
 def test_coherence_results_rejects_placeholder_field():
     body = """
 - Organ touched: docs/governance
@@ -49,6 +87,20 @@ def test_coherence_results_rejects_placeholder_field():
 
     assert result["ok"] is False
     assert result["fields"]["Declared-vs-actual gap closed"]["ok"] is False
+
+
+def test_coherence_results_rejects_bold_placeholder_without_swallowing_next_field():
+    body = """
+- **Organ touched:** docs/governance
+- **Declared-vs-actual gap closed:** TODO
+- **Proof that re-reads the map:** checked the generated inventory.
+- **New drift introduced:** None
+"""
+
+    result = prc.coherence_results(body)
+
+    assert result["ok"] is False
+    assert result["fields"]["Declared-vs-actual gap closed"]["value"] == "TODO"
 
 
 def test_coherence_results_accepts_substantive_fields():
@@ -159,6 +211,55 @@ def test_review_receipt_status_accepts_request_changes_for_gate_to_block(tmp_pat
 
     assert result["ok"] is True
     assert result["verdict"] == "REQUEST_CHANGES"
+
+
+def test_build_gate_blocks_when_review_thread_lookup_fails(tmp_path, monkeypatch):
+    packet_dir = tmp_path / "packet"
+    packet_dir.mkdir()
+    prc.write_json(packet_dir / "FACTS.json", {"risk": {"level": "LOW"}})
+    for name in ("codex_review.md", "claude_review.md"):
+        (packet_dir / name).write_text(
+            "## Verdict\nAPPROVE\n\n## Findings\nNo blocking findings.\n",
+            encoding="utf-8",
+        )
+
+    args = SimpleNamespace(
+        packet_dir=str(packet_dir),
+        state_root=str(tmp_path),
+        pr=42,
+        allow_pending=False,
+        human_approved=False,
+    )
+
+    monkeypatch.setattr(
+        prc,
+        "fetch_pr_view",
+        lambda _pr: {
+            "number": 42,
+            "title": "ok",
+            "body": """
+- Organ touched: docs
+- Declared-vs-actual gap closed: reviewer proof is now strict.
+- Proof that re-reads the map: packet and gate both load.
+- New drift introduced: None
+""",
+            "isDraft": False,
+            "mergeable": "MERGEABLE",
+            "reviewDecision": "APPROVED",
+            "statusCheckRollup": [{"name": "tests", "status": "COMPLETED", "conclusion": "SUCCESS"}],
+        },
+    )
+    monkeypatch.setattr(prc, "repo_name", lambda: "owner/repo")
+    monkeypatch.setattr(
+        prc,
+        "fetch_review_threads",
+        lambda _pr, _repo: {"ok": False, "error": "rate limited", "unresolved_count": None},
+    )
+
+    gate = prc.build_gate(args)
+
+    assert gate["decision"] == "BLOCKED"
+    assert "could not verify review threads: rate limited" in gate["blockers"]
 
 
 def test_claude_review_env_can_opt_into_api_key():

--- a/tests/test_pr_merge_control.py
+++ b/tests/test_pr_merge_control.py
@@ -77,6 +77,19 @@ def test_coherence_results_accepts_bold_field_with_colon_inside_bold():
     assert result["ok"] is True
 
 
+def test_coherence_results_accepts_no_new_drift_statement():
+    body = """
+- Organ touched: governance / docs / state
+- Declared-vs-actual gap closed: stale operational surfaces are refreshed.
+- Proof that re-reads the map: `make docops-integrity` passes.
+- New drift introduced: None
+"""
+
+    result = prc.coherence_results(body)
+
+    assert result["ok"] is True
+
+
 def test_risk_from_files_flags_hot_paths():
     files = [
         {"filename": "dharma_swarm/telos_gates.py", "additions": 3, "deletions": 1},


### PR DESCRIPTION
## Why

The repo had 42 open PRs, and GitHub-green status was not enough to decide merges. This adds a deterministic PR queue, dual-review packet surface, local merge gate, and a self-contained `@terminal-review` GitHub Action path that comments blockers without relying on a local webhook.

## Surface area touched

- [x] `.github/` / governance configs
- [x] `scripts/runtime/...`
- [x] `tests/...`
- [x] `docs/...` / DocOps
- [x] `Makefile`

## Interface mismatch impact

- [x] Existing overlap resolved: the GitHub Action now owns the GitHub-side `@terminal-review` packet/gate comment.
- [x] `scripts/codex_mention_bridge.py` remains a local webhook experiment and now defaults to `@codex`, not `@terminal-review`, so it no longer competes for the governed mention path.

## Coherence Delta

- Organ touched: `scripts/runtime/pr_merge_control.py`, `.github/workflows/codex-mention-router.yml`, `Makefile`, `docs/ops/PR_REVIEW_CONTROL.md` — operator review / merge-control lane.
- Declared-vs-actual gap closed: turns `@terminal-review` from a brittle local-webhook-only path into a deterministic GitHub packet/gate comment path, and adds local Codex/Claude review receipts plus confirmation-gated merge commands.
- Proof that re-reads the map: reread `docs/governance/COHERENCE_DELTA.md`, `docs/governance/AGENTOPS.md`, `docs/ops/LONG_RUNNING_HARNESS.md`, `docs/architecture/NAVIGATION.md`, and the existing `codex-mention-router` / `merge_snapshot` / `review_bridge` surfaces before adding this bounded lane. The gate now fails closed on review-thread lookup uncertainty, unclear CI conclusions, invalid or stale-head review receipts, template verdicts, shallow approvals without concrete file/path evidence, non-APPROVE review verdicts, missing gate output, high-risk approval without a note, and merge execution without a matching head commit. The queue classifier also collapses superseded duplicate check names so cancelled old reruns do not mask a later green check.
- New drift introduced: Claude Code non-interactive review remains credential-gated; `make pr-reviewers` reports that state explicitly instead of pretending Claude reviewed anything.

## Verification

- [x] `pytest -q tests/test_pr_merge_control.py` -> 29 passed
- [x] `make docops-integrity` -> passed
- [x] `make pr-queue` -> scanned 20 open PRs; duplicate cancelled checks are now collapsed behind the latest check per name
- [x] PR #401 GitHub checks -> rerun required on head `8f2044a2`
- [x] pre-commit hooks during commits -> hygiene, contract tests, uplift guards, DocOps, gitleaks, semgrep, whitespace/yaml checks passed

## Risk + rollback

- Blast radius: high. This changes the GitHub mention workflow and adds local merge-control commands, but `pr-merge` is dry-run unless `--execute` and an exact confirmation token are supplied. High-risk merges still require `--human-approved`.
- Rollback: single revert restores the old `@terminal-review` webhook-only behavior and removes local PR review control commands.

## Checklist

- [x] No unintended changes (`git diff --stat` reviewed)
- [x] No new files at repo root
- [x] No `git add -A` / `git add .` in added scripts
- [x] Tests added for behavior change
