### PR TITLE
feat(runtime): add execution identity spine v2 [impact-checked]

### DIFF
--- a/dharma_swarm/a2a/a2a_server.py
+++ b/dharma_swarm/a2a/a2a_server.py
@@ -34,6 +34,8 @@ from pathlib import Path
 from typing import Any, Callable
 
 from dharma_swarm.daemon_config import dharma_state_dir
+from dharma_swarm.runtime_state import RuntimeReceipt, RuntimeStateStore
+from dharma_swarm.spine.identity import ExecutionIdentity, MissingExecutionIdentity
 
 logger = logging.getLogger(__name__)
 
@@ -272,12 +274,16 @@ class A2AServer:
         self,
         task_log_path: Path | None = None,
         persist: bool = True,
+        runtime_state: RuntimeStateStore | None = None,
+        require_execution_identity: bool = False,
     ) -> None:
         self._tasks: dict[str, A2ATask] = {}
         self._handlers: dict[str, TaskHandler] = {}
         self._default_handler: TaskHandler | None = None
         self._persist = persist
         self._task_log_path = task_log_path or _DEFAULT_TASK_LOG
+        self._runtime_state = runtime_state
+        self._require_execution_identity = require_execution_identity
 
     # -- handler registration ------------------------------------------------
 
@@ -323,6 +329,31 @@ class A2AServer:
         if not task.context_id:
             task.context_id = uuid.uuid4().hex[:12]
 
+        identity = self._ensure_execution_identity(task)
+        side_effect_key = f"a2a_handler:{task.id}:{task.capability or 'default'}"
+        if self._runtime_state is not None:
+            self._runtime_state.record_execution_identity_sync(
+                identity,
+                source="a2a_server.submit",
+                metadata={
+                    "ingress_surface": "a2a_local",
+                    "context_id": task.context_id,
+                    "capability": task.capability,
+                    "status": task.status.value,
+                },
+            )
+            if not self._runtime_state.try_begin_idempotent_side_effect_sync(
+                identity,
+                side_effect_key,
+                metadata={"source": "a2a_server.submit"},
+            ):
+                existing = self._tasks.get(task.id)
+                if existing is not None:
+                    return existing
+                task.metadata["idempotency_status"] = "duplicate"
+                self._tasks[task.id] = task
+                return task
+
         self._tasks[task.id] = task
 
         logger.info(
@@ -333,8 +364,74 @@ class A2AServer:
 
         # Dispatch to handler
         result = self._dispatch(task)
+        if self._runtime_state is not None:
+            receipt_id = f"rr_{identity.run_id}_a2a_{result.status.value}"
+            self._runtime_state.record_runtime_receipt_sync(
+                RuntimeReceipt(
+                    receipt_id=receipt_id,
+                    receipt_type="a2a_task",
+                    status=result.status.value,
+                    run_id=identity.run_id,
+                    task_id=identity.task_id,
+                    trace_id=identity.trace_id,
+                    correlation_id=identity.correlation_id,
+                    causation_id=identity.causation_id,
+                    parent_run_id=identity.parent_run_id,
+                    agent_id=identity.agent_id,
+                    idempotency_key=identity.idempotency_key,
+                    side_effect_key=side_effect_key,
+                    payload={
+                        "external_a2a_task_id": result.id,
+                        "context_id": result.context_id,
+                        "capability": result.capability,
+                    },
+                )
+            )
+            self._runtime_state.complete_idempotent_side_effect_sync(
+                identity,
+                side_effect_key,
+                result_receipt_id=receipt_id,
+                metadata={"status": result.status.value},
+            )
         self._append_task_log(result)
         return result
+
+    def _ensure_execution_identity(self, task: A2ATask) -> ExecutionIdentity:
+        meta = dict(task.metadata or {})
+        nested = meta.get("execution_identity")
+        explicit = dict(nested) if isinstance(nested, dict) else {}
+        trace_id = task.trace_id or str(meta.get("trace_id") or explicit.get("trace_id") or "")
+        if self._require_execution_identity and not trace_id:
+            raise MissingExecutionIdentity("A2A task requires trace_id")
+        identity = ExecutionIdentity.new(
+            task_id=str(meta.get("task_id") or task.dharma_task_id or task.id),
+            agent_id=task.to_agent or str(meta.get("agent_id") or ""),
+            session_id=str(meta.get("session_id") or explicit.get("session_id") or ""),
+            trace_id=trace_id,
+            correlation_id=str(meta.get("correlation_id") or explicit.get("correlation_id") or trace_id),
+            causation_id=str(meta.get("causation_id") or explicit.get("causation_id") or ""),
+            parent_run_id=str(meta.get("parent_run_id") or explicit.get("parent_run_id") or ""),
+            run_id=str(meta.get("run_id") or meta.get("runtime_run_id") or explicit.get("run_id") or ""),
+            claim_id=str(meta.get("claim_id") or explicit.get("claim_id") or ""),
+            idempotency_key=str(meta.get("idempotency_key") or explicit.get("idempotency_key") or ""),
+            external_a2a_task_id=task.id,
+            metadata={"context_id": task.context_id, "capability": task.capability},
+        )
+        task.trace_id = identity.trace_id
+        task.dharma_task_id = task.dharma_task_id or identity.task_id
+        task.metadata.update(
+            {
+                "execution_identity": identity.to_dict(),
+                "trace_id": identity.trace_id,
+                "correlation_id": identity.correlation_id,
+                "run_id": identity.run_id,
+                "runtime_run_id": identity.run_id,
+                "claim_id": identity.claim_id,
+                "idempotency_key": identity.idempotency_key,
+                "external_a2a_task_id": identity.external_a2a_task_id,
+            }
+        )
+        return identity.require_for_dispatch()
 
     def _dispatch(self, task: A2ATask) -> A2ATask:
         """Route task to appropriate handler and execute."""

--- a/dharma_swarm/a2a/node_gateway.py
+++ b/dharma_swarm/a2a/node_gateway.py
@@ -58,6 +58,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import uuid
 from dataclasses import asdict
 from datetime import datetime, timezone
 from typing import Any
@@ -173,6 +174,17 @@ def _task_to_dict(task: A2ATask) -> dict[str, Any]:
     d = asdict(task)
     # Exclude the property alias from serialization
     d.pop("messages", None)
+    metadata = dict(d.get("metadata") or {})
+    for key in (
+        "run_id",
+        "runtime_run_id",
+        "correlation_id",
+        "idempotency_key",
+        "claim_id",
+        "external_a2a_task_id",
+    ):
+        if metadata.get(key):
+            d[key] = metadata[key]
     # Strip internal validation flags from serialized parts
     _strip_internal_fields(d)
     return d
@@ -207,15 +219,32 @@ def _parse_task_from_body(body: dict[str, Any]) -> A2ATask:
     if not messages and body.get("message"):
         messages = [A2AMessage.text(body["message"])]
 
-    return A2ATask(
+    metadata = dict(body.get("metadata", {}) or {})
+    for key in (
+        "run_id",
+        "runtime_run_id",
+        "correlation_id",
+        "causation_id",
+        "parent_run_id",
+        "claim_id",
+        "idempotency_key",
+        "session_id",
+        "task_id",
+    ):
+        if body.get(key):
+            metadata[key] = body[key]
+
+    task = A2ATask(
+        id=str(body.get("id") or body.get("task_id") or "") or uuid.uuid4().hex[:16],
         from_agent=body.get("from_agent", "remote"),
         to_agent=body.get("to_agent", ""),
         capability=body.get("capability", ""),
         context_id=body.get("context_id", ""),
         trace_id=body.get("trace_id", ""),
         history=messages,
-        metadata=body.get("metadata", {}),
+        metadata=metadata,
     )
+    return task
 
 
 def _health_payload() -> dict[str, Any]:

--- a/dharma_swarm/checkpoint.py
+++ b/dharma_swarm/checkpoint.py
@@ -91,14 +91,15 @@ class InterruptGate:
       - API: emits WebSocket event and awaits response
       - TUI: shows modal dialog
 
-    If no callback is set, interrupts auto-approve (backward compatible).
+    If no callback is set, interrupts reject immediately unless auto_approve is
+    explicitly enabled.
     """
 
     def __init__(
         self,
         callback: Callable[[InterruptRequest], Any] | None = None,
         timeout_seconds: float = 300.0,
-        auto_approve: bool = True,
+        auto_approve: bool = False,
     ) -> None:
         self._callback = callback
         self._timeout = timeout_seconds
@@ -108,15 +109,22 @@ class InterruptGate:
     async def interrupt(self, request: InterruptRequest) -> InterruptResponse:
         """Pause execution and wait for operator response.
 
-        If no callback is registered and auto_approve is True, returns
-        APPROVE immediately (backward compatible with existing behavior).
+        If no callback is registered, return immediately instead of waiting for
+        a response that no transport can deliver.
         """
-        if self._callback is None and self._auto_approve:
-            return InterruptResponse(
+        if self._callback is None:
+            response = InterruptResponse(
                 request_id=request.id,
-                decision=InterruptDecision.APPROVE,
-                reason="auto-approved (no interrupt handler registered)",
+                decision=InterruptDecision.APPROVE if self._auto_approve else InterruptDecision.REJECT,
+                reason=(
+                    "auto-approved (no interrupt handler registered)"
+                    if self._auto_approve
+                    else "rejected (no interrupt handler registered)"
+                ),
             )
+            _write_interrupt_request(request)
+            write_interrupt_response(response)
+            return response
 
         # Create a future for the response
         loop = asyncio.get_running_loop()

--- a/dharma_swarm/message_bus.py
+++ b/dharma_swarm/message_bus.py
@@ -11,6 +11,7 @@ a foreign key back to ``messages(id)``.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import sqlite3
 from contextlib import asynccontextmanager
@@ -26,6 +27,8 @@ from dharma_swarm.models import (
     MessageStatus,
     _new_id,
 )
+from dharma_swarm.runtime_state import RuntimeStateStore
+from dharma_swarm.spine.identity import ExecutionIdentity
 
 _MESSAGES_DDL = """
 CREATE TABLE IF NOT EXISTS messages (
@@ -114,8 +117,14 @@ class MessageBus:
     _BUSY_TIMEOUT_S = 30
     _LOCK_RETRY_DELAYS_S = (0.05, 0.1, 0.25, 0.5, 1.0)
 
-    def __init__(self, db_path: Path) -> None:
+    def __init__(
+        self,
+        db_path: Path,
+        *,
+        runtime_state: RuntimeStateStore | None = None,
+    ) -> None:
         self.db_path = db_path
+        self._runtime_state = runtime_state
 
     def _open(self) -> aiosqlite.Connection:
         """Open a connection with enough headroom for concurrent writers."""
@@ -586,10 +595,64 @@ class MessageBus:
         task_id: str | None = None,
         agent_id: str | None = None,
         payload: dict[str, Any] | None = None,
+        idempotency_key: str | None = None,
     ) -> str:
         """Persist a cross-process event.  Returns the event_id."""
         import os
-        event_id = _new_id()
+        event_payload = payload or {}
+        event_id = (
+            "evt_" + hashlib.sha256(
+                f"message_bus.emit_event:{idempotency_key}".encode("utf-8")
+            ).hexdigest()[:16]
+            if idempotency_key
+            else _new_id()
+        )
+        identity: ExecutionIdentity | None = None
+        side_effect_key = f"message_bus.emit_event:{event_type}:{event_id}"
+        if idempotency_key:
+            if self._runtime_state is None:
+                raise ValueError("runtime_state is required when idempotency_key is supplied")
+            identity = ExecutionIdentity.new(
+                task_id=str(task_id or event_payload.get("task_id") or "message_bus"),
+                agent_id=str(agent_id or event_payload.get("agent_id") or ""),
+                trace_id=str(event_payload.get("trace_id") or ""),
+                correlation_id=str(event_payload.get("correlation_id") or event_payload.get("trace_id") or ""),
+                run_id=str(event_payload.get("run_id") or ""),
+                claim_id=str(event_payload.get("claim_id") or ""),
+                idempotency_key=idempotency_key,
+                event_id=event_id,
+            )
+            existing = await self._runtime_state.get_idempotency_record(
+                identity.idempotency_key,
+                side_effect_key,
+            )
+            if existing is not None:
+                return existing.result_receipt_id or event_id
+            should_execute = await self._runtime_state.try_begin_idempotent_side_effect(
+                identity,
+                side_effect_key,
+                metadata={
+                    "event_type": event_type,
+                    "operation_hash": hashlib.sha256(
+                        json.dumps(
+                            {
+                                "event_type": event_type,
+                                "task_id": task_id,
+                                "agent_id": agent_id,
+                                "payload": event_payload,
+                            },
+                            sort_keys=True,
+                            default=str,
+                        ).encode("utf-8")
+                    ).hexdigest(),
+                },
+            )
+            if not should_execute:
+                record = await self._runtime_state.get_idempotency_record(
+                    identity.idempotency_key,
+                    side_effect_key,
+                )
+                return (record.result_receipt_id if record else "") or event_id
 
         async def _emit() -> str:
             async with self._open() as db:
@@ -601,13 +664,21 @@ class MessageBus:
                     (
                         event_id, event_type, task_id, agent_id,
                         os.getpid(), _now_iso(),
-                        json.dumps(payload or {}, default=str),
+                        json.dumps(event_payload, default=str),
                     ),
                 )
                 await db.commit()
             return event_id
 
-        return await self._run_with_lock_retry(_emit)
+        emitted = await self._run_with_lock_retry(_emit)
+        if identity is not None and self._runtime_state is not None:
+            await self._runtime_state.complete_idempotent_side_effect(
+                identity,
+                side_effect_key,
+                result_receipt_id=emitted,
+                metadata={"event_type": event_type},
+            )
+        return emitted
 
     async def consume_events(
         self,

--- a/dharma_swarm/orchestrator.py
+++ b/dharma_swarm/orchestrator.py
@@ -2000,7 +2000,7 @@ class Orchestrator:
             td.metadata["witness_reroutes"] = gate.attempts
 
         claim_meta = self._prepare_claim(task_for_gate, td)
-        self._runtime_lifecycle.ensure_runtime_run_id(td)
+        self._runtime_lifecycle.ensure_execution_identity(td, task=task_for_gate)
         claim_meta = await self._attach_context_bundle(task_for_gate, td, claim_meta)
         claim_meta = self._attach_latent_gold(task_for_gate, claim_meta)
         if task_for_gate is not None:
@@ -2033,6 +2033,7 @@ class Orchestrator:
             task=task_for_gate,
             status="claimed",
         )
+        await self._runtime_lifecycle.record_delegation_run(td, task=task_for_gate, status="claimed")
         _pe_t2 = _adt.monotonic()
         if self._bus is not None:
             await self._bus.send(Message(
@@ -2174,22 +2175,33 @@ class Orchestrator:
         correlation_token = None
         reset_correlation = None
 
-        # Set CorrelationContext with cell_id for room-scoped tracing.
+        # Set CorrelationContext with execution identity for room-scoped tracing.
         # The token is reset in finally to avoid context leakage across tasks.
         cell_id = td.metadata.get("cell_id", "")
-        if cell_id:
+        identity_meta = td.metadata.get("execution_identity")
+        if not isinstance(identity_meta, dict):
+            identity_meta = {}
+        trace_id = str(identity_meta.get("trace_id", "") or "")
+        session_id = str(identity_meta.get("session_id", "") or "")
+        if cell_id or trace_id:
             try:
                 from dharma_swarm.correlation_context import (
+                    CorrelationContext,
                     set_correlation,
                     reset_correlation as _reset_correlation,
                     get_correlation,
                 )
                 current = get_correlation()
-                ctx = current.with_cell(cell_id)
+                ctx = CorrelationContext(
+                    trace_id=trace_id or current.trace_id,
+                    proposal_id=current.proposal_id,
+                    session_id=session_id or current.session_id,
+                    cell_id=cell_id or current.cell_id,
+                )
                 correlation_token = set_correlation(ctx)
                 reset_correlation = _reset_correlation
             except Exception:
-                logger.debug("cell_id correlation context setup failed", exc_info=True)
+                logger.debug("execution correlation context setup failed", exc_info=True)
 
         try:
             await self._runtime_lifecycle.record_delegation_run(
@@ -2444,25 +2456,23 @@ class Orchestrator:
                     except Exception:
                         logger.debug("Lifecycle event emit failed (non-critical)", exc_info=True)
 
-            # Auto-extract: if task says "write to <path>", save result there
-            try:
-                import re as _re_extract
-                desc = task.description or ""
-                path_match = _re_extract.search(
-                    r"[Ww]rite [\w\s]*?(?:to |report to |results to |output to |findings to )(~/[^\s,\"]+\.md)",
-                    desc,
-                )
-                if path_match and result and len(result) > 200:
-                    from pathlib import Path as _P
-                    target = _P(path_match.group(1)).expanduser()
-                    target.parent.mkdir(parents=True, exist_ok=True)
-                    target.write_text(result, encoding="utf-8")
-                    logger.info(
-                        "Auto-extracted %d chars to %s",
-                        len(result), target,
+            # Legacy compatibility only: free-text task descriptions must not
+            # choose infrastructure write paths unless a structured caller opts in.
+            task_metadata = getattr(task, "metadata", {}) or {}
+            if task_metadata.get("allow_free_text_result_path") is True:
+                try:
+                    desc = task.description or ""
+                    path_match = re.search(
+                        r"[Ww]rite [\w\s]*?(?:to |report to |results to |output to |findings to )(~/[^\s,\"]+\.md)",
+                        desc,
                     )
-            except Exception:
-                logger.debug("Auto-extract failed", exc_info=True)
+                    if path_match and result and len(result) > 200:
+                        target = Path(path_match.group(1)).expanduser()
+                        target.parent.mkdir(parents=True, exist_ok=True)
+                        target.write_text(result, encoding="utf-8")
+                        logger.info("Auto-extracted %d chars to %s", len(result), target)
+                except Exception:
+                    logger.debug("Auto-extract failed", exc_info=True)
 
             # Persist result to shared notes and stigmergy
             runner_cfg = getattr(runner, "_config", None)
@@ -2567,12 +2577,17 @@ class Orchestrator:
         trace_id = (
             str(task.metadata.get("trace_id")) if isinstance(task.metadata, dict) else ""
         ) or f"task:{task.id}"
+        correlation_id = (
+            str(task.metadata.get("correlation_id")) if isinstance(task.metadata, dict) else ""
+        ) or trace_id
         result_hash = hashlib.sha256((result or "").encode("utf-8")).hexdigest()
         timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
         # Truncate very long results for notes (full result is in task board)
         summary = result[:2000] if len(result) > 2000 else result
         provenance_record = {
             "trace_id": trace_id,
+            "correlation_id": correlation_id,
+            "run_id": run_id,
             "task_id": task.id,
             "task_title": task.title,
             "agent": agent_name,
@@ -2606,6 +2621,8 @@ class Orchestrator:
                 notes_file=str(notes_file),
                 provenance_file=str(provenance_path),
                 trace_id=trace_id,
+                correlation_id=correlation_id,
+                run_id=run_id,
                 result_chars=len(result or ""),
             )
         except Exception as exc:
@@ -2626,6 +2643,9 @@ class Orchestrator:
             shared_artifact.write_text(
                 f"# {task.title}\n\n"
                 f"**Task ID:** {task.id}\n"
+                f"**Run ID:** {run_id}\n"
+                f"**Trace ID:** {trace_id}\n"
+                f"**Correlation ID:** {correlation_id}\n"
                 f"**Agent:** {agent_name}\n"
                 f"**Completed:** {datetime.now(timezone.utc).isoformat()}\n\n"
                 f"---\n\n"
@@ -2650,6 +2670,8 @@ class Orchestrator:
                     "model": model_name,
                     "provider": provider_name,
                     "trace_id": trace_id,
+                    "correlation_id": correlation_id,
+                    "run_id": run_id,
                     "notes_file": str(notes_file),
                     "result_chars": len(result or ""),
                 },

--- a/dharma_swarm/runtime_lifecycle.py
+++ b/dharma_swarm/runtime_lifecycle.py
@@ -8,8 +8,14 @@ from pathlib import Path
 from typing import Any
 
 from dharma_swarm.models import Task, TaskDispatch, _new_id
-from dharma_swarm.runtime_state import ArtifactRecord, DelegationRun, TaskClaim
+from dharma_swarm.runtime_state import (
+    ArtifactRecord,
+    DelegationRun,
+    RuntimeReceipt,
+    TaskClaim,
+)
 from dharma_swarm.session_ledger import SessionLedger
+from dharma_swarm.spine.identity import ExecutionIdentity, MissingExecutionIdentity
 
 logger = logging.getLogger(__name__)
 
@@ -67,6 +73,101 @@ class RuntimeLifecycle:
         td.metadata["runtime_run_id"] = run_id
         return run_id
 
+    def ensure_execution_identity(
+        self,
+        td: TaskDispatch,
+        *,
+        task: Task | None = None,
+        require: bool = False,
+    ) -> ExecutionIdentity:
+        task_meta = self._task_meta(task)
+        nested = task_meta.get("execution_identity")
+        merged: dict[str, Any] = {}
+        if isinstance(nested, dict):
+            merged.update(nested)
+        merged.update(task_meta)
+        dispatch_nested = td.metadata.get("execution_identity")
+        if isinstance(dispatch_nested, dict):
+            merged.update(dispatch_nested)
+        merged.update(td.metadata)
+
+        run_id = str(
+            merged.get("run_id")
+            or merged.get("runtime_run_id")
+            or self.ensure_runtime_run_id(td)
+        ).strip()
+        trace_id = str(merged.get("trace_id") or "").strip()
+        if not trace_id:
+            try:
+                from dharma_swarm.correlation_context import get_correlation
+
+                trace_id = get_correlation().trace_id
+            except Exception:
+                trace_id = ""
+        if require and not trace_id:
+            raise MissingExecutionIdentity("ExecutionIdentity requires trace_id on this path")
+        correlation_id = str(merged.get("correlation_id") or trace_id).strip()
+        if require and not correlation_id:
+            raise MissingExecutionIdentity("ExecutionIdentity requires correlation_id on this path")
+        claim_id = str(merged.get("claim_id") or "").strip()
+        if require and not claim_id:
+            raise MissingExecutionIdentity("ExecutionIdentity requires claim_id on this path")
+
+        identity = ExecutionIdentity.new(
+            task_id=td.task_id,
+            agent_id=td.agent_id,
+            session_id=self._ledger.session_id,
+            trace_id=trace_id,
+            correlation_id=correlation_id,
+            causation_id=str(merged.get("causation_id") or ""),
+            parent_run_id=str(merged.get("parent_run_id") or ""),
+            run_id=run_id,
+            claim_id=claim_id,
+            idempotency_key=str(merged.get("idempotency_key") or ""),
+            external_a2a_task_id=str(merged.get("external_a2a_task_id") or ""),
+            message_id=str(merged.get("message_id") or ""),
+            event_id=str(merged.get("event_id") or ""),
+            artifact_id=str(merged.get("artifact_id") or ""),
+            proposal_id=str(merged.get("proposal_id") or ""),
+            metadata={
+                "source": "runtime_lifecycle.ensure_execution_identity",
+                **dict(merged.get("metadata") or {}),
+            },
+        )
+        td.metadata.update(
+            {
+                "execution_identity": identity.to_dict(),
+                "trace_id": identity.trace_id,
+                "correlation_id": identity.correlation_id,
+                "runtime_run_id": identity.run_id,
+                "run_id": identity.run_id,
+                "claim_id": identity.claim_id,
+                "agent_id": identity.agent_id,
+                "session_id": identity.session_id,
+                "idempotency_key": identity.idempotency_key,
+            }
+        )
+        if task is not None:
+            task.metadata = {
+                **self._task_meta(task),
+                "execution_identity": identity.to_dict(),
+                "trace_id": identity.trace_id,
+                "correlation_id": identity.correlation_id,
+                "runtime_run_id": identity.run_id,
+                "run_id": identity.run_id,
+                "claim_id": identity.claim_id,
+                "idempotency_key": identity.idempotency_key,
+            }
+        store = self._runtime_state_store()
+        if store is not None:
+            store.record_execution_identity_sync(
+                identity,
+                source="runtime_lifecycle",
+            )
+        elif require:
+            raise MissingExecutionIdentity("RuntimeStateStore is required on this path")
+        return identity.require_for_dispatch()
+
     def runtime_metadata(
         self,
         td: TaskDispatch,
@@ -110,11 +211,19 @@ class RuntimeLifecycle:
         status: str,
         failure_code: str = "",
         error: str = "",
+        require_identity: bool = False,
     ) -> None:
         store = self._runtime_state_store()
         claim_id = str(td.metadata.get("claim_id", "") or "").strip()
         if store is None or not claim_id:
+            if require_identity:
+                raise MissingExecutionIdentity("RuntimeStateStore and claim_id are required")
             return
+        identity = self.ensure_execution_identity(
+            td,
+            task=task,
+            require=require_identity,
+        )
         task_meta = self._task_meta(task)
         active_claim = task_meta.get("active_claim")
         if not isinstance(active_claim, dict):
@@ -141,11 +250,36 @@ class RuntimeLifecycle:
                 status=status,
                 failure_code=failure_code,
                 error=error,
-            ),
+            )
+            | identity.to_metadata()
+            | {
+                "trace_id": identity.trace_id,
+                "correlation_id": identity.correlation_id,
+                "run_id": identity.run_id,
+                "idempotency_key": identity.idempotency_key,
+            },
         )
         try:
             await store.record_task_claim(claim)
+            await store.record_runtime_receipt(
+                RuntimeReceipt(
+                    receipt_id=f"rr_{identity.run_id}_{status}_claim",
+                    receipt_type="task_claim",
+                    status=status,
+                    run_id=identity.run_id,
+                    task_id=identity.task_id,
+                    trace_id=identity.trace_id,
+                    correlation_id=identity.correlation_id,
+                    causation_id=identity.causation_id,
+                    parent_run_id=identity.parent_run_id,
+                    agent_id=identity.agent_id,
+                    idempotency_key=identity.idempotency_key,
+                    payload={"claim_id": identity.claim_id, "failure_code": failure_code},
+                )
+            )
         except Exception:
+            if require_identity:
+                raise
             logger.debug("Runtime task claim recording failed", exc_info=True)
 
     async def record_delegation_run(
@@ -157,11 +291,19 @@ class RuntimeLifecycle:
         failure_code: str = "",
         error: str = "",
         result: str | None = None,
+        require_identity: bool = False,
     ) -> None:
         store = self._runtime_state_store()
         if store is None:
+            if require_identity:
+                raise MissingExecutionIdentity("RuntimeStateStore is required")
             return
-        run_id = self.ensure_runtime_run_id(td)
+        identity = self.ensure_execution_identity(
+            td,
+            task=task,
+            require=require_identity,
+        )
+        run_id = identity.run_id
         started_raw = td.metadata.get("runtime_run_started_at")
         started_at = self._utc_datetime_from(started_raw)
         if not started_raw:
@@ -191,11 +333,62 @@ class RuntimeLifecycle:
                 failure_code=failure_code,
                 error=error,
                 result=result,
-            ),
+            )
+            | identity.to_metadata()
+            | {
+                "trace_id": identity.trace_id,
+                "correlation_id": identity.correlation_id,
+                "idempotency_key": identity.idempotency_key,
+            },
         )
         try:
             await store.record_delegation_run(run)
+            await store.record_runtime_receipt(
+                RuntimeReceipt(
+                    receipt_id=f"rr_{identity.run_id}_{status}_run",
+                    receipt_type="delegation_run",
+                    status=status,
+                    run_id=identity.run_id,
+                    task_id=identity.task_id,
+                    trace_id=identity.trace_id,
+                    correlation_id=identity.correlation_id,
+                    causation_id=identity.causation_id,
+                    parent_run_id=identity.parent_run_id,
+                    agent_id=identity.agent_id,
+                    idempotency_key=identity.idempotency_key,
+                    payload={"failure_code": failure_code, "result_chars": len(result or "")},
+                )
+            )
+            if identity.parent_run_id and status in {"queued", "claimed", "running"}:
+                await store.record_receipt_for_identity(
+                    identity,
+                    receipt_id=f"rr_{identity.parent_run_id}_{identity.run_id}_child_spawned",
+                    receipt_type="child_spawned",
+                    status=status,
+                    side_effect_key=f"child:{identity.parent_run_id}:{identity.run_id}",
+                    payload={
+                        "child_run_id": identity.run_id,
+                        "parent_run_id": identity.parent_run_id,
+                        "assigned_to": identity.agent_id,
+                    },
+                )
+            if identity.parent_run_id and status in {"completed", "failed"}:
+                await store.record_receipt_for_identity(
+                    identity,
+                    receipt_id=f"rr_{identity.parent_run_id}_{identity.run_id}_child_completed_{status}",
+                    receipt_type="child_completed",
+                    status=status,
+                    side_effect_key=f"child:{identity.parent_run_id}:{identity.run_id}",
+                    payload={
+                        "child_run_id": identity.run_id,
+                        "parent_run_id": identity.parent_run_id,
+                        "failure_code": failure_code,
+                        "result_chars": len(result or ""),
+                    },
+                )
         except Exception:
+            if require_identity:
+                raise
             logger.debug("Runtime delegation run recording failed", exc_info=True)
 
     async def record_artifact(
@@ -209,16 +402,39 @@ class RuntimeLifecycle:
         manifest_path: Path | None = None,
         run_id: str = "",
         metadata: dict[str, Any] | None = None,
+        require_identity: bool = False,
     ) -> None:
         store = self._runtime_state_store()
         if store is None:
+            if require_identity:
+                raise MissingExecutionIdentity("RuntimeStateStore is required")
             return
+        artifact_metadata = {
+            **self._task_meta(task),
+            **dict(metadata or {}),
+        }
+        identity = ExecutionIdentity.from_metadata(
+            artifact_metadata,
+            task_id=task.id,
+            session_id=self._ledger.session_id,
+            require=require_identity,
+        )
+        if identity is None:
+            if require_identity:
+                raise MissingExecutionIdentity("ExecutionIdentity is required for artifact")
+            trace_id = str(artifact_metadata.get("trace_id") or "")
+            correlation_id = str(artifact_metadata.get("correlation_id") or trace_id)
+        else:
+            trace_id = identity.trace_id
+            correlation_id = identity.correlation_id
+            run_id = run_id or identity.run_id
         artifact = ArtifactRecord(
             artifact_id=artifact_id,
             artifact_kind=artifact_kind,
             session_id=self._ledger.session_id,
             task_id=task.id,
             run_id=run_id,
+            trace_id=trace_id,
             manifest_path=str(manifest_path or ""),
             payload_path=str(payload_path),
             checksum=checksum,
@@ -226,10 +442,49 @@ class RuntimeLifecycle:
             metadata={
                 "source": "orchestrator._persist_result",
                 "task_title": task.title,
-                **(metadata or {}),
+                "trace_id": trace_id,
+                "correlation_id": correlation_id,
+                **dict(metadata or {}),
             },
         )
         try:
             await store.record_artifact(artifact)
+            if identity is not None:
+                await store.record_runtime_receipt(
+                    RuntimeReceipt(
+                        receipt_id=f"rr_{identity.run_id}_{artifact_id}_artifact",
+                        receipt_type="artifact",
+                        status="completed",
+                        run_id=identity.run_id,
+                        task_id=identity.task_id,
+                        trace_id=identity.trace_id,
+                        correlation_id=identity.correlation_id,
+                        causation_id=identity.causation_id,
+                        parent_run_id=identity.parent_run_id,
+                        agent_id=identity.agent_id,
+                        idempotency_key=identity.idempotency_key,
+                        side_effect_key=f"artifact:{artifact_id}",
+                        payload={
+                            "artifact_id": artifact_id,
+                            "artifact_kind": artifact_kind,
+                            "payload_path": str(payload_path),
+                        },
+                    )
+                )
+                await store.record_receipt_for_identity(
+                    identity.with_updates(artifact_id=artifact_id),
+                    receipt_id=f"rr_{identity.run_id}_{artifact_id}_artifact_written",
+                    receipt_type="artifact_written",
+                    status="completed",
+                    side_effect_key=f"artifact:{artifact_id}",
+                    payload={
+                        "artifact_id": artifact_id,
+                        "artifact_kind": artifact_kind,
+                        "payload_path": str(payload_path),
+                        "manifest_path": str(manifest_path or ""),
+                    },
+                )
         except Exception:
+            if require_identity:
+                raise
             logger.debug("Runtime artifact recording failed", exc_info=True)

--- a/dharma_swarm/runtime_state.py
+++ b/dharma_swarm/runtime_state.py
@@ -25,6 +25,7 @@ from dharma_swarm.engine.event_memory import (
     ensure_memory_plane_schema_async,
     ensure_memory_plane_schema_sync,
 )
+from dharma_swarm.spine.identity import ExecutionIdentity
 
 DEFAULT_RUNTIME_DB = Path.home() / ".dharma" / "state" / "runtime.db"
 
@@ -96,6 +97,7 @@ CREATE TABLE IF NOT EXISTS artifact_records (
     session_id TEXT NOT NULL DEFAULT '',
     task_id TEXT NOT NULL DEFAULT '',
     run_id TEXT NOT NULL DEFAULT '',
+    trace_id TEXT NOT NULL DEFAULT '',
     artifact_kind TEXT NOT NULL,
     manifest_path TEXT NOT NULL DEFAULT '',
     payload_path TEXT NOT NULL DEFAULT '',
@@ -205,6 +207,63 @@ CREATE VIRTUAL TABLE IF NOT EXISTS session_events_fts USING fts5(
     tokenize='porter unicode61'
 )"""
 
+_EXECUTION_IDENTITIES_DDL = """
+CREATE TABLE IF NOT EXISTS execution_identities (
+    run_id TEXT PRIMARY KEY,
+    trace_id TEXT NOT NULL,
+    correlation_id TEXT NOT NULL,
+    task_id TEXT NOT NULL,
+    claim_id TEXT NOT NULL DEFAULT '',
+    idempotency_key TEXT NOT NULL DEFAULT '',
+    causation_id TEXT NOT NULL DEFAULT '',
+    parent_run_id TEXT NOT NULL DEFAULT '',
+    agent_id TEXT NOT NULL DEFAULT '',
+    session_id TEXT NOT NULL DEFAULT '',
+    external_a2a_task_id TEXT NOT NULL DEFAULT '',
+    message_id TEXT NOT NULL DEFAULT '',
+    event_id TEXT NOT NULL DEFAULT '',
+    artifact_id TEXT NOT NULL DEFAULT '',
+    proposal_id TEXT NOT NULL DEFAULT '',
+    source TEXT NOT NULL DEFAULT '',
+    metadata_json TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+)"""
+
+_RUNTIME_RECEIPTS_DDL = """
+CREATE TABLE IF NOT EXISTS runtime_receipts (
+    receipt_id TEXT PRIMARY KEY,
+    receipt_type TEXT NOT NULL,
+    run_id TEXT NOT NULL DEFAULT '',
+    task_id TEXT NOT NULL DEFAULT '',
+    trace_id TEXT NOT NULL DEFAULT '',
+    correlation_id TEXT NOT NULL DEFAULT '',
+    causation_id TEXT NOT NULL DEFAULT '',
+    parent_run_id TEXT NOT NULL DEFAULT '',
+    agent_id TEXT NOT NULL DEFAULT '',
+    idempotency_key TEXT NOT NULL DEFAULT '',
+    side_effect_key TEXT NOT NULL DEFAULT '',
+    status TEXT NOT NULL,
+    payload_json TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL
+)"""
+
+_IDEMPOTENCY_RECORDS_DDL = """
+CREATE TABLE IF NOT EXISTS idempotency_records (
+    idempotency_key TEXT NOT NULL,
+    side_effect_key TEXT NOT NULL,
+    run_id TEXT NOT NULL DEFAULT '',
+    task_id TEXT NOT NULL DEFAULT '',
+    trace_id TEXT NOT NULL DEFAULT '',
+    correlation_id TEXT NOT NULL DEFAULT '',
+    status TEXT NOT NULL,
+    result_receipt_id TEXT NOT NULL DEFAULT '',
+    metadata_json TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (idempotency_key, side_effect_key)
+)"""
+
 _INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_sessions_status_updated ON sessions(status, updated_at)",
     "CREATE INDEX IF NOT EXISTS idx_claims_task_status ON task_claims(task_id, status)",
@@ -214,6 +273,7 @@ _INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_leases_zone_released ON workspace_leases(zone_path, released_at)",
     "CREATE INDEX IF NOT EXISTS idx_artifacts_task_created ON artifact_records(task_id, created_at)",
     "CREATE INDEX IF NOT EXISTS idx_artifacts_run_created ON artifact_records(run_id, created_at)",
+    "CREATE INDEX IF NOT EXISTS idx_artifacts_trace_created ON artifact_records(trace_id, created_at)",
     "CREATE INDEX IF NOT EXISTS idx_memory_truth_updated ON memory_facts(truth_state, updated_at)",
     "CREATE INDEX IF NOT EXISTS idx_memory_task_truth ON memory_facts(task_id, truth_state)",
     "CREATE INDEX IF NOT EXISTS idx_context_session_created ON context_bundles(session_id, created_at)",
@@ -221,6 +281,15 @@ _INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_operator_actions_session_created ON operator_actions(session_id, created_at)",
     "CREATE INDEX IF NOT EXISTS idx_session_events_session_created ON session_events(session_id, created_at)",
     "CREATE INDEX IF NOT EXISTS idx_session_events_kind_created ON session_events(ledger_kind, created_at)",
+    "CREATE INDEX IF NOT EXISTS idx_exec_identity_trace ON execution_identities(trace_id)",
+    "CREATE INDEX IF NOT EXISTS idx_exec_identity_correlation ON execution_identities(correlation_id)",
+    "CREATE INDEX IF NOT EXISTS idx_exec_identity_task ON execution_identities(task_id)",
+    "CREATE INDEX IF NOT EXISTS idx_exec_identity_external_a2a ON execution_identities(external_a2a_task_id)",
+    "CREATE INDEX IF NOT EXISTS idx_exec_identity_parent ON execution_identities(parent_run_id)",
+    "CREATE INDEX IF NOT EXISTS idx_runtime_receipts_run_created ON runtime_receipts(run_id, created_at)",
+    "CREATE INDEX IF NOT EXISTS idx_runtime_receipts_trace_created ON runtime_receipts(trace_id, created_at)",
+    "CREATE INDEX IF NOT EXISTS idx_runtime_receipts_idempotency ON runtime_receipts(idempotency_key)",
+    "CREATE INDEX IF NOT EXISTS idx_idempotency_run ON idempotency_records(run_id)",
 ]
 
 
@@ -234,6 +303,41 @@ def _utc_now_iso() -> str:
 
 def _new_id(prefix: str) -> str:
     return f"{prefix}_{uuid4().hex[:16]}"
+
+
+RUNTIME_RECEIPT_TYPES = frozenset(
+    {
+        "task_claim",
+        "delegation_run",
+        "side_effect_intent",
+        "side_effect_complete",
+        "artifact",
+        "artifact_written",
+        "message_consumed",
+        "idempotency_consumed",
+        "ontology_action_requested",
+        "ontology_action_applied",
+        "child_spawned",
+        "child_completed",
+        "self_mod_proposal",
+        "self_mod_gate",
+        "self_mod_apply",
+        "self_mod_verify",
+        "self_mod_promote",
+        "self_mod_revert",
+    }
+)
+
+SELF_MOD_RECEIPT_TYPES = frozenset(
+    {
+        "self_mod_proposal",
+        "self_mod_gate",
+        "self_mod_apply",
+        "self_mod_verify",
+        "self_mod_promote",
+        "self_mod_revert",
+    }
+)
 
 
 def _json_dump(value: Any) -> str:
@@ -290,8 +394,21 @@ def ensure_runtime_state_schema_sync(
         _OPERATOR_ACTIONS_DDL,
         _SESSION_EVENTS_DDL,
         _SESSION_EVENTS_FTS_DDL,
+        _EXECUTION_IDENTITIES_DDL,
+        _RUNTIME_RECEIPTS_DDL,
+        _IDEMPOTENCY_RECORDS_DDL,
     ):
         db.execute(ddl)
+    for tbl, column_sql in (
+        ("task_claims", "trace_id TEXT NOT NULL DEFAULT ''"),
+        ("delegation_runs", "trace_id TEXT NOT NULL DEFAULT ''"),
+        ("delegation_runs", "receipt_json TEXT"),
+        ("artifact_records", "trace_id TEXT NOT NULL DEFAULT ''"),
+    ):
+        try:
+            db.execute(f"ALTER TABLE {tbl} ADD COLUMN {column_sql}")
+        except sqlite3.Error:
+            pass
     for idx in _INDEXES:
         db.execute(idx)
     if include_memory_plane:
@@ -319,18 +436,24 @@ async def ensure_runtime_state_schema_async(
         _OPERATOR_ACTIONS_DDL,
         _SESSION_EVENTS_DDL,
         _SESSION_EVENTS_FTS_DDL,
+        _EXECUTION_IDENTITIES_DDL,
+        _RUNTIME_RECEIPTS_DDL,
+        _IDEMPOTENCY_RECORDS_DDL,
     ):
         await db.execute(ddl)
-    for idx in _INDEXES:
-        await db.execute(idx)
-    # Migrate: add trace_id column to existing task_claims/delegation_runs
-    for tbl in ("task_claims", "delegation_runs"):
+    # Migrate old runtime DBs without changing existing rows destructively.
+    for tbl, column_sql in (
+        ("task_claims", "trace_id TEXT NOT NULL DEFAULT ''"),
+        ("delegation_runs", "trace_id TEXT NOT NULL DEFAULT ''"),
+        ("delegation_runs", "receipt_json TEXT"),
+        ("artifact_records", "trace_id TEXT NOT NULL DEFAULT ''"),
+    ):
         try:
-            await db.execute(
-                f"ALTER TABLE {tbl} ADD COLUMN trace_id TEXT NOT NULL DEFAULT ''"
-            )
+            await db.execute(f"ALTER TABLE {tbl} ADD COLUMN {column_sql}")
         except Exception:
             pass  # column already exists
+    for idx in _INDEXES:
+        await db.execute(idx)
     if include_memory_plane:
         await ensure_memory_plane_schema_async(db)
     await db.commit()
@@ -402,6 +525,7 @@ class ArtifactRecord:
     session_id: str = ""
     task_id: str = ""
     run_id: str = ""
+    trace_id: str = ""
     manifest_path: str = ""
     payload_path: str = ""
     checksum: str = ""
@@ -485,6 +609,39 @@ class SessionEventRecord:
     created_at: datetime = field(default_factory=_utc_now)
 
 
+@dataclass(frozen=True)
+class RuntimeReceipt:
+    receipt_id: str
+    receipt_type: str
+    status: str
+    run_id: str = ""
+    task_id: str = ""
+    trace_id: str = ""
+    correlation_id: str = ""
+    causation_id: str = ""
+    parent_run_id: str = ""
+    agent_id: str = ""
+    idempotency_key: str = ""
+    side_effect_key: str = ""
+    payload: dict[str, Any] = field(default_factory=dict)
+    created_at: datetime = field(default_factory=_utc_now)
+
+
+@dataclass(frozen=True)
+class IdempotencyRecord:
+    idempotency_key: str
+    side_effect_key: str
+    status: str
+    run_id: str = ""
+    task_id: str = ""
+    trace_id: str = ""
+    correlation_id: str = ""
+    result_receipt_id: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+    created_at: datetime = field(default_factory=_utc_now)
+    updated_at: datetime = field(default_factory=_utc_now)
+
+
 def _row_to_session(row: sqlite3.Row | aiosqlite.Row) -> SessionState:
     return SessionState(
         session_id=str(row["session_id"]),
@@ -555,6 +712,7 @@ def _row_to_artifact(row: sqlite3.Row | aiosqlite.Row) -> ArtifactRecord:
         session_id=str(row["session_id"] or ""),
         task_id=str(row["task_id"] or ""),
         run_id=str(row["run_id"] or ""),
+        trace_id=str(row["trace_id"] or "") if "trace_id" in row.keys() else "",
         manifest_path=str(row["manifest_path"] or ""),
         payload_path=str(row["payload_path"] or ""),
         checksum=str(row["checksum"] or ""),
@@ -629,6 +787,74 @@ def _row_to_session_event(row: sqlite3.Row | aiosqlite.Row) -> SessionEventRecor
         payload=_json_load(row["payload_json"], {}),
         created_at=_parse_dt(row["created_at"]) or _utc_now(),
     )
+
+
+def _row_to_execution_identity(row: sqlite3.Row | aiosqlite.Row) -> ExecutionIdentity:
+    return ExecutionIdentity(
+        trace_id=str(row["trace_id"]),
+        correlation_id=str(row["correlation_id"]),
+        task_id=str(row["task_id"]),
+        run_id=str(row["run_id"]),
+        claim_id=str(row["claim_id"] or ""),
+        idempotency_key=str(row["idempotency_key"] or ""),
+        causation_id=str(row["causation_id"] or ""),
+        parent_run_id=str(row["parent_run_id"] or ""),
+        agent_id=str(row["agent_id"] or ""),
+        session_id=str(row["session_id"] or ""),
+        external_a2a_task_id=str(row["external_a2a_task_id"] or ""),
+        message_id=str(row["message_id"] or ""),
+        event_id=str(row["event_id"] or ""),
+        artifact_id=str(row["artifact_id"] or ""),
+        proposal_id=str(row["proposal_id"] or ""),
+        metadata=_json_load(row["metadata_json"], {}),
+    )
+
+
+def _row_to_runtime_receipt(row: sqlite3.Row | aiosqlite.Row) -> RuntimeReceipt:
+    return RuntimeReceipt(
+        receipt_id=str(row["receipt_id"]),
+        receipt_type=str(row["receipt_type"]),
+        status=str(row["status"]),
+        run_id=str(row["run_id"] or ""),
+        task_id=str(row["task_id"] or ""),
+        trace_id=str(row["trace_id"] or ""),
+        correlation_id=str(row["correlation_id"] or ""),
+        causation_id=str(row["causation_id"] or ""),
+        parent_run_id=str(row["parent_run_id"] or ""),
+        agent_id=str(row["agent_id"] or ""),
+        idempotency_key=str(row["idempotency_key"] or ""),
+        side_effect_key=str(row["side_effect_key"] or ""),
+        payload=_json_load(row["payload_json"], {}),
+        created_at=_parse_dt(row["created_at"]) or _utc_now(),
+    )
+
+
+def _row_to_idempotency_record(row: sqlite3.Row | aiosqlite.Row) -> IdempotencyRecord:
+    return IdempotencyRecord(
+        idempotency_key=str(row["idempotency_key"]),
+        side_effect_key=str(row["side_effect_key"]),
+        status=str(row["status"]),
+        run_id=str(row["run_id"] or ""),
+        task_id=str(row["task_id"] or ""),
+        trace_id=str(row["trace_id"] or ""),
+        correlation_id=str(row["correlation_id"] or ""),
+        result_receipt_id=str(row["result_receipt_id"] or ""),
+        metadata=_json_load(row["metadata_json"], {}),
+        created_at=_parse_dt(row["created_at"]) or _utc_now(),
+        updated_at=_parse_dt(row["updated_at"]) or _utc_now(),
+    )
+
+
+def _identity_from_metadata(metadata: dict[str, Any] | None) -> ExecutionIdentity | None:
+    return ExecutionIdentity.from_metadata(metadata, require=False)
+
+
+def _trace_from_metadata(metadata: dict[str, Any] | None) -> str:
+    identity = _identity_from_metadata(metadata)
+    if identity is not None and identity.trace_id:
+        return identity.trace_id
+    meta = dict(metadata or {})
+    return str(meta.get("trace_id", "") or "")
 
 
 def _flatten_search_text(value: Any) -> str:
@@ -1116,7 +1342,7 @@ class RuntimeStateStore:
     async def record_task_claim(self, claim: TaskClaim) -> TaskClaim:
         await self.init_db()
         corr = get_correlation()
-        trace_id = corr.trace_id
+        trace_id = _trace_from_metadata(claim.metadata) or corr.trace_id
         if corr.cell_id:
             claim.metadata.setdefault("cell_id", corr.cell_id)
         async with aiosqlite.connect(self.db_path) as db:
@@ -1269,7 +1495,7 @@ class RuntimeStateStore:
     async def record_delegation_run(self, run: DelegationRun) -> DelegationRun:
         await self.init_db()
         corr = get_correlation()
-        trace_id = corr.trace_id
+        trace_id = _trace_from_metadata(run.metadata) or corr.trace_id
         if corr.cell_id:
             run.metadata.setdefault("cell_id", corr.cell_id)
         async with aiosqlite.connect(self.db_path) as db:
@@ -1639,13 +1865,14 @@ class RuntimeStateStore:
         async with aiosqlite.connect(self.db_path) as db:
             await db.execute(
                 "INSERT INTO artifact_records (artifact_id, session_id, task_id, run_id,"
-                " artifact_kind, manifest_path, payload_path, checksum,"
+                " trace_id, artifact_kind, manifest_path, payload_path, checksum,"
                 " parent_artifact_id, promotion_state, created_at, metadata_json)"
-                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
                 " ON CONFLICT(artifact_id) DO UPDATE SET"
                 " session_id = excluded.session_id,"
                 " task_id = excluded.task_id,"
                 " run_id = excluded.run_id,"
+                " trace_id = excluded.trace_id,"
                 " artifact_kind = excluded.artifact_kind,"
                 " manifest_path = excluded.manifest_path,"
                 " payload_path = excluded.payload_path,"
@@ -1659,6 +1886,7 @@ class RuntimeStateStore:
                     artifact.session_id,
                     artifact.task_id,
                     artifact.run_id,
+                    artifact.trace_id,
                     artifact.artifact_kind,
                     artifact.manifest_path,
                     artifact.payload_path,
@@ -1680,8 +1908,8 @@ class RuntimeStateStore:
             db.row_factory = aiosqlite.Row
             row = await (
                 await db.execute(
-                    "SELECT artifact_id, session_id, task_id, run_id, artifact_kind,"
-                    " manifest_path, payload_path, checksum, parent_artifact_id,"
+                    "SELECT artifact_id, session_id, task_id, run_id, trace_id,"
+                    " artifact_kind, manifest_path, payload_path, checksum, parent_artifact_id,"
                     " promotion_state, created_at, metadata_json"
                     " FROM artifact_records WHERE artifact_id = ?",
                     (artifact_id,),
@@ -1695,12 +1923,13 @@ class RuntimeStateStore:
         session_id: str | None = None,
         task_id: str | None = None,
         run_id: str | None = None,
+        trace_id: str | None = None,
         promotion_state: str | None = None,
         limit: int = 20,
     ) -> list[ArtifactRecord]:
         await self.init_db()
         query = (
-            "SELECT artifact_id, session_id, task_id, run_id, artifact_kind,"
+            "SELECT artifact_id, session_id, task_id, run_id, trace_id, artifact_kind,"
             " manifest_path, payload_path, checksum, parent_artifact_id,"
             " promotion_state, created_at, metadata_json"
             " FROM artifact_records WHERE 1=1"
@@ -1715,6 +1944,9 @@ class RuntimeStateStore:
         if run_id is not None:
             query += " AND run_id = ?"
             params.append(run_id)
+        if trace_id is not None:
+            query += " AND trace_id = ?"
+            params.append(trace_id)
         if promotion_state is not None:
             query += " AND promotion_state = ?"
             params.append(promotion_state)
@@ -1724,6 +1956,815 @@ class RuntimeStateStore:
             db.row_factory = aiosqlite.Row
             rows = await (await db.execute(query, params)).fetchall()
         return [_row_to_artifact(row) for row in rows]
+
+    @staticmethod
+    def _identity_params(
+        identity: ExecutionIdentity,
+        *,
+        source: str,
+        now: datetime,
+        metadata: dict[str, Any] | None = None,
+    ) -> tuple[Any, ...]:
+        merged_metadata = {
+            **dict(identity.metadata or {}),
+            **dict(metadata or {}),
+        }
+        return (
+            identity.run_id,
+            identity.trace_id,
+            identity.correlation_id,
+            identity.task_id,
+            identity.claim_id,
+            identity.idempotency_key,
+            identity.causation_id,
+            identity.parent_run_id,
+            identity.agent_id,
+            identity.session_id,
+            identity.external_a2a_task_id,
+            identity.message_id,
+            identity.event_id,
+            identity.artifact_id,
+            identity.proposal_id,
+            source,
+            _json_dump(merged_metadata),
+            now.isoformat(),
+            now.isoformat(),
+        )
+
+    @staticmethod
+    def _identity_upsert_sql() -> str:
+        return (
+            "INSERT INTO execution_identities (run_id, trace_id, correlation_id,"
+            " task_id, claim_id, idempotency_key, causation_id, parent_run_id,"
+            " agent_id, session_id, external_a2a_task_id, message_id, event_id,"
+            " artifact_id, proposal_id, source, metadata_json, created_at, updated_at)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+            " ON CONFLICT(run_id) DO UPDATE SET"
+            " trace_id = excluded.trace_id,"
+            " correlation_id = excluded.correlation_id,"
+            " task_id = excluded.task_id,"
+            " claim_id = excluded.claim_id,"
+            " idempotency_key = excluded.idempotency_key,"
+            " causation_id = excluded.causation_id,"
+            " parent_run_id = excluded.parent_run_id,"
+            " agent_id = excluded.agent_id,"
+            " session_id = excluded.session_id,"
+            " external_a2a_task_id = CASE"
+            "   WHEN excluded.external_a2a_task_id != '' THEN excluded.external_a2a_task_id"
+            "   ELSE execution_identities.external_a2a_task_id"
+            " END,"
+            " message_id = CASE"
+            "   WHEN excluded.message_id != '' THEN excluded.message_id"
+            "   ELSE execution_identities.message_id"
+            " END,"
+            " event_id = CASE"
+            "   WHEN excluded.event_id != '' THEN excluded.event_id"
+            "   ELSE execution_identities.event_id"
+            " END,"
+            " artifact_id = CASE"
+            "   WHEN excluded.artifact_id != '' THEN excluded.artifact_id"
+            "   ELSE execution_identities.artifact_id"
+            " END,"
+            " proposal_id = CASE"
+            "   WHEN excluded.proposal_id != '' THEN excluded.proposal_id"
+            "   ELSE execution_identities.proposal_id"
+            " END,"
+            " source = excluded.source,"
+            " metadata_json = excluded.metadata_json,"
+            " updated_at = excluded.updated_at"
+        )
+
+    async def record_execution_identity(
+        self,
+        identity: ExecutionIdentity,
+        *,
+        source: str = "",
+        metadata: dict[str, Any] | None = None,
+    ) -> ExecutionIdentity:
+        identity.require_for_dispatch()
+        await self.init_db()
+        now = _utc_now()
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute(
+                self._identity_upsert_sql(),
+                self._identity_params(identity, source=source, now=now, metadata=metadata),
+            )
+            await db.commit()
+        loaded = await self.get_execution_identity(identity.run_id)
+        assert loaded is not None
+        return loaded
+
+    def record_execution_identity_sync(
+        self,
+        identity: ExecutionIdentity,
+        *,
+        source: str = "",
+        metadata: dict[str, Any] | None = None,
+    ) -> ExecutionIdentity:
+        identity.require_for_dispatch()
+        self.init_db_sync()
+        now = _utc_now()
+        with sqlite3.connect(self.db_path) as db:
+            _apply_connection_pragmas_sync(db)
+            db.execute(
+                self._identity_upsert_sql(),
+                self._identity_params(identity, source=source, now=now, metadata=metadata),
+            )
+            db.commit()
+        return self.get_execution_identity_sync(identity.run_id) or identity
+
+    async def get_execution_identity(self, run_id: str) -> ExecutionIdentity | None:
+        await self.init_db()
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            row = await (
+                await db.execute(
+                    "SELECT run_id, trace_id, correlation_id, task_id, claim_id,"
+                    " idempotency_key, causation_id, parent_run_id, agent_id,"
+                    " session_id, external_a2a_task_id, message_id, event_id,"
+                    " artifact_id, proposal_id, metadata_json"
+                    " FROM execution_identities WHERE run_id = ?",
+                    (run_id,),
+                )
+            ).fetchone()
+        return _row_to_execution_identity(row) if row is not None else None
+
+    def get_execution_identity_sync(self, run_id: str) -> ExecutionIdentity | None:
+        self.init_db_sync()
+        with sqlite3.connect(self.db_path) as db:
+            _apply_connection_pragmas_sync(db)
+            db.row_factory = sqlite3.Row
+            row = db.execute(
+                "SELECT run_id, trace_id, correlation_id, task_id, claim_id,"
+                " idempotency_key, causation_id, parent_run_id, agent_id,"
+                " session_id, external_a2a_task_id, message_id, event_id,"
+                " artifact_id, proposal_id, metadata_json"
+                " FROM execution_identities WHERE run_id = ?",
+                (run_id,),
+            ).fetchone()
+        return _row_to_execution_identity(row) if row is not None else None
+
+    async def get_execution_identity_by_external_a2a_task(
+        self,
+        external_a2a_task_id: str,
+    ) -> ExecutionIdentity | None:
+        await self.init_db()
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            row = await (
+                await db.execute(
+                    "SELECT run_id, trace_id, correlation_id, task_id, claim_id,"
+                    " idempotency_key, causation_id, parent_run_id, agent_id,"
+                    " session_id, external_a2a_task_id, message_id, event_id,"
+                    " artifact_id, proposal_id, metadata_json"
+                    " FROM execution_identities WHERE external_a2a_task_id = ?"
+                    " ORDER BY updated_at DESC LIMIT 1",
+                    (external_a2a_task_id,),
+                )
+            ).fetchone()
+        return _row_to_execution_identity(row) if row is not None else None
+
+    @staticmethod
+    def build_runtime_receipt(
+        identity: ExecutionIdentity,
+        *,
+        receipt_type: str,
+        status: str,
+        side_effect_key: str = "",
+        payload: dict[str, Any] | None = None,
+        receipt_id: str = "",
+        created_at: datetime | None = None,
+    ) -> RuntimeReceipt:
+        """Build a RuntimeReceipt that preserves the canonical identity fields."""
+        identity.require_for_dispatch()
+        return RuntimeReceipt(
+            receipt_id=receipt_id or _new_id("rr"),
+            receipt_type=receipt_type,
+            status=status,
+            run_id=identity.run_id,
+            task_id=identity.task_id,
+            trace_id=identity.trace_id,
+            correlation_id=identity.correlation_id,
+            causation_id=identity.causation_id,
+            parent_run_id=identity.parent_run_id,
+            agent_id=identity.agent_id,
+            idempotency_key=identity.idempotency_key,
+            side_effect_key=side_effect_key,
+            payload=dict(payload or {}),
+            created_at=created_at or _utc_now(),
+        )
+
+    async def record_receipt_for_identity(
+        self,
+        identity: ExecutionIdentity,
+        *,
+        receipt_type: str,
+        status: str,
+        side_effect_key: str = "",
+        payload: dict[str, Any] | None = None,
+        receipt_id: str = "",
+    ) -> RuntimeReceipt:
+        receipt = self.build_runtime_receipt(
+            identity,
+            receipt_type=receipt_type,
+            status=status,
+            side_effect_key=side_effect_key,
+            payload=payload,
+            receipt_id=receipt_id,
+        )
+        return await self.record_runtime_receipt(receipt)
+
+    def record_receipt_for_identity_sync(
+        self,
+        identity: ExecutionIdentity,
+        *,
+        receipt_type: str,
+        status: str,
+        side_effect_key: str = "",
+        payload: dict[str, Any] | None = None,
+        receipt_id: str = "",
+    ) -> RuntimeReceipt:
+        receipt = self.build_runtime_receipt(
+            identity,
+            receipt_type=receipt_type,
+            status=status,
+            side_effect_key=side_effect_key,
+            payload=payload,
+            receipt_id=receipt_id,
+        )
+        return self.record_runtime_receipt_sync(receipt)
+
+    async def record_idempotency_consumed(
+        self,
+        identity: ExecutionIdentity,
+        side_effect_key: str,
+        *,
+        status: str,
+        payload: dict[str, Any] | None = None,
+    ) -> RuntimeReceipt:
+        return await self.record_receipt_for_identity(
+            identity,
+            receipt_type="idempotency_consumed",
+            status=status,
+            side_effect_key=side_effect_key,
+            payload=payload,
+        )
+
+    def record_idempotency_consumed_sync(
+        self,
+        identity: ExecutionIdentity,
+        side_effect_key: str,
+        *,
+        status: str,
+        payload: dict[str, Any] | None = None,
+    ) -> RuntimeReceipt:
+        return self.record_receipt_for_identity_sync(
+            identity,
+            receipt_type="idempotency_consumed",
+            status=status,
+            side_effect_key=side_effect_key,
+            payload=payload,
+        )
+
+    async def record_side_effect_intent(
+        self,
+        identity: ExecutionIdentity,
+        side_effect_key: str,
+        *,
+        payload: dict[str, Any] | None = None,
+    ) -> RuntimeReceipt:
+        return await self.record_receipt_for_identity(
+            identity,
+            receipt_type="side_effect_intent",
+            status="started",
+            side_effect_key=side_effect_key,
+            payload=payload,
+        )
+
+    def record_side_effect_intent_sync(
+        self,
+        identity: ExecutionIdentity,
+        side_effect_key: str,
+        *,
+        payload: dict[str, Any] | None = None,
+    ) -> RuntimeReceipt:
+        return self.record_receipt_for_identity_sync(
+            identity,
+            receipt_type="side_effect_intent",
+            status="started",
+            side_effect_key=side_effect_key,
+            payload=payload,
+        )
+
+    async def record_side_effect_complete(
+        self,
+        identity: ExecutionIdentity,
+        side_effect_key: str,
+        *,
+        status: str = "completed",
+        result_receipt_id: str = "",
+        payload: dict[str, Any] | None = None,
+    ) -> RuntimeReceipt:
+        return await self.record_receipt_for_identity(
+            identity,
+            receipt_type="side_effect_complete",
+            status=status,
+            side_effect_key=side_effect_key,
+            payload={
+                "result_receipt_id": result_receipt_id,
+                **dict(payload or {}),
+            },
+        )
+
+    def record_side_effect_complete_sync(
+        self,
+        identity: ExecutionIdentity,
+        side_effect_key: str,
+        *,
+        status: str = "completed",
+        result_receipt_id: str = "",
+        payload: dict[str, Any] | None = None,
+    ) -> RuntimeReceipt:
+        return self.record_receipt_for_identity_sync(
+            identity,
+            receipt_type="side_effect_complete",
+            status=status,
+            side_effect_key=side_effect_key,
+            payload={
+                "result_receipt_id": result_receipt_id,
+                **dict(payload or {}),
+            },
+        )
+
+    async def record_message_consumed(
+        self,
+        identity: ExecutionIdentity,
+        message_id: str,
+        *,
+        payload: dict[str, Any] | None = None,
+    ) -> RuntimeReceipt:
+        return await self.record_receipt_for_identity(
+            identity.with_updates(message_id=message_id),
+            receipt_type="message_consumed",
+            status="consumed",
+            side_effect_key=f"message:{message_id}",
+            payload={"message_id": message_id, **dict(payload or {})},
+        )
+
+    async def record_ontology_action_receipt(
+        self,
+        identity: ExecutionIdentity,
+        *,
+        action_name: str,
+        object_type: str,
+        object_id: str = "",
+        applied: bool = False,
+        status: str = "",
+        payload: dict[str, Any] | None = None,
+    ) -> RuntimeReceipt:
+        receipt_type = "ontology_action_applied" if applied else "ontology_action_requested"
+        return await self.record_receipt_for_identity(
+            identity,
+            receipt_type=receipt_type,
+            status=status or ("applied" if applied else "requested"),
+            side_effect_key=f"ontology:{object_type}:{object_id}:{action_name}",
+            payload={
+                "action_name": action_name,
+                "object_type": object_type,
+                "object_id": object_id,
+                **dict(payload or {}),
+            },
+        )
+
+    def record_ontology_action_receipt_sync(
+        self,
+        identity: ExecutionIdentity,
+        *,
+        action_name: str,
+        object_type: str,
+        object_id: str = "",
+        applied: bool = False,
+        status: str = "",
+        payload: dict[str, Any] | None = None,
+    ) -> RuntimeReceipt:
+        receipt_type = "ontology_action_applied" if applied else "ontology_action_requested"
+        return self.record_receipt_for_identity_sync(
+            identity,
+            receipt_type=receipt_type,
+            status=status or ("applied" if applied else "requested"),
+            side_effect_key=f"ontology:{object_type}:{object_id}:{action_name}",
+            payload={
+                "action_name": action_name,
+                "object_type": object_type,
+                "object_id": object_id,
+                **dict(payload or {}),
+            },
+        )
+
+    async def record_self_mod_receipt(
+        self,
+        identity: ExecutionIdentity,
+        *,
+        stage: str,
+        status: str,
+        proposal_id: str = "",
+        payload: dict[str, Any] | None = None,
+    ) -> RuntimeReceipt:
+        stage_key = stage.removeprefix("self_mod_")
+        receipt_type = f"self_mod_{stage_key}"
+        if receipt_type not in SELF_MOD_RECEIPT_TYPES:
+            raise ValueError(f"unknown self-mod receipt stage: {stage}")
+        return await self.record_receipt_for_identity(
+            identity.with_updates(proposal_id=proposal_id or identity.proposal_id),
+            receipt_type=receipt_type,
+            status=status,
+            side_effect_key=f"self_mod:{proposal_id or identity.proposal_id}:{stage_key}",
+            payload={"proposal_id": proposal_id or identity.proposal_id, **dict(payload or {})},
+        )
+
+    def record_self_mod_receipt_sync(
+        self,
+        identity: ExecutionIdentity,
+        *,
+        stage: str,
+        status: str,
+        proposal_id: str = "",
+        payload: dict[str, Any] | None = None,
+    ) -> RuntimeReceipt:
+        stage_key = stage.removeprefix("self_mod_")
+        receipt_type = f"self_mod_{stage_key}"
+        if receipt_type not in SELF_MOD_RECEIPT_TYPES:
+            raise ValueError(f"unknown self-mod receipt stage: {stage}")
+        return self.record_receipt_for_identity_sync(
+            identity.with_updates(proposal_id=proposal_id or identity.proposal_id),
+            receipt_type=receipt_type,
+            status=status,
+            side_effect_key=f"self_mod:{proposal_id or identity.proposal_id}:{stage_key}",
+            payload={"proposal_id": proposal_id or identity.proposal_id, **dict(payload or {})},
+        )
+
+    async def record_runtime_receipt(self, receipt: RuntimeReceipt) -> RuntimeReceipt:
+        await self.init_db()
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute(
+                "INSERT OR REPLACE INTO runtime_receipts (receipt_id, receipt_type,"
+                " run_id, task_id, trace_id, correlation_id, causation_id,"
+                " parent_run_id, agent_id, idempotency_key, side_effect_key,"
+                " status, payload_json, created_at)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    receipt.receipt_id,
+                    receipt.receipt_type,
+                    receipt.run_id,
+                    receipt.task_id,
+                    receipt.trace_id,
+                    receipt.correlation_id,
+                    receipt.causation_id,
+                    receipt.parent_run_id,
+                    receipt.agent_id,
+                    receipt.idempotency_key,
+                    receipt.side_effect_key,
+                    receipt.status,
+                    _json_dump(receipt.payload),
+                    receipt.created_at.isoformat(),
+                ),
+            )
+            await db.commit()
+        return receipt
+
+    def record_runtime_receipt_sync(self, receipt: RuntimeReceipt) -> RuntimeReceipt:
+        self.init_db_sync()
+        with sqlite3.connect(self.db_path) as db:
+            _apply_connection_pragmas_sync(db)
+            db.execute(
+                "INSERT OR REPLACE INTO runtime_receipts (receipt_id, receipt_type,"
+                " run_id, task_id, trace_id, correlation_id, causation_id,"
+                " parent_run_id, agent_id, idempotency_key, side_effect_key,"
+                " status, payload_json, created_at)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    receipt.receipt_id,
+                    receipt.receipt_type,
+                    receipt.run_id,
+                    receipt.task_id,
+                    receipt.trace_id,
+                    receipt.correlation_id,
+                    receipt.causation_id,
+                    receipt.parent_run_id,
+                    receipt.agent_id,
+                    receipt.idempotency_key,
+                    receipt.side_effect_key,
+                    receipt.status,
+                    _json_dump(receipt.payload),
+                    receipt.created_at.isoformat(),
+                ),
+            )
+            db.commit()
+        return receipt
+
+    async def list_runtime_receipts(
+        self,
+        *,
+        run_id: str | None = None,
+        trace_id: str | None = None,
+        correlation_id: str | None = None,
+        receipt_type: str | None = None,
+        limit: int = 50,
+    ) -> list[RuntimeReceipt]:
+        await self.init_db()
+        query = (
+            "SELECT receipt_id, receipt_type, run_id, task_id, trace_id,"
+            " correlation_id, causation_id, parent_run_id, agent_id,"
+            " idempotency_key, side_effect_key, status, payload_json, created_at"
+            " FROM runtime_receipts WHERE 1=1"
+        )
+        params: list[Any] = []
+        if run_id is not None:
+            query += " AND run_id = ?"
+            params.append(run_id)
+        if trace_id is not None:
+            query += " AND trace_id = ?"
+            params.append(trace_id)
+        if correlation_id is not None:
+            query += " AND correlation_id = ?"
+            params.append(correlation_id)
+        if receipt_type is not None:
+            query += " AND receipt_type = ?"
+            params.append(receipt_type)
+        query += " ORDER BY created_at ASC LIMIT ?"
+        params.append(max(1, limit))
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            rows = await (await db.execute(query, params)).fetchall()
+        return [_row_to_runtime_receipt(row) for row in rows]
+
+    async def try_begin_idempotent_side_effect(
+        self,
+        identity: ExecutionIdentity,
+        side_effect_key: str,
+        *,
+        metadata: dict[str, Any] | None = None,
+    ) -> bool:
+        identity.require_for_dispatch()
+        if not side_effect_key:
+            raise ValueError("side_effect_key is required")
+        await self.init_db()
+        now = _utc_now_iso()
+        async with aiosqlite.connect(self.db_path) as db:
+            cur = await db.execute(
+                "INSERT OR IGNORE INTO idempotency_records (idempotency_key,"
+                " side_effect_key, run_id, task_id, trace_id, correlation_id,"
+                " status, result_receipt_id, metadata_json, created_at, updated_at)"
+                " VALUES (?, ?, ?, ?, ?, ?, 'started', '', ?, ?, ?)",
+                (
+                    identity.idempotency_key,
+                    side_effect_key,
+                    identity.run_id,
+                    identity.task_id,
+                    identity.trace_id,
+                    identity.correlation_id,
+                    _json_dump(metadata or {}),
+                    now,
+                    now,
+                ),
+            )
+            await db.commit()
+            inserted = int(cur.rowcount or 0) == 1
+        await self.record_idempotency_consumed(
+            identity,
+            side_effect_key,
+            status="accepted" if inserted else "duplicate",
+            payload=metadata,
+        )
+        if inserted:
+            await self.record_side_effect_intent(
+                identity,
+                side_effect_key,
+                payload=metadata,
+            )
+        return inserted
+
+    def try_begin_idempotent_side_effect_sync(
+        self,
+        identity: ExecutionIdentity,
+        side_effect_key: str,
+        *,
+        metadata: dict[str, Any] | None = None,
+    ) -> bool:
+        identity.require_for_dispatch()
+        if not side_effect_key:
+            raise ValueError("side_effect_key is required")
+        self.init_db_sync()
+        now = _utc_now_iso()
+        with sqlite3.connect(self.db_path) as db:
+            _apply_connection_pragmas_sync(db)
+            cur = db.execute(
+                "INSERT OR IGNORE INTO idempotency_records (idempotency_key,"
+                " side_effect_key, run_id, task_id, trace_id, correlation_id,"
+                " status, result_receipt_id, metadata_json, created_at, updated_at)"
+                " VALUES (?, ?, ?, ?, ?, ?, 'started', '', ?, ?, ?)",
+                (
+                    identity.idempotency_key,
+                    side_effect_key,
+                    identity.run_id,
+                    identity.task_id,
+                    identity.trace_id,
+                    identity.correlation_id,
+                    _json_dump(metadata or {}),
+                    now,
+                    now,
+                ),
+            )
+            db.commit()
+            inserted = int(cur.rowcount or 0) == 1
+        self.record_idempotency_consumed_sync(
+            identity,
+            side_effect_key,
+            status="accepted" if inserted else "duplicate",
+            payload=metadata,
+        )
+        if inserted:
+            self.record_side_effect_intent_sync(
+                identity,
+                side_effect_key,
+                payload=metadata,
+            )
+        return inserted
+
+    async def complete_idempotent_side_effect(
+        self,
+        identity: ExecutionIdentity,
+        side_effect_key: str,
+        *,
+        status: str = "completed",
+        result_receipt_id: str = "",
+        metadata: dict[str, Any] | None = None,
+    ) -> IdempotencyRecord:
+        identity.require_for_dispatch()
+        await self.init_db()
+        now = _utc_now_iso()
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute(
+                "UPDATE idempotency_records SET status = ?, result_receipt_id = ?,"
+                " metadata_json = ?, updated_at = ?"
+                " WHERE idempotency_key = ? AND side_effect_key = ?",
+                (
+                    status,
+                    result_receipt_id,
+                    _json_dump(metadata or {}),
+                    now,
+                    identity.idempotency_key,
+                    side_effect_key,
+                ),
+            )
+            await db.commit()
+        record = await self.get_idempotency_record(identity.idempotency_key, side_effect_key)
+        if record is None:
+            raise KeyError(f"idempotency record {identity.idempotency_key}:{side_effect_key} not found")
+        await self.record_side_effect_complete(
+            identity,
+            side_effect_key,
+            status=status,
+            result_receipt_id=result_receipt_id,
+            payload=metadata,
+        )
+        return record
+
+    def complete_idempotent_side_effect_sync(
+        self,
+        identity: ExecutionIdentity,
+        side_effect_key: str,
+        *,
+        status: str = "completed",
+        result_receipt_id: str = "",
+        metadata: dict[str, Any] | None = None,
+    ) -> IdempotencyRecord:
+        identity.require_for_dispatch()
+        self.init_db_sync()
+        now = _utc_now_iso()
+        with sqlite3.connect(self.db_path) as db:
+            _apply_connection_pragmas_sync(db)
+            db.execute(
+                "UPDATE idempotency_records SET status = ?, result_receipt_id = ?,"
+                " metadata_json = ?, updated_at = ?"
+                " WHERE idempotency_key = ? AND side_effect_key = ?",
+                (
+                    status,
+                    result_receipt_id,
+                    _json_dump(metadata or {}),
+                    now,
+                    identity.idempotency_key,
+                    side_effect_key,
+                ),
+            )
+            db.commit()
+        record = self.get_idempotency_record_sync(identity.idempotency_key, side_effect_key)
+        if record is None:
+            raise KeyError(f"idempotency record {identity.idempotency_key}:{side_effect_key} not found")
+        self.record_side_effect_complete_sync(
+            identity,
+            side_effect_key,
+            status=status,
+            result_receipt_id=result_receipt_id,
+            payload=metadata,
+        )
+        return record
+
+    async def get_idempotency_record(
+        self,
+        idempotency_key: str,
+        side_effect_key: str,
+    ) -> IdempotencyRecord | None:
+        await self.init_db()
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            row = await (
+                await db.execute(
+                    "SELECT idempotency_key, side_effect_key, run_id, task_id,"
+                    " trace_id, correlation_id, status, result_receipt_id,"
+                    " metadata_json, created_at, updated_at FROM idempotency_records"
+                    " WHERE idempotency_key = ? AND side_effect_key = ?",
+                    (idempotency_key, side_effect_key),
+                )
+            ).fetchone()
+        return _row_to_idempotency_record(row) if row is not None else None
+
+    def get_idempotency_record_sync(
+        self,
+        idempotency_key: str,
+        side_effect_key: str,
+    ) -> IdempotencyRecord | None:
+        self.init_db_sync()
+        with sqlite3.connect(self.db_path) as db:
+            _apply_connection_pragmas_sync(db)
+            db.row_factory = sqlite3.Row
+            row = db.execute(
+                "SELECT idempotency_key, side_effect_key, run_id, task_id,"
+                " trace_id, correlation_id, status, result_receipt_id,"
+                " metadata_json, created_at, updated_at FROM idempotency_records"
+                " WHERE idempotency_key = ? AND side_effect_key = ?",
+                (idempotency_key, side_effect_key),
+            ).fetchone()
+        return _row_to_idempotency_record(row) if row is not None else None
+
+    async def was_side_effect_performed(
+        self,
+        idempotency_key: str,
+        side_effect_key: str,
+    ) -> bool:
+        record = await self.get_idempotency_record(idempotency_key, side_effect_key)
+        return record is not None and record.status in {"completed", "skipped"}
+
+    async def list_child_runs(self, parent_run_id: str) -> list[DelegationRun]:
+        await self.init_db()
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            rows = await (
+                await db.execute(
+                    "SELECT run_id, session_id, task_id, claim_id, parent_run_id,"
+                    " assigned_by, assigned_to, requested_output_json,"
+                    " current_artifact_id, status, started_at, completed_at,"
+                    " failure_code, metadata_json FROM delegation_runs"
+                    " WHERE parent_run_id = ? ORDER BY started_at ASC",
+                    (parent_run_id,),
+                )
+            ).fetchall()
+        return [_row_to_run(row) for row in rows]
+
+    async def describe_run(self, run_id: str) -> dict[str, Any]:
+        identity = await self.get_execution_identity(run_id)
+        run = await self.get_delegation_run(run_id)
+        artifacts = await self.list_artifacts(run_id=run_id, limit=100)
+        receipts = await self.list_runtime_receipts(run_id=run_id, limit=200)
+        children = await self.list_child_runs(run_id)
+        idempotency_records: list[IdempotencyRecord] = []
+        if identity is not None:
+            await self.init_db()
+            async with aiosqlite.connect(self.db_path) as db:
+                db.row_factory = aiosqlite.Row
+                rows = await (
+                    await db.execute(
+                        "SELECT idempotency_key, side_effect_key, run_id, task_id,"
+                        " trace_id, correlation_id, status, result_receipt_id,"
+                        " metadata_json, created_at, updated_at"
+                        " FROM idempotency_records WHERE idempotency_key = ?"
+                        " ORDER BY created_at ASC",
+                        (identity.idempotency_key,),
+                    )
+                ).fetchall()
+            idempotency_records = [_row_to_idempotency_record(row) for row in rows]
+        return {
+            "identity": identity,
+            "run": run,
+            "artifacts": artifacts,
+            "receipts": receipts,
+            "children": children,
+            "idempotency_records": idempotency_records,
+        }
+
+    async def get_run_ledger(self, run_id: str) -> dict[str, Any]:
+        """Return the durable runtime facts known for one run."""
+        return await self.describe_run(run_id)
 
     async def record_memory_fact(self, fact: MemoryFact) -> MemoryFact:
         await self.init_db()

--- a/dharma_swarm/spine/__init__.py
+++ b/dharma_swarm/spine/__init__.py
@@ -32,12 +32,32 @@ See ACTIVE_SURFACE_MANIFEST.yaml ``correlation_spine`` block.
 from dharma_swarm.spine.receipt import EvidenceReceipt, ErrorSource, ReceiptStatus
 from dharma_swarm.spine.routing import RoutingDecision
 from dharma_swarm.spine.invoke import invoke_agent, AgentInvoker
+from dharma_swarm.spine.identity import (
+    ExecutionIdentity,
+    MissingExecutionIdentity,
+    require_execution_identity,
+)
+from dharma_swarm.spine.adapters import (
+    adapt_execution_identity,
+    attach_execution_identity,
+    identity_from_carrier,
+    identity_metadata,
+    runtime_receipt_kwargs,
+)
 
 __all__ = [
+    "ExecutionIdentity",
     "EvidenceReceipt",
     "ErrorSource",
+    "MissingExecutionIdentity",
     "ReceiptStatus",
     "RoutingDecision",
+    "adapt_execution_identity",
+    "attach_execution_identity",
+    "identity_from_carrier",
+    "identity_metadata",
     "invoke_agent",
     "AgentInvoker",
+    "require_execution_identity",
+    "runtime_receipt_kwargs",
 ]

--- a/dharma_swarm/spine/adapters.py
+++ b/dharma_swarm/spine/adapters.py
@@ -1,0 +1,327 @@
+# spine: compatibility-adapter
+"""Compatibility adapters for carrying ExecutionIdentity across runtime organs.
+
+This module deliberately does not route, dispatch, persist, or call tools. It
+only normalizes identity into and out of existing carrier shapes so each organ
+can join the RuntimeStateStore ledger without a local rewrite.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, MutableMapping
+from dataclasses import fields, is_dataclass, replace
+from typing import Any
+
+from dharma_swarm.spine.identity import ExecutionIdentity, MissingExecutionIdentity
+
+IDENTITY_FLAT_KEYS = (
+    "trace_id",
+    "correlation_id",
+    "causation_id",
+    "task_id",
+    "run_id",
+    "runtime_run_id",
+    "claim_id",
+    "parent_run_id",
+    "agent_id",
+    "session_id",
+    "external_a2a_task_id",
+    "message_id",
+    "event_id",
+    "artifact_id",
+    "proposal_id",
+    "idempotency_key",
+)
+
+
+def _clean(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _read(carrier: Any, key: str) -> Any:
+    if isinstance(carrier, Mapping):
+        return carrier.get(key)
+    return getattr(carrier, key, None)
+
+
+def _read_nested_mapping(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _carrier_metadata(carrier: Any) -> dict[str, Any]:
+    if isinstance(carrier, Mapping):
+        return _read_nested_mapping(carrier.get("metadata"))
+    return _read_nested_mapping(getattr(carrier, "metadata", None))
+
+
+def _surface_fields(carrier: Any, surface: str) -> dict[str, Any]:
+    surface_key = surface.lower().replace("-", "_")
+    data: dict[str, Any] = {}
+
+    for key in IDENTITY_FLAT_KEYS:
+        value = _read(carrier, key)
+        if value not in (None, ""):
+            data[key] = value
+
+    carrier_id = _clean(_read(carrier, "id"))
+    if carrier_id:
+        data.setdefault("task_id", carrier_id)
+
+    if surface_key in {"a2a", "a2a_task", "a2a_ingress"}:
+        data.setdefault("external_a2a_task_id", carrier_id)
+        data["task_id"] = _clean(_read(carrier, "dharma_task_id")) or data.get("task_id", carrier_id)
+        data.setdefault("agent_id", _read(carrier, "to_agent") or _read(carrier, "from_agent"))
+
+    elif surface_key in {"task", "taskboard", "task_board"}:
+        data["task_id"] = carrier_id or data.get("task_id", "")
+        data.setdefault("agent_id", _read(carrier, "assigned_to") or _read(carrier, "created_by"))
+
+    elif surface_key in {"dispatch", "orchestrator", "task_dispatch"}:
+        data["task_id"] = _read(carrier, "task_id") or data.get("task_id", "")
+        data["agent_id"] = _read(carrier, "agent_id") or data.get("agent_id", "")
+
+    elif surface_key in {"message", "message_bus", "event", "event_bus"}:
+        data.setdefault("message_id", carrier_id or _read(carrier, "message_id"))
+        data.setdefault("event_id", _read(carrier, "event_id"))
+        data.setdefault("agent_id", _read(carrier, "agent_id") or _read(carrier, "to_agent") or _read(carrier, "from_agent"))
+        data.setdefault("task_id", _read(carrier, "task_id") or data.get("message_id") or data.get("event_id"))
+
+    elif surface_key in {"artifact", "artifact_record", "artifact_store"}:
+        data["artifact_id"] = _read(carrier, "artifact_id") or carrier_id or data.get("artifact_id", "")
+        data.setdefault("task_id", _read(carrier, "task_id") or data.get("artifact_id"))
+        data.setdefault("run_id", _read(carrier, "run_id"))
+        data.setdefault("trace_id", _read(carrier, "trace_id"))
+
+    elif surface_key in {"ontology", "ontology_action", "action"}:
+        params = _read_nested_mapping(_read(carrier, "params"))
+        object_type = _clean(_read(carrier, "object_type") or params.get("object_type"))
+        object_id = _clean(_read(carrier, "object_id") or params.get("object_id"))
+        action_name = _clean(_read(carrier, "action_name") or params.get("action_name"))
+        data.setdefault("agent_id", _read(carrier, "executed_by") or params.get("executed_by"))
+        data.setdefault("task_id", params.get("task_id") or f"ontology:{object_type}:{object_id}:{action_name}")
+
+    elif surface_key in {"tool", "tool_call", "mcp_tool"}:
+        data.setdefault("task_id", _read(carrier, "task_id") or _read(carrier, "tool_call_id") or carrier_id)
+        data.setdefault("agent_id", _read(carrier, "agent_id"))
+
+    elif surface_key in {"checkpoint", "graph_checkpoint", "graph"}:
+        data.setdefault("task_id", _read(carrier, "task_id") or _read(carrier, "checkpoint_id") or _read(carrier, "cycle_id") or carrier_id)
+        data.setdefault("run_id", _read(carrier, "run_id"))
+
+    elif surface_key in {"proposal", "self_mod", "self_mod_proposal", "evolution_proposal"}:
+        proposal_id = carrier_id or _read(carrier, "proposal_id") or _read(carrier, "envelope_id")
+        data["proposal_id"] = proposal_id
+        data.setdefault("task_id", _read(carrier, "task_id") or proposal_id)
+        data.setdefault("agent_id", _read(carrier, "agent_id"))
+
+    return data
+
+
+def identity_metadata(
+    identity: ExecutionIdentity,
+    *,
+    surface: str = "",
+    extra: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return nested plus flat metadata for legacy and spine-aware callers."""
+    identity.require_for_dispatch()
+    payload = identity.to_dict()
+    metadata: dict[str, Any] = {
+        "execution_identity": payload,
+        "trace_id": identity.trace_id,
+        "correlation_id": identity.correlation_id,
+        "causation_id": identity.causation_id,
+        "task_id": identity.task_id,
+        "run_id": identity.run_id,
+        "runtime_run_id": identity.run_id,
+        "claim_id": identity.claim_id,
+        "parent_run_id": identity.parent_run_id,
+        "agent_id": identity.agent_id,
+        "session_id": identity.session_id,
+        "external_a2a_task_id": identity.external_a2a_task_id,
+        "message_id": identity.message_id,
+        "event_id": identity.event_id,
+        "artifact_id": identity.artifact_id,
+        "proposal_id": identity.proposal_id,
+        "idempotency_key": identity.idempotency_key,
+    }
+    if surface:
+        metadata["execution_identity_surface"] = surface
+    if extra:
+        metadata.update(dict(extra))
+    return {key: value for key, value in metadata.items() if value not in ("", None)}
+
+
+def identity_from_carrier(
+    carrier: Any,
+    *,
+    surface: str,
+    task_id: str = "",
+    agent_id: str = "",
+    session_id: str = "",
+    require_existing: bool = False,
+) -> ExecutionIdentity:
+    """Extract or construct ExecutionIdentity from an existing organ carrier.
+
+    ``require_existing=True`` is for selected hard runtime boundaries. It fails
+    instead of generating missing identity fields. Compatibility adapters should
+    use the default during migration and persist the returned identity before
+    irreversible side effects.
+    """
+    metadata = _carrier_metadata(carrier)
+    nested = _read_nested_mapping(metadata.get("execution_identity"))
+    top_level = _surface_fields(carrier, surface)
+    merged: dict[str, Any] = {}
+    merged.update(top_level)
+    merged.update(metadata)
+    merged.update(nested)
+
+    if task_id:
+        merged["task_id"] = task_id
+    if agent_id:
+        merged["agent_id"] = agent_id
+    if session_id:
+        merged["session_id"] = session_id
+
+    if require_existing:
+        identity = ExecutionIdentity.from_metadata(
+            merged,
+            task_id=task_id,
+            agent_id=agent_id,
+            session_id=session_id,
+            require=True,
+        )
+        if identity is None:
+            raise MissingExecutionIdentity("ExecutionIdentity is required")
+        return identity.require_for_dispatch()
+
+    return ExecutionIdentity.new(
+        task_id=_clean(merged.get("task_id")),
+        agent_id=_clean(merged.get("agent_id")),
+        session_id=_clean(merged.get("session_id")),
+        trace_id=_clean(merged.get("trace_id")),
+        correlation_id=_clean(merged.get("correlation_id")),
+        causation_id=_clean(merged.get("causation_id")),
+        parent_run_id=_clean(merged.get("parent_run_id")),
+        run_id=_clean(merged.get("run_id") or merged.get("runtime_run_id")),
+        claim_id=_clean(merged.get("claim_id")),
+        idempotency_key=_clean(merged.get("idempotency_key")),
+        external_a2a_task_id=_clean(merged.get("external_a2a_task_id")),
+        message_id=_clean(merged.get("message_id")),
+        event_id=_clean(merged.get("event_id")),
+        artifact_id=_clean(merged.get("artifact_id")),
+        proposal_id=_clean(merged.get("proposal_id")),
+        metadata={
+            "surface": surface,
+            **_read_nested_mapping(merged.get("metadata")),
+        },
+    ).require_for_dispatch()
+
+
+def attach_execution_identity(
+    carrier: Any,
+    identity: ExecutionIdentity,
+    *,
+    surface: str,
+    mutate: bool = True,
+) -> Any:
+    """Attach identity metadata to dicts, dataclasses, and model-like objects.
+
+    Frozen dataclasses are returned as copies. Mutable carriers are updated
+    in-place by default to match existing Task/A2A/MessageBus idioms.
+    """
+    identity.require_for_dispatch()
+    current_meta = _carrier_metadata(carrier)
+    metadata = {
+        **current_meta,
+        **identity_metadata(identity, surface=surface),
+    }
+
+    if isinstance(carrier, MutableMapping):
+        target = carrier if mutate else dict(carrier)
+        target["metadata"] = metadata
+        for key, value in identity_metadata(identity, surface=surface).items():
+            if key != "execution_identity":
+                target.setdefault(key, value)
+        return target
+
+    if is_dataclass(carrier) and not isinstance(carrier, type):
+        dataclass_fields = {field.name for field in fields(carrier)}
+        updates: dict[str, Any] = {}
+        if "metadata" in dataclass_fields:
+            updates["metadata"] = metadata
+        for key, value in identity_metadata(identity, surface=surface).items():
+            if key in dataclass_fields and key != "metadata":
+                current = getattr(carrier, key, "")
+                if not current:
+                    updates[key] = value
+        if updates:
+            return replace(carrier, **updates)
+        return carrier
+
+    if hasattr(carrier, "metadata"):
+        current = getattr(carrier, "metadata", None)
+        if current is None:
+            setattr(carrier, "metadata", metadata)
+        else:
+            setattr(carrier, "metadata", metadata)
+    for key, value in identity_metadata(identity, surface=surface).items():
+        if key == "execution_identity":
+            continue
+        if hasattr(carrier, key) and not getattr(carrier, key):
+            setattr(carrier, key, value)
+    return carrier
+
+
+def adapt_execution_identity(
+    carrier: Any,
+    *,
+    surface: str,
+    task_id: str = "",
+    agent_id: str = "",
+    session_id: str = "",
+    require_existing: bool = False,
+    mutate: bool = True,
+) -> tuple[ExecutionIdentity, Any]:
+    """Extract or create identity and attach it back to the carrier."""
+    identity = identity_from_carrier(
+        carrier,
+        surface=surface,
+        task_id=task_id,
+        agent_id=agent_id,
+        session_id=session_id,
+        require_existing=require_existing,
+    )
+    return identity, attach_execution_identity(
+        carrier,
+        identity,
+        surface=surface,
+        mutate=mutate,
+    )
+
+
+def runtime_receipt_kwargs(
+    identity: ExecutionIdentity,
+    *,
+    receipt_type: str,
+    status: str,
+    side_effect_key: str = "",
+    payload: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return kwargs compatible with ``RuntimeReceipt`` without importing it."""
+    identity.require_for_dispatch()
+    return {
+        "receipt_id": f"rr_{identity.run_id}_{receipt_type}_{status}",
+        "receipt_type": receipt_type,
+        "status": status,
+        "run_id": identity.run_id,
+        "task_id": identity.task_id,
+        "trace_id": identity.trace_id,
+        "correlation_id": identity.correlation_id,
+        "causation_id": identity.causation_id,
+        "parent_run_id": identity.parent_run_id,
+        "agent_id": identity.agent_id,
+        "idempotency_key": identity.idempotency_key,
+        "side_effect_key": side_effect_key,
+        "payload": dict(payload or {}),
+    }

--- a/dharma_swarm/spine/identity.py
+++ b/dharma_swarm/spine/identity.py
@@ -1,0 +1,191 @@
+# spine: canonical-store
+"""Canonical execution identity for the Runtime Truth Spine.
+
+This module is intentionally dependency-light so runtime producers can import
+it without creating circular ownership between the spine, orchestration, and
+durable store layers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+from uuid import uuid4
+
+
+class MissingExecutionIdentity(ValueError):
+    """Raised when a runtime path requires identity but cannot construct it."""
+
+
+def _new_id(prefix: str) -> str:
+    return f"{prefix}_{uuid4().hex[:16]}"
+
+
+def _clean(value: Any) -> str:
+    return str(value or "").strip()
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutionIdentity:
+    """Join key set for one durable unit of work.
+
+    `trace_id` is the local dispatch identity. `correlation_id` is the
+    cross-layer alias used by A2A/operator-core receipts. They may be equal,
+    but both fields are explicit so adapters cannot silently rename identity.
+    """
+
+    trace_id: str
+    correlation_id: str
+    task_id: str
+    run_id: str
+    claim_id: str
+    idempotency_key: str
+    causation_id: str = ""
+    parent_run_id: str = ""
+    agent_id: str = ""
+    session_id: str = ""
+    external_a2a_task_id: str = ""
+    message_id: str = ""
+    event_id: str = ""
+    artifact_id: str = ""
+    proposal_id: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def new(
+        cls,
+        *,
+        task_id: str,
+        agent_id: str = "",
+        session_id: str = "",
+        trace_id: str = "",
+        correlation_id: str = "",
+        causation_id: str = "",
+        parent_run_id: str = "",
+        run_id: str = "",
+        claim_id: str = "",
+        idempotency_key: str = "",
+        external_a2a_task_id: str = "",
+        message_id: str = "",
+        event_id: str = "",
+        artifact_id: str = "",
+        proposal_id: str = "",
+        metadata: dict[str, Any] | None = None,
+    ) -> "ExecutionIdentity":
+        clean_task_id = _clean(task_id)
+        if not clean_task_id:
+            raise MissingExecutionIdentity("ExecutionIdentity requires task_id")
+        clean_trace = _clean(trace_id) or _new_id("trace")
+        clean_correlation = _clean(correlation_id) or clean_trace
+        clean_run = _clean(run_id) or _new_id("run")
+        clean_claim = _clean(claim_id) or _new_id("claim")
+        clean_idem = _clean(idempotency_key) or f"idem_{clean_run}"
+        return cls(
+            trace_id=clean_trace,
+            correlation_id=clean_correlation,
+            task_id=clean_task_id,
+            run_id=clean_run,
+            claim_id=clean_claim,
+            idempotency_key=clean_idem,
+            causation_id=_clean(causation_id),
+            parent_run_id=_clean(parent_run_id),
+            agent_id=_clean(agent_id),
+            session_id=_clean(session_id),
+            external_a2a_task_id=_clean(external_a2a_task_id),
+            message_id=_clean(message_id),
+            event_id=_clean(event_id),
+            artifact_id=_clean(artifact_id),
+            proposal_id=_clean(proposal_id),
+            metadata=dict(metadata or {}),
+        )
+
+    @classmethod
+    def from_metadata(
+        cls,
+        metadata: dict[str, Any] | None,
+        *,
+        task_id: str = "",
+        agent_id: str = "",
+        session_id: str = "",
+        require: bool = False,
+    ) -> "ExecutionIdentity | None":
+        meta = dict(metadata or {})
+        nested = meta.get("execution_identity")
+        raw = dict(nested) if isinstance(nested, dict) else meta
+        resolved_task_id = _clean(raw.get("task_id")) or _clean(task_id)
+        if require and not resolved_task_id:
+            raise MissingExecutionIdentity("missing task_id for required ExecutionIdentity")
+        if not resolved_task_id:
+            return None
+        if require:
+            required = ("trace_id", "correlation_id", "run_id", "claim_id", "idempotency_key")
+            missing = [name for name in required if not _clean(raw.get(name))]
+            if missing:
+                raise MissingExecutionIdentity(
+                    "missing required ExecutionIdentity field(s): " + ", ".join(missing)
+                )
+        return cls.new(
+            task_id=resolved_task_id,
+            agent_id=_clean(raw.get("agent_id")) or _clean(agent_id),
+            session_id=_clean(raw.get("session_id")) or _clean(session_id),
+            trace_id=_clean(raw.get("trace_id")),
+            correlation_id=_clean(raw.get("correlation_id")),
+            causation_id=_clean(raw.get("causation_id")),
+            parent_run_id=_clean(raw.get("parent_run_id")),
+            run_id=_clean(raw.get("run_id")),
+            claim_id=_clean(raw.get("claim_id")),
+            idempotency_key=_clean(raw.get("idempotency_key")),
+            external_a2a_task_id=_clean(raw.get("external_a2a_task_id")),
+            message_id=_clean(raw.get("message_id")),
+            event_id=_clean(raw.get("event_id")),
+            artifact_id=_clean(raw.get("artifact_id")),
+            proposal_id=_clean(raw.get("proposal_id")),
+            metadata=dict(raw.get("metadata") or {}),
+        )
+
+    def require_for_dispatch(self) -> "ExecutionIdentity":
+        missing = [
+            name
+            for name in ("trace_id", "correlation_id", "task_id", "run_id", "claim_id", "idempotency_key")
+            if not _clean(getattr(self, name))
+        ]
+        if missing:
+            raise MissingExecutionIdentity(
+                "ExecutionIdentity is incomplete for dispatch: " + ", ".join(missing)
+            )
+        return self
+
+    def with_updates(self, **updates: Any) -> "ExecutionIdentity":
+        payload = self.to_dict()
+        nested_metadata = payload.pop("metadata", {})
+        payload.update({key: value for key, value in updates.items() if key != "metadata"})
+        payload["metadata"] = {
+            **nested_metadata,
+            **dict(updates.get("metadata") or {}),
+        }
+        return ExecutionIdentity(**payload)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    def to_metadata(self) -> dict[str, Any]:
+        return {"execution_identity": self.to_dict()}
+
+
+def require_execution_identity(
+    metadata: dict[str, Any] | None,
+    *,
+    task_id: str = "",
+    agent_id: str = "",
+    session_id: str = "",
+) -> ExecutionIdentity:
+    identity = ExecutionIdentity.from_metadata(
+        metadata,
+        task_id=task_id,
+        agent_id=agent_id,
+        session_id=session_id,
+        require=True,
+    )
+    if identity is None:
+        raise MissingExecutionIdentity("ExecutionIdentity is required")
+    return identity.require_for_dispatch()

--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -6,16 +6,16 @@ Do not hand-edit the generated block.
 <!-- DOCOPS:START metric=repo_inventory -->
 | Metric | Value |
 |---|---:|
-| Dharma Python modules | 659 |
+| Dharma Python modules | 661 |
 | Top-level Dharma Python modules | 389 |
-| Dharma Python LOC | 277,634 |
-| Test files | 613 |
-| Test function occurrences | 10,717 |
-| Markdown files | 753 |
-| Markdown total lines | 189,745 |
+| Dharma Python LOC | 279,695 |
+| Test files | 617 |
+| Test function occurrences | 10,734 |
+| Markdown files | 757 |
+| Markdown total lines | 190,990 |
 | Bridge files | 24 |
-| Adapter files | 20 |
+| Adapter files | 21 |
 | Orchestrator files | 4 |
 | Router files | 14 |
-| Authority candidate docs | 303 |
+| Authority candidate docs | 307 |
 <!-- DOCOPS:END -->

--- a/docs/docops/assertions.yaml
+++ b/docs/docops/assertions.yaml
@@ -136,7 +136,8 @@
     ],
     "ignore": [
       "docs/archive/**",
-      "docs/_archive/**"
+      "docs/_archive/**",
+      "reports/governance/**"
     ],
       "registered": [
         "AGENTS.md",

--- a/docs/governance/SOVEREIGN_MANIFEST.md
+++ b/docs/governance/SOVEREIGN_MANIFEST.md
@@ -80,10 +80,10 @@ For machine-readable status, see [`reports/governance/active_track_evidence.md`]
 These are immutable engineering laws for this repository. Violation = architectural regression.
 
 ### A1: NO FLAT-PACKAGE GROWTH
-The `dharma_swarm/` package currently has **387 files at its top level (63.2% of 612 total Python modules)** (V). No new .py file may be added to the top level. New modules must go into an appropriate subdirectory. Existing top-level files will be organized over time.
+The `dharma_swarm/` package currently has **389 files at its top level (58.9% of 661 total Python modules)** (V). No new .py file may be added to the top level. New modules must go into an appropriate subdirectory. Existing top-level files will be organized over time.
 
 ### A2: NO DUPLICATE IMPLEMENTATIONS
-Before creating a new file for routing, bridging, adapting, or orchestrating, check if one already exists. The repo currently has **24 bridge files** (V), **3 model_routing copies** (2 are identical, 1 is different) (V), **4 orchestrators** (V), **16 adapter files across 8 locations** (V), and **14 router files** (V). Do not add more without deprecating an existing one.
+Before creating a new file for routing, bridging, adapting, or orchestrating, check if one already exists. The repo currently has **24 bridge files** (V), **3 model_routing copies** (2 are identical, 1 is different) (V), **4 orchestrators** (V), **21 adapter files across 8 locations** (V), and **14 router files** (V). Do not add more without deprecating an existing one.
 
 ### A3: NO UNDOCUMENTED SEAMS
 If your code creates a new interface between domains (a bridge, adapter, or protocol), you must update `NAVIGATION.md` with its purpose, entry point, and boundary constraints. Undocumented seams become invisible coupling.
@@ -125,17 +125,17 @@ These are the ground-truth metrics. All other documents citing different numbers
 
 | Metric | Value | Verification |
 |--------|-------|-------------|
-| Total Python modules | **659** | find dharma_swarm -name "*.py" -type f |
+| Total Python modules | **661** | find dharma_swarm -name "*.py" -type f |
 | Top-level (flat) modules | **389 (59.0%)** | find dharma_swarm -maxdepth 1 -name "*.py" -type f |
-| Total Python LOC | **277,634** | wc -l across dharma_swarm Python modules |
-| Test files | **613** | find tests -name "*.py" -type f |
-| Test functions | **10,717 `def test_` occurrences under tests/** | rg "def test_" tests |
+| Total Python LOC | **279,695** | wc -l across dharma_swarm Python modules |
+| Test files | **617** | find tests -name "*.py" -type f |
+| Test functions | **10,734 `def test_` occurrences under tests/** | rg "def test_" tests |
 | Tests collected (pytest) | **Needs write-permitted refresh** | not run during this DocOps count pass |
 | Collection errors | **Historical: 16 on 2026-04-04** | refresh before relying on this count |
-| Markdown files | **753** | find . -name "*.md" -type f |
-| Markdown total lines | **189,745** | wc -l across all .md |
+| Markdown files | **757** | find . -name "*.md" -type f |
+| Markdown total lines | **190,990** | wc -l across all .md |
 | Bridge files | **24** | find dharma_swarm -name "*bridge*.py" |
-| Adapter files | **20 across 8 locations** | find dharma_swarm -type f \| rg -i "adapter" |
+| Adapter files | **21 across 8 locations** | find dharma_swarm -type f \| rg -i "adapter" |
 | Orchestrator files | **4** (6,034 LOC total) | find dharma_swarm -name "*orchestrat*" |
 | Router files | **14** (4,976 LOC total) | find dharma_swarm -type f \| rg -i "rout" |
 | Memory modules | **11** (5,848 LOC) | find dharma_swarm -name "*memory*" |

--- a/reports/governance/active_track_evidence.json
+++ b/reports/governance/active_track_evidence.json
@@ -1,11 +1,11 @@
 {
-  "generated_at": "2026-05-28T13:23:13+00:00",
+  "generated_at": "2026-06-01T21:50:17+08:00",
   "active_track_id": "runtime-truth-spine-2026-06",
   "shippable": true,
   "prerequisites_ok": true,
   "completion_progress": {
-    "passed": 6,
-    "total": 6
+    "passed": 13,
+    "total": 13
   },
   "criteria": [
     {
@@ -45,10 +45,52 @@
       "detail": "pattern 'async def invoke_agent' found in dharma_swarm/spine/invoke.py"
     },
     {
-      "id": "spine_check_ci",
+      "id": "spine_ownership_guard",
       "kind": "file_exists",
       "passed": true,
-      "detail": ".github/workflows/spine-check.yml present"
+      "detail": "scripts/uplift_guards/check_spine_ownership.py present"
+    },
+    {
+      "id": "spine_guard_registered",
+      "kind": "file_contains",
+      "passed": true,
+      "detail": "pattern 'check_spine_ownership' found in scripts/uplift_guards/run_pre_commit.py"
+    },
+    {
+      "id": "spine_doctrine_anchored",
+      "kind": "file_contains",
+      "passed": true,
+      "detail": "pattern 'Correlation identity must not' found in dharma_swarm/spine/__init__.py"
+    },
+    {
+      "id": "correlation_spine_manifest_block",
+      "kind": "file_contains",
+      "passed": true,
+      "detail": "pattern 'correlation_spine:' found in ACTIVE_SURFACE_MANIFEST.yaml"
+    },
+    {
+      "id": "correlation_id_alias_present",
+      "kind": "file_contains",
+      "passed": true,
+      "detail": "pattern 'dharma.correlation_id' found in dharma_swarm/spine/receipt.py"
+    },
+    {
+      "id": "onboard_renders_spine",
+      "kind": "file_contains",
+      "passed": true,
+      "detail": "pattern 'render_spine_status' found in scripts/governance/agent_onboard.py"
+    },
+    {
+      "id": "anti_slop_role_vocabulary",
+      "kind": "file_contains",
+      "passed": true,
+      "detail": "pattern 'canonical-store' found in docs/governance/ANTI_SLOP_RULES.md"
+    },
+    {
+      "id": "runtime_state_receipt_field",
+      "kind": "file_contains",
+      "passed": true,
+      "detail": "pattern 'receipt_json' found in dharma_swarm/runtime_state.py"
     },
     {
       "id": "dropoff_tests_pass",
@@ -61,7 +103,7 @@
     {
       "severity": "INFO",
       "check": "track-shippable",
-      "message": "All 6 completion criteria pass. Track 'runtime-truth-spine-2026-06' is SHIPPABLE \u2014 close it and declare the next active track.",
+      "message": "All 13 completion criteria pass. Track 'runtime-truth-spine-2026-06' is SHIPPABLE \u2014 close it and declare the next active track.",
       "criterion_id": null
     }
   ]

--- a/reports/governance/active_track_evidence.md
+++ b/reports/governance/active_track_evidence.md
@@ -1,9 +1,9 @@
 # Active Track Evidence
 
-Generated: 2026-05-28T13:23:13+00:00
+Generated: 2026-06-01T21:50:17+08:00
 Track: `runtime-truth-spine-2026-06`
 Prerequisites: **OK**
-Completion: **6/6**
+Completion: **13/13**
 Shippable: **YES**
 
 ## Criteria
@@ -14,9 +14,16 @@ Shippable: **YES**
 - ✓ `evidence_receipt_defined` (file_contains) — pattern 'class EvidenceReceipt' found in dharma_swarm/spine/receipt.py
 - ✓ `routing_decision_defined` (file_contains) — pattern 'class RoutingDecision' found in dharma_swarm/spine/routing.py
 - ✓ `invoke_agent_defined` (file_contains) — pattern 'async def invoke_agent' found in dharma_swarm/spine/invoke.py
-- ✓ `spine_check_ci` (file_exists) — .github/workflows/spine-check.yml present
+- ✓ `spine_ownership_guard` (file_exists) — scripts/uplift_guards/check_spine_ownership.py present
+- ✓ `spine_guard_registered` (file_contains) — pattern 'check_spine_ownership' found in scripts/uplift_guards/run_pre_commit.py
+- ✓ `spine_doctrine_anchored` (file_contains) — pattern 'Correlation identity must not' found in dharma_swarm/spine/__init__.py
+- ✓ `correlation_spine_manifest_block` (file_contains) — pattern 'correlation_spine:' found in ACTIVE_SURFACE_MANIFEST.yaml
+- ✓ `correlation_id_alias_present` (file_contains) — pattern 'dharma.correlation_id' found in dharma_swarm/spine/receipt.py
+- ✓ `onboard_renders_spine` (file_contains) — pattern 'render_spine_status' found in scripts/governance/agent_onboard.py
+- ✓ `anti_slop_role_vocabulary` (file_contains) — pattern 'canonical-store' found in docs/governance/ANTI_SLOP_RULES.md
+- ✓ `runtime_state_receipt_field` (file_contains) — pattern 'receipt_json' found in dharma_swarm/runtime_state.py
 - ✓ `dropoff_tests_pass` (file_contains) — pattern 'test_provider_failure_not_confused_with_dropoff' found in tests/test_dispatch_dropoff_sources.py
 
 ## Findings
 
-- **INFO** `track-shippable`: All 6 completion criteria pass. Track 'runtime-truth-spine-2026-06' is SHIPPABLE — close it and declare the next active track.
+- **INFO** `track-shippable`: All 13 completion criteria pass. Track 'runtime-truth-spine-2026-06' is SHIPPABLE — close it and declare the next active track.

--- a/reports/governance/execution_identity_lineage_blast_radius_audit.md
+++ b/reports/governance/execution_identity_lineage_blast_radius_audit.md
@@ -1,0 +1,701 @@
+# Execution Identity Lineage and Blast-Radius Audit
+
+Date: 2026-06-01
+
+Audit target: `/Users/dhyana/worktrees/dharma_swarm_runtime_truth_spine_v2`
+
+Branch: `codex/runtime-truth-spine-v2`
+
+Base HEAD: `2737b26d7ed8dbee9c828ba64d5a6c9ec128b859`
+
+Verdict: the v2 branch has a real Canonical `ExecutionIdentity` spine for selected paths, but identity is not yet saturated. The repo still contains multiple parallel identity lineages, legacy run/claim writes, graph/workflow IDs, event envelope IDs, artifact IDs, A2A IDs, provider session IDs, and proposal/gate IDs that are not mechanically joined to the runtime ledger.
+
+The shortest accurate summary: `ExecutionIdentity` is no longer vapor, but it is still optional infrastructure unless the remaining boundary surfaces are adapted or quarantined.
+
+## 1. Clean Source Boundary
+
+Evidence level: `code-enforced/staged-v2-candidate`, `test-backed`.
+
+The intended clean branch exists, but the v2 spine changes are currently staged rather than committed. A checkpoint commit was attempted and blocked by repo governance hooks:
+
+- `dharma-uplift-guards` required hot-path impact acknowledgement in the commit message.
+- `dharma-docops-integrity` reported stale generated counts in manifest/inventory files.
+
+I did not bypass those hooks.
+
+Source boundary used for this audit:
+
+| Field | Value |
+| --- | --- |
+| Worktree | `/Users/dhyana/worktrees/dharma_swarm_runtime_truth_spine_v2` |
+| Branch | `codex/runtime-truth-spine-v2` |
+| Base HEAD | `2737b26d7ed8dbee9c828ba64d5a6c9ec128b859` |
+| Tracked/index file count | `2746` |
+| Source status | staged v2 candidate, no unstaged diff observed |
+| Staged scope | 20 files, 3710 insertions, 56 deletions |
+
+Staged files in scope include:
+
+- `dharma_swarm/spine/identity.py`
+- `dharma_swarm/spine/adapters.py`
+- `dharma_swarm/runtime_state.py`
+- `dharma_swarm/runtime_lifecycle.py`
+- `dharma_swarm/a2a/a2a_server.py`
+- `dharma_swarm/message_bus.py`
+- `tests/test_runtime_truth_spine_v1.py`
+- `tests/test_runtime_truth_spine_v2_adapters.py`
+- `tests/test_runtime_truth_spine_v2_evidence.py`
+
+Important caveat: this is not a clean committed `AUDIT_SHA` yet. Implementation claims below are valid against the staged v2 worktree, not against a merged `origin/main` commit.
+
+Search scope:
+
+- Broad ID-like grep found `9540` references across `649` files.
+- Top term counts: `session_id` 2404, `task_id` 2391, `agent_id` 1831, `run_id` 1209, `trace_id` 1085, `artifact_id` 571, `proposal_id` 506, `claim_id` 439, `event_id` 299, `correlation_id` 240, `idempotency_key` 207.
+- Absence test: `promotion_id`, `revert_id`, `verification_id`, and `ontology_action_id` had zero implementation hits in tracked Python/docs/config search.
+
+## 2. Identity Surface Inventory
+
+Evidence level: mostly `code-enforced/staged-v2-candidate`; noted gaps are `absence-test-backed` or `inferred`.
+
+| ID surface | Meaning found | Generator / owner | Required? | Durable surface | Maps to `ExecutionIdentity`? | Evidence |
+| --- | --- | --- | --- | --- | --- | --- |
+| `ExecutionIdentity` | Canonical runtime identity bundle | `ExecutionIdentity.new` | Required only where invoked | `execution_identities` table | Canonical | `dharma_swarm/spine/identity.py:29`, `runtime_state.py:210` |
+| `trace_id` | Cross-surface trace lineage | `CorrelationContext`, `ExecutionIdentity.new`, `RuntimeEnvelope.create` | Required on selected v2 paths | TaskBoard column, `execution_identities`, receipts | Yes, but also parallel | `identity.py:37`, `correlation_context.py:64`, `runtime_contract.py:49` |
+| `correlation_id` | Correlates task/run/message lineage | Defaults to trace in `ExecutionIdentity.new` | Required in `from_metadata(require=True)` | `execution_identities`, receipts | Yes | `identity.py:38`, `identity.py:79`, `runtime_state.py:215` |
+| `causation_id` | Causal predecessor | Caller-provided or blank | Optional | `execution_identities`, receipts | Yes | `identity.py:43`, `runtime_state.py:217` |
+| `task_id` | Internal task identity | `TaskBoard._new_id`, A2A fallback, adapters | Required for `ExecutionIdentity` | TaskBoard, RuntimeStateStore, receipts | Yes, but many independent generators | `identity.py:39`, `task_board.py:207`, `a2a_server.py:407` |
+| `run_id` | Runtime/work unit identity | `ExecutionIdentity.new`, `RuntimeStateStore.new_run_id`, workflow-local generators | Required for dispatch identity | `execution_identities`, `delegation_runs`, receipts | Yes, but legacy writes bypass it | `identity.py:40`, `runtime_state.py:210`, `opportunity_dispatcher.py:157` |
+| `workflow_id` | Graph/durable workflow identity | `workflow.py`, `workflow_graph.py`, `durable_execution.py` | Required in workflow systems | Checkpoint/state files | No direct mapping found | `workflow.py:231`, `workflow_graph.py:240`, `durable_execution.py:99` |
+| `thread_id` | Chat/provider thread identity | Gateway/provider adapters | Optional | Gateway/TUI/session metadata | No | `gateway/base.py:36`, `gateway/telegram.py:137`, `tui/engine/adapters/codex.py:383` |
+| `session_id` | Operator/runtime/provider session | Multiple session stores and `RuntimeStateStore.new_session_id` | Often optional | TaskBoard metadata, runtime tables, TUI stores | Optional field on identity | `identity.py:46`, `runtime_state.py:3062`, `task_board.py:212` |
+| `claim_id` | Work claim/lease-ish runtime claim | `ExecutionIdentity.new`, `RuntimeStateStore.new_claim_id`, legacy sync callers | Required for dispatch identity | `task_claims`, `execution_identities`, receipts | Yes, but legacy path bypasses identity row | `identity.py:41`, `runtime_state.py:3066`, `opportunity_dispatcher.py:156` |
+| `lease_id` | Workspace lease ID | `RuntimeStateStore.new_lease_id` | Lease-specific | `workspace_leases` | No canonical mapping except holder run | `runtime_state.py:81`, `runtime_state.py:3074` |
+| `lock_id` | File lock implementation identity | `file_lock.py` hash | Lock-specific | Lock files | No | `file_lock.py:79`, `file_lock.py:284` |
+| `message_id` | Message transport ID | `Message.id`, adapter metadata | Optional | MessageBus `messages`, identity table optional | Optional field | `models.py:243`, `spine/identity.py:48`, `message_bus.py:33` |
+| `event_id` | Event envelope / MessageBus event ID | `RuntimeEnvelope.create`, `MessageBus.emit_event` | Event-specific | `events`, `execution_identities` optional | Optional field | `runtime_contract.py:43`, `message_bus.py:603`, `identity.py:49` |
+| `artifact_id` | Artifact object identity | Engine/runtime artifact stores | Optional | Artifact manifests, runtime artifact table | Optional field | `identity.py:50`, `artifact_store.py:151`, `engine/artifacts.py:111` |
+| `receipt_id` | Runtime ledger receipt ID | `RuntimeStateStore.build_runtime_receipt` | Receipt-specific | `runtime_receipts` | Receipt links to identity fields | `runtime_state.py:233`, `runtime_state.py:2127` |
+| `agent_id` | Agent identity / assignee | `AgentConfig.id`, callers, A2A `to_agent` | Optional | Agent config, receipts, runtime tables | Optional field | `models.py:173`, `identity.py:45`, `a2a_server.py:408` |
+| `parent_run_id` | Parent runtime run | Caller-provided | Optional | `execution_identities`, `delegation_runs`, receipts | Yes | `identity.py:44`, `runtime_lifecycle.py:362` |
+| `parent_task_id` | Parent task concept | Only one tracked hit | Not implemented | None found | No | absence count: 1 |
+| `external_a2a_task_id` | External A2A task ID | `A2ATask.id` mapped in A2A server | Optional but important for A2A | `execution_identities` indexed | Yes | `identity.py:47`, `a2a_server.py:417`, `runtime_state.py:287` |
+| `a2a_task_id` | Legacy A2A metadata field | A2A bridge/test | Not canonical | Message metadata only | No | `a2a_bridge.py:229`, `tests/test_a2a.py:639` |
+| `idempotency_key` | Duplicate suppression key | `ExecutionIdentity.new`, MessageBus caller, A2A metadata | Required in v2 required identity | `idempotency_records`, receipts | Yes | `identity.py:42`, `runtime_state.py:251`, `message_bus.py:598` |
+| `request_id` | Request-local identity | Scattered adapters/contracts | Not canonical | Varies | No direct mapping found | grep count: 171 |
+| `operation_id` | Operation-local identity | Scattered | Not canonical | Varies | No direct mapping found | grep count: present in broad search |
+| `checkpoint_id` | Checkpoint store identity | Contract/checkpoint modules | Checkpoint-specific | Checkpoint stores/files | No canonical mapping found | `contracts/runtime.py:63`, checkpoint search count: 31 |
+| `action_id` | Operator action / generic action ID | `RuntimeStateStore.new_action_id`, ontology/action code uses action names | Action-specific | `operator_actions` | No ontology-specific canonical ID | `runtime_state.py:169`, `runtime_state.py:3094` |
+| `ontology_action_id` | Expected ontology action ID | None found | Missing | None found | No | absence count: 0 |
+| `proposal_id` | Self-mod/telos proposal lineage | Evolution/telic systems | Proposal-specific | Evolution/telic/proposal records | Optional field on identity, not wired broadly | `identity.py:51`, `evolution.py` grep, `runtime_state.py:224` |
+| `gate_id` | Gate-decision record identity | Telic/operator brief | Gate-specific | Ontology/telic records | No direct runtime mapping | `operator_brief/insight_brief.py:161`, `tests/test_telic_seam.py:313` |
+| `verification_id` | Expected self-mod verification ID | None found | Missing | None found | No | absence count: 0 |
+| `promotion_id` | Expected self-mod promotion ID | None found | Missing | None found | No | absence count: 0 |
+| `revert_id` | Expected self-mod revert ID | None found | Missing | None found | No | absence count: 0 |
+| `swarm_id` | Swarm grouping identity | Rare/scattered | Not canonical | unclear | No direct mapping found | broad grep term included |
+| `provider_session_id` | Provider/TUI external session | TUI/operator session stores | UI/provider-specific | TUI/operator stores | No | `tui/engine/session_store.py:62`, `operator_core/session_store.py:60` |
+| `block_id` / `pipeline_id` | Logic/lineage graph block IDs | Logic/lineage modules | Graph-local | Lineage DB | No direct mapping found | `logic_layer.py:139`, `lineage.py:68` |
+| `bundle_id` | Context bundle identity | RuntimeStateStore | Bundle-specific | `context_bundles` | Indirect via run/task/session | `runtime_state.py:152` |
+
+## 3. Same-Name Collision Matrix
+
+Evidence level: `code-enforced/staged-v2-candidate`, `absence-test-backed`.
+
+| Name | Collision | Risk | Evidence | Recommendation |
+| --- | --- | --- | --- | --- |
+| `trace_id` | Created by `CorrelationContext`, `RuntimeEnvelope`, and `ExecutionIdentity` | Same field name can mean ambient trace, transport trace, or canonical runtime trace | `correlation_context.py:64`, `runtime_contract.py:67`, `identity.py:78` | Keep `trace_id`, but require it to be carried inside `ExecutionIdentity` at runtime boundaries. |
+| `task_id` | TaskBoard task, A2A fallback task, RuntimeState task claim field, tests | Same name is close enough to be useful but not always ledger-backed | `task_board.py:207`, `a2a_server.py:407`, `runtime_state.py:44` | `TaskBoard.create` should emit/accept identity adapter metadata or be marked task-only projection. |
+| `run_id` | Canonical runtime run, delegation run, workflow-adjacent run, operator action run | Legacy helpers can write run rows without identity | `identity.py:80`, `runtime_state.py:61`, `runtime_state.py:1686`, `opportunity_dispatcher.py:157` | Make `execution_identities.run_id` the FK-like owner for all runtime runs. |
+| `claim_id` | Canonical claim in identity and direct task claim primary key | Legacy claim writes do not guarantee identity or receipt | `identity.py:81`, `runtime_state.py:44`, `runtime_state.py:1595` | Require `ExecutionIdentity` or quarantine legacy claim creation. |
+| `event_id` | Runtime envelope event, MessageBus event, optional identity field | Event identity can be generated without run linkage | `runtime_contract.py:67`, `message_bus.py:603`, `identity.py:49` | Message/event envelopes should include canonical run mapping before handlers run. |
+| `message_id` | MessageBus message ID and optional identity field | Raw message send is not ledger-backed | `models.py:243`, `message_bus.py:184`, `identity.py:48` | Add message-consumed receipt and run/trace mapping on receive. |
+| `artifact_id` | Runtime artifact, engine artifact, optional identity field | Engine artifacts can exist without run/trace | `artifact_store.py:151`, `engine/artifacts.py:111`, `runtime_state.py:94` | Require runtime artifact adapter for selected surfaces. |
+| `session_id` | Operator session, provider session, runtime session | Many meanings with different lifetimes | `identity.py:46`, `runtime_state.py:3062`, `tui/engine/session_store.py:62` | Treat session as context, not execution truth. |
+| `agent_id` | Agent config identity, actor, assignee, A2A target | Agent identity is not the same as execution identity | `models.py:173`, `a2a_server.py:408`, `runtime_state.py:190` | Keep as participant field; do not use as run owner. |
+| `workflow_id` | Graph/durable workflow ID, not runtime run ID | Cannot reconstruct runtime ledger by workflow ID without mapping | `workflow.py:231`, `workflow_graph.py:240`, `durable_execution.py:99` | Add workflow-to-run mapping receipt or quarantine graph workflow as graph-local. |
+| `proposal_id` | Self-mod/telic proposal ID and optional identity field | Proposal can pass gates/apply without runtime run linkage | `identity.py:51`, `runtime_state.py:224`, `evolution.py` grep | Add proposal/gate/apply/verify receipts tied to run. |
+| `a2a_task_id` vs `external_a2a_task_id` | Two names for external A2A task lineage | Legacy A2A metadata will not join to v2 lookup | `a2a_bridge.py:229`, `a2a_server.py:417`, `runtime_state.py:2110` | Migrate to `external_a2a_task_id`; adapter should read legacy alias. |
+
+## 4. Lineage Map
+
+Evidence level: `code-enforced/staged-v2-candidate`, `inferred` where call path is not fully wired.
+
+### A2A Local Ingress
+
+Path: `A2AServer.submit` -> `_ensure_execution_identity` -> `RuntimeStateStore.record_execution_identity_sync` -> idempotency -> dispatch -> runtime receipt.
+
+Evidence:
+
+- `A2AServer.__init__` accepts `runtime_state` and `require_execution_identity`, default false: `a2a/a2a_server.py:273`.
+- `_ensure_execution_identity` creates an identity from A2A task metadata and maps `task.id` to `external_a2a_task_id`: `a2a/a2a_server.py:399`, `a2a/a2a_server.py:417`.
+- It persists identity when runtime state exists: `a2a/a2a_server.py:335`.
+- It checks idempotency before dispatch: `a2a/a2a_server.py:345`.
+- It records a runtime receipt after dispatch: `a2a/a2a_server.py:367`.
+- It completes the idempotent side effect: `a2a/a2a_server.py:390`.
+
+Verdict: joined for the selected path, but not globally mandatory because `require_execution_identity=False` by default.
+
+### TaskBoard
+
+Path: `TaskBoard.create` -> task row with `trace_id` column and metadata.
+
+Evidence:
+
+- Tasks table has `trace_id`: `task_board.py:29`.
+- `create` generates `task_id` with `_new_id`: `task_board.py:207`.
+- It copies ambient `CorrelationContext.trace_id` to metadata/column: `task_board.py:212`.
+
+Verdict: adapter-ready, not canonical. It stores trace, not full `ExecutionIdentity`.
+
+### Orchestrator / RuntimeLifecycle Dispatch
+
+Path: task/dispatch metadata -> `RuntimeLifecycle.ensure_execution_identity` -> task and dispatch metadata -> `RuntimeStateStore`.
+
+Evidence:
+
+- `ensure_runtime_run_id` writes `runtime_run_id`: `runtime_lifecycle.py:68`.
+- `ensure_execution_identity` merges task and dispatch metadata: `runtime_lifecycle.py:83`.
+- Required mode rejects missing trace/correlation/claim: `runtime_lifecycle.py:108`.
+- It writes identity fields back to dispatch and task metadata: `runtime_lifecycle.py:137`.
+- It records identity in `RuntimeStateStore`: `runtime_lifecycle.py:163`.
+
+Verdict: strongest current canonical seam after A2A.
+
+### MessageBus
+
+Path A: `emit_event` with `idempotency_key` -> `ExecutionIdentity` -> idempotency table -> event insert -> idempotency completion.
+
+Evidence:
+
+- Optional `idempotency_key` parameter: `message_bus.py:598`.
+- Deterministic event ID from idempotency key: `message_bus.py:603`.
+- Requires runtime state when idempotency key is provided: `message_bus.py:612`.
+- Constructs `ExecutionIdentity`: `message_bus.py:615`.
+- Checks existing idempotency record before insert: `message_bus.py:625`.
+- Begins idempotent side effect before insert: `message_bus.py:631`.
+- Completes it after insert: `message_bus.py:675`.
+
+Path B: raw message/artifact send -> no identity enforcement.
+
+Evidence:
+
+- `send` inserts message directly: `message_bus.py:184`.
+- `attach_artifact` generates artifact IDs and inserts artifacts: `message_bus.py:373`.
+- `consume_events` marks events consumed without `ExecutionIdentity` or receipt: `message_bus.py:683`.
+
+Verdict: event emit with idempotency is joined; raw messages, artifacts, and consume path are not.
+
+### Artifact Stores
+
+Path A: `RuntimeArtifactStore` can write runtime artifact records if caller supplies run/trace.
+
+Evidence:
+
+- `create_text_artifact` accepts optional `run_id` and `trace_id`, default blank: `artifact_store.py:40`.
+- `_record_ref` records into runtime state when present: `artifact_store.py:298`.
+
+Path B: `engine/artifacts.py` creates artifacts independently.
+
+Evidence:
+
+- `ArtifactRef` only carries artifact/session/type/version/path: `engine/artifacts.py:15`.
+- `create_artifact` generates `artifact_id` independently: `engine/artifacts.py:90`, `engine/artifacts.py:111`.
+
+Verdict: runtime artifact path is adapter-ready; engine artifact path is a parallel artifact lineage.
+
+### Workflow / Graph
+
+Path: workflow ID -> checkpoint state files.
+
+Evidence:
+
+- `CompiledWorkflow` creates `workflow_id`: `workflow.py:231`.
+- Checkpoint writes `workflow_id`: `workflow.py:377`.
+- `WorkflowGraph.execute` defaults `workflow_id` to `wfg_<timestamp>`: `workflow_graph.py:240`.
+- `DurableWorkflow` persists by `workflow_id`: `durable_execution.py:99`, `durable_execution.py:220`.
+
+Verdict: graph/workflow has a separate lineage. No direct `workflow_id -> run_id` mapping was found in the audited search.
+
+### Ontology Actions
+
+Path: `OntologyRegistry.execute_action` -> telos check -> success log.
+
+Evidence:
+
+- `ActionDef.modifies` and `requires_approval` are declared: `ontology.py:161`, `ontology.py:172`, `ontology.py:174`.
+- `execute_action` starts at `ontology.py:763`.
+- Telos gate logic exists before success: `ontology.py:798`.
+- The action logs success: `ontology.py:872`.
+- `ontology_action_id` absence test returned zero hits.
+
+Verdict: ontology action lineage is not currently joined to `ExecutionIdentity`; the C2 tollbooth fix remains queued.
+
+### Tools
+
+Path: `ToolRegistry.dispatch` -> handler call.
+
+Evidence:
+
+- Registry class: `tool_registry.py:58`.
+- Dispatch method: `tool_registry.py:129`.
+- No `ExecutionIdentity`, `run_id`, `trace_id`, or `idempotency` hits in the file-level search.
+
+Verdict: tool dispatch is missing an identity boundary.
+
+### Self-Modification
+
+Path: proposal/gate/apply/test modules carry `proposal_id`, but runtime ledger receipts are not wired.
+
+Evidence:
+
+- `proposal_id` appears widely in evolution/telic code.
+- `RuntimeStateStore` has self-mod receipt helpers: `runtime_state.py:2364`, `runtime_state.py:2385`.
+- Absence tests found zero `verification_id`, `promotion_id`, and `revert_id`.
+
+Verdict: self-mod identity is proposal-centric, not runtime-ledger-centric.
+
+## 5. Durable Ledger Map
+
+Evidence level: `code-enforced/staged-v2-candidate`, `test-backed`.
+
+`RuntimeStateStore` is the durable ledger candidate.
+
+Ledger tables:
+
+- `execution_identities`: `runtime_state.py:210`
+- `runtime_receipts`: `runtime_state.py:233`
+- `idempotency_records`: `runtime_state.py:251`
+- `task_claims`: `runtime_state.py:44`
+- `delegation_runs`: `runtime_state.py:61`
+- `artifact_records`: `runtime_state.py:94`
+- `session_events`: `runtime_state.py:180`
+
+Capabilities:
+
+| Question | Can answer? | Evidence |
+| --- | --- | --- |
+| What happened to `run_id X`? | Yes, for joined paths | `describe_run`: `runtime_state.py:2734`; `get_run_ledger`: `runtime_state.py:2765` |
+| Who spawned this child? | Yes, if `parent_run_id` is recorded | `list_child_runs`: `runtime_state.py:2718`; child receipts in `runtime_lifecycle.py:362` |
+| Was this side effect already performed? | Yes, for side effects that use idempotency helpers | `was_side_effect_performed`: `runtime_state.py:2710`; `idempotency_records`: `runtime_state.py:251` |
+| Which external A2A task maps to run? | Yes, for v2 A2A path | `get_execution_identity_by_external_a2a_task`: `runtime_state.py:2107` |
+| Which workflow ID maps to run? | Not proven | no mapping found in workflow grep |
+| Which proposal/gate maps to run? | Only possible via optional `proposal_id`; not wired broadly | `identity.py:51`, self-mod receipt helpers present |
+| Which ontology action maps to run? | Not proven | `ontology_action_id` absence count 0 |
+
+Critical caveat: the same store still exposes legacy sync methods that write runtime-looking rows without the canonical identity ledger.
+
+Evidence:
+
+- `create_task_claim_sync`: `runtime_state.py:1595`
+- `create_delegation_run_sync`: `runtime_state.py:1686`
+- Opportunity dispatcher uses both: `opportunity_dispatcher.py:184`, `opportunity_dispatcher.py:193`
+
+## 6. Idempotency Map
+
+Evidence level: `code-enforced/staged-v2-candidate`, `test-backed`.
+
+Canonical idempotency implementation:
+
+- Table: `idempotency_records` with primary key `(idempotency_key, side_effect_key)`: `runtime_state.py:251`.
+- Begin-before-side-effect helper: `try_begin_idempotent_side_effect`: `runtime_state.py:2501`.
+- Completion helper: `complete_idempotent_side_effect`: `runtime_state.py:2594`.
+- Query helper: `was_side_effect_performed`: `runtime_state.py:2710`.
+
+Proven joined users:
+
+- A2A submit path uses `try_begin_idempotent_side_effect_sync` before dispatch: `a2a/a2a_server.py:345`.
+- MessageBus `emit_event` uses begin-before-insert and completion: `message_bus.py:631`, `message_bus.py:675`.
+- RuntimeState tests cover duplicate side-effect prevention: `tests/test_runtime_state.py:192`.
+
+Unproven or missing users:
+
+- MessageBus `consume_events`: no receiver-side `message_consumed` receipt or idempotency guard found: `message_bus.py:683`.
+- `ToolRegistry.dispatch`: no identity/idempotency evidence: `tool_registry.py:129`.
+- `OntologyRegistry.execute_action`: no `ontology_action_id` or idempotency guard found: `ontology.py:763`.
+- Workflow/checkpoint execution: no `workflow_id -> run_id` idempotency mapping found.
+- Engine artifact store: artifact writes can happen without idempotency or runtime receipt: `engine/artifacts.py:90`.
+
+Verdict: idempotency is real where the new helpers are used; it is not a property of the repo yet.
+
+## 7. Parent/Child Lineage Map
+
+Evidence level: `code-enforced/staged-v2-candidate`.
+
+Joined path:
+
+- `ExecutionIdentity` includes `parent_run_id`: `identity.py:44`.
+- `execution_identities` stores `parent_run_id`: `runtime_state.py:218`.
+- `delegation_runs` stores `parent_run_id`: `runtime_state.py:66`.
+- `RuntimeLifecycle.record_delegation_run` emits `child_spawned` for queued/claimed/running child state: `runtime_lifecycle.py:362`.
+- It emits `child_completed` for completed/failed child state: `runtime_lifecycle.py:375`.
+- `RuntimeStateStore.list_child_runs` queries children: `runtime_state.py:2718`.
+
+Gaps:
+
+- `parent_task_id` is effectively absent from implementation search.
+- Opportunity dispatcher writes claim/run rows with no parent linkage: `opportunity_dispatcher.py:155`.
+- Workflow graph dependencies use graph-local topology and `workflow_id`, not runtime parent/child run IDs: `workflow.py:653`.
+- Swarm/delegation surfaces outside `RuntimeLifecycle` are not proven joined.
+
+Verdict: parent/child lineage is real in `RuntimeLifecycle`; it is not saturated across all delegation/scheduler paths.
+
+## 8. Artifact / Receipt / Message Linkage Map
+
+Evidence level: `code-enforced/staged-v2-candidate`, `inferred` for missing enforcement.
+
+| Surface | Carries run/trace/correlation? | Durable receipt? | Evidence | Verdict |
+| --- | --- | --- | --- | --- |
+| `RuntimeLifecycle.record_artifact` | Yes, via identity metadata | Yes: `artifact` and `artifact_written` | `runtime_lifecycle.py:416`, `runtime_lifecycle.py:453`, `runtime_lifecycle.py:474` | joined |
+| `RuntimeArtifactStore` | Optional run/trace args | Runtime record if `runtime_state` exists | `artifact_store.py:40`, `artifact_store.py:298` | adapter-ready |
+| `engine.ArtifactStore` | No run/trace | No runtime receipt | `engine/artifacts.py:15`, `engine/artifacts.py:90` | parallel lineage |
+| MessageBus `emit_event` | Yes when idempotency path used | idempotency receipts | `message_bus.py:615`, `message_bus.py:631` | joined for emit |
+| MessageBus `send` | No canonical identity | No runtime receipt | `message_bus.py:184` | missing |
+| MessageBus `consume_events` | Reads task/agent only | No `message_consumed` receipt found on consume path | `message_bus.py:683` | missing |
+| A2A completion receipt | Includes external A2A mapping | Yes | `a2a/a2a_server.py:367` | joined |
+| RuntimeStateStore receipts | run/task/trace/correlation/idempotency fields | Yes | `runtime_state.py:233` | canonical |
+
+## 9. Identity Drop / Fork Findings
+
+Evidence level: `code-enforced/staged-v2-candidate`, `absence-test-backed`.
+
+1. Legacy RuntimeStateStore sync helpers bypass the spine.
+   - Evidence: `create_task_claim_sync` at `runtime_state.py:1595`; `create_delegation_run_sync` at `runtime_state.py:1686`.
+   - Caller evidence: `opportunity_dispatcher.py:184`, `opportunity_dispatcher.py:193`.
+   - Risk: runtime-looking rows exist without `execution_identities` or `runtime_receipts`.
+
+2. `CorrelationContext` is a predecessor, not canonical execution identity.
+   - Evidence: only trace/proposal/session/cell fields in `correlation_context.py:53`.
+   - Risk: code can believe it is traced while missing run/claim/idempotency.
+
+3. `RuntimeEnvelope` is an event envelope, not workflow identity.
+   - Evidence: `RuntimeEnvelope` carries event/session/trace only: `runtime_contract.py:41`.
+   - Risk: event trace can fork from runtime trace unless adapted.
+
+4. Workflow and DurableWorkflow use `workflow_id` without a runtime run mapping.
+   - Evidence: `workflow.py:231`, `workflow_graph.py:240`, `durable_execution.py:99`.
+   - Risk: checkpoints cannot be reconstructed from `run_id` unless caller records a mapping.
+
+5. Raw MessageBus send/consume paths do not enforce identity.
+   - Evidence: direct `send`: `message_bus.py:184`; consume path: `message_bus.py:683`.
+   - Risk: event delivery and handler execution can be unjoinable to run ledger.
+
+6. Tool dispatch is identity-free.
+   - Evidence: `tool_registry.py:129`.
+   - Risk: side-effecting tools can bypass idempotency and receipts.
+
+7. Ontology action execution has no ontology action ID lineage.
+   - Evidence: `execute_action`: `ontology.py:763`; `ontology_action_id` absence count 0.
+   - Risk: domain mutations or declared action successes cannot be joined to runtime run unless caller wraps them.
+
+8. Artifact stores fork identity.
+   - Evidence: runtime artifact path optional run/trace: `artifact_store.py:40`; engine artifact path generates independent artifact IDs: `engine/artifacts.py:111`.
+   - Risk: artifacts can be real but unjoinable.
+
+9. Self-mod lifecycle IDs are incomplete.
+   - Evidence: `proposal_id` exists; `verification_id`, `promotion_id`, `revert_id` absence counts 0.
+   - Risk: proposal/gate/apply/verify/promote/revert cannot be reconstructed as one runtime chain.
+
+10. `a2a_task_id` is a legacy alias.
+    - Evidence: `a2a_bridge.py:229`; v2 canonical mapping uses `external_a2a_task_id`: `a2a/a2a_server.py:417`.
+    - Risk: old A2A paths may not be queryable via `get_execution_identity_by_external_a2a_task`.
+
+## 10. Canonical / Adapt / Quarantine Recommendations
+
+Evidence level: `code-enforced/staged-v2-candidate`, `inferred`.
+
+| Surface | Classification | Reason | Action |
+| --- | --- | --- | --- |
+| `ExecutionIdentity` | canonical | Central bundle with required runtime fields | Keep and make mandatory at selected boundaries |
+| `RuntimeStateStore.execution_identities` | canonical | Durable identity table keyed by run | Keep as runtime ledger root |
+| `RuntimeStateStore.runtime_receipts` | canonical | Durable receipt table | Keep and extend coverage |
+| `RuntimeStateStore.idempotency_records` | canonical | Pre-side-effect duplicate suppression | Keep and require before irreversible work |
+| `RuntimeLifecycle` | canonical seam | Writes identity, claims, runs, artifacts, receipts | Expand into TaskBoard/orchestrator default path |
+| A2A v2 local submit | canonical seam | Maps external A2A ID to runtime run and idempotency | Flip required mode once adapters land |
+| `spine/adapters.py` | adapter-ready | Defines surface mappings but not widely invoked | Wire into boundary modules |
+| TaskBoard | adapter-ready | Trace-only today | Add identity metadata adapter |
+| MessageBus emit | partially canonical | Joined when idempotency key supplied | Require envelope/identity on selected event subjects |
+| MessageBus send/consume | missing | No canonical identity receipt | Add consume receipt and receiver idempotency |
+| RuntimeArtifactStore | adapter-ready | Optional run/trace | Require identity for selected write paths |
+| Engine ArtifactStore | quarantine/projection | Independent artifact lineage | Wrap or mark graph/local artifact store |
+| Workflow/DurableWorkflow | transitional | Uses workflow_id lineage | Add mapping receipt or quarantine as graph-local |
+| Ontology execute_action | missing/tollbooth queued | Declares action contracts but no runtime identity/action ID | Queue C2 fix with identity receipt |
+| ToolRegistry | missing | Dispatch has no identity | Add tool-call boundary adapter |
+| Self-mod evolution | missing/transitional | Proposal IDs not joined to runtime receipts | Add self-mod lifecycle receipts |
+| CorrelationContext | predecessor/context | Useful trace context, not execution truth | Keep as source for `trace_id`, never as ledger substitute |
+| RuntimeEnvelope | transport envelope | Useful event validation, not workflow identity | Adapt to `ExecutionIdentity` at ingress/consume |
+| TUI/provider session IDs | projection/external | Provider-local sessions | Do not force canonical semantics; map when launching work |
+| File locks | local infrastructure | `lock_id` is lock-specific | Do not map unless locks guard runtime side effects |
+
+## 11. Blast-Radius Map
+
+Evidence level: `code-enforced/staged-v2-candidate`, `inferred`.
+
+If `ExecutionIdentity` becomes mandatory everywhere, these files/classes/functions are in the direct blast radius:
+
+Canonical spine:
+
+- `dharma_swarm/spine/identity.py`
+- `dharma_swarm/spine/adapters.py`
+- `dharma_swarm/runtime_state.py`
+- `dharma_swarm/runtime_lifecycle.py`
+
+Ingress and external protocol:
+
+- `dharma_swarm/a2a/a2a_server.py`
+- `dharma_swarm/a2a/a2a_bridge.py`
+- `dharma_swarm/a2a/node_gateway.py`
+- `dharma_swarm/gateway/base.py`
+- `dharma_swarm/gateway/telegram.py`
+
+Dispatch and scheduling:
+
+- `dharma_swarm/task_board.py`
+- `dharma_swarm/orchestrator.py`
+- `dharma_swarm/opportunity_dispatcher.py`
+- `dharma_swarm/contracts/runtime.py`
+- `dharma_swarm/contracts/runtime_adapters.py`
+
+Messaging and events:
+
+- `dharma_swarm/message_bus.py`
+- `dharma_swarm/runtime_contract.py`
+
+Artifacts:
+
+- `dharma_swarm/artifact_store.py`
+- `dharma_swarm/engine/artifacts.py`
+
+Graph/checkpoint:
+
+- `dharma_swarm/workflow.py`
+- `dharma_swarm/workflow_graph.py`
+- `dharma_swarm/durable_execution.py`
+- `dharma_swarm/checkpoint.py`
+
+Ontology/tools/governance:
+
+- `dharma_swarm/ontology.py`
+- `dharma_swarm/tool_registry.py`
+- `dharma_swarm/telic_seam.py`
+- `dharma_swarm/evolution.py`
+- `dharma_swarm/self_improve.py`
+- `dharma_swarm/sealed_packet_apply.py`
+
+Operator/TUI/provider projections:
+
+- `dharma_swarm/tui/engine/session_store.py`
+- `dharma_swarm/operator_core/session_store.py`
+- `dharma_swarm/tui/engine/adapters/codex.py`
+- `dharma_swarm/tui/engine/adapters/claude.py`
+
+Tests that must grow:
+
+- `tests/test_runtime_truth_spine_v1.py`
+- `tests/test_runtime_truth_spine_v2_adapters.py`
+- `tests/test_runtime_truth_spine_v2_evidence.py`
+- `tests/test_runtime_state.py`
+- `tests/test_runtime_lifecycle.py`
+- `tests/test_message_bus.py`
+- New tests for TaskBoard, ToolRegistry, ontology action receipts, workflow mapping, and self-mod lifecycle receipts.
+
+## 12. Tests and Falsification
+
+Evidence level: `test-backed`.
+
+Focused verification command:
+
+```bash
+env HOME=/private/tmp/dharma_spine_v2_identity_audit_home pytest -q \
+  tests/test_runtime_truth_spine_v2_evidence.py \
+  tests/test_runtime_truth_spine_v2_adapters.py \
+  tests/test_runtime_truth_spine_v1.py \
+  tests/test_runtime_state.py \
+  tests/test_runtime_lifecycle.py \
+  tests/test_message_bus.py
+```
+
+Result:
+
+```text
+34 passed, 1 warning in 2.69s
+```
+
+Falsification attempts:
+
+- Searched for every named identity field across Python/docs/config/test surfaces.
+- Verified `ExecutionIdentity` import/use sites. Runtime use is limited to `message_bus.py`, `runtime_lifecycle.py`, `runtime_state.py`, `a2a/a2a_server.py`, exports, adapters, and tests.
+- Searched for `create_task_claim_sync` and `create_delegation_run_sync`; found direct legacy callers in `opportunity_dispatcher.py`.
+- Searched for self-mod lifecycle IDs; `verification_id`, `promotion_id`, and `revert_id` were absent.
+- Searched for `ontology_action_id`; absent.
+- Searched low-count transport/provider aliases (`thread_id`, `lock_id`, `gate_id`, `a2a_task_id`) and separated external/local meanings from canonical runtime identity.
+- Verified adapter functions exist; usage search shows they are tested/exported but not yet broadly wired into runtime source.
+
+What would disprove the major findings:
+
+- A committed branch where `create_task_claim_sync` and `create_delegation_run_sync` require and persist `ExecutionIdentity`.
+- A call path where TaskBoard, ToolRegistry, raw MessageBus consume, ontology actions, workflow checkpoints, and self-mod proposal/apply/verify all invoke `ExecutionIdentity` adapters before side effects.
+- A runtime ledger query proving `workflow_id`, `proposal_id`, `ontology_action_id`, `message_id`, and `artifact_id` all map back to one `run_id`.
+
+## 13. Top Risks
+
+Evidence level: `code-enforced/staged-v2-candidate`, `test-backed` where noted.
+
+1. Duplicate execution despite ID fields.
+   - Cause: idempotency is enforced only on selected paths.
+   - Evidence: idempotency helper exists at `runtime_state.py:2501`, but ToolRegistry and consume paths lack it.
+
+2. Broken lineage from legacy RuntimeStateStore writes.
+   - Cause: old sync methods can create claims/runs without `execution_identities`.
+   - Evidence: `runtime_state.py:1595`, `runtime_state.py:1686`.
+
+3. Unjoinable artifacts.
+   - Cause: artifacts can be created with blank run/trace or through engine store only.
+   - Evidence: `artifact_store.py:40`, `engine/artifacts.py:90`.
+
+4. False idempotency.
+   - Cause: presence of `idempotency_key` is not the same as pre-side-effect guard.
+   - Evidence: pre-side-effect guard is proven only in A2A submit and MessageBus emit, not all consumers.
+
+5. Orphan child runs.
+   - Cause: parent-child receipts exist only through `RuntimeLifecycle.record_delegation_run`.
+   - Evidence: `runtime_lifecycle.py:362`; legacy `opportunity_dispatcher.py:155` creates independent IDs.
+
+6. Audit gaps around workflow/checkpoint lineage.
+   - Cause: `workflow_id` is separate from `run_id`.
+   - Evidence: `workflow.py:231`, `workflow_graph.py:240`, `durable_execution.py:99`.
+
+7. Governance bypasses.
+   - Cause: ontology action and tool dispatch are not identity/idempotency receipt boundaries.
+   - Evidence: `ontology.py:763`, `tool_registry.py:129`.
+
+8. Self-mod chain is not reconstructable as one runtime lineage.
+   - Cause: missing verification/promotion/revert IDs and unused self-mod receipt helpers.
+   - Evidence: absence counts 0 for `verification_id`, `promotion_id`, `revert_id`; helpers at `runtime_state.py:2364`.
+
+## 14. Next Implementation Slices
+
+Exactly three prioritized slices.
+
+### Slice 1: Close the RuntimeStateStore Legacy Bypass
+
+Problem:
+
+`RuntimeStateStore` has canonical identity/receipt tables, but `create_task_claim_sync` and `create_delegation_run_sync` still write runtime-looking state without `ExecutionIdentity`.
+
+Why first:
+
+This is the deepest identity fork. If the ledger itself accepts non-spine rows, every downstream query can lie by omission.
+
+Files:
+
+- `dharma_swarm/runtime_state.py`
+- `dharma_swarm/opportunity_dispatcher.py`
+- `tests/test_runtime_state.py`
+- New/updated tests for OpportunityDispatcher identity propagation.
+
+Target architecture:
+
+All claim/run creation either:
+
+- receives an `ExecutionIdentity` and writes `execution_identities` plus `runtime_receipts`, or
+- is explicitly named and marked legacy/quarantined with tests proving it is not used on canonical paths.
+
+Migration steps:
+
+1. Add optional `identity` parameter to legacy sync helpers.
+2. If helper is used in canonical mode, require identity and record it before inserting claim/run rows.
+3. Update `OpportunityDispatcher` to construct one identity and pass it through.
+4. Add invariant test: every `delegation_runs.run_id` created by canonical helpers has an `execution_identities` row and at least one receipt.
+5. Leave a deprecated compatibility shim only for tests that explicitly assert legacy behavior.
+
+Success criteria:
+
+- No selected runtime path can create a `run_id` without `ExecutionIdentity`.
+- `get_run_ledger(run_id)` reconstructs claim, run, receipts, artifacts, idempotency, and child rows for OpportunityDispatcher-created work.
+
+### Slice 2: Promote Adapters Into Boundary Tollbooths
+
+Problem:
+
+`spine/adapters.py` defines the right compatibility surface, but broad runtime modules do not call it yet.
+
+Why second:
+
+Once the ledger refuses bypasses, edge surfaces need cheap adapters rather than broad rewrites.
+
+Files:
+
+- `dharma_swarm/spine/adapters.py`
+- `dharma_swarm/task_board.py`
+- `dharma_swarm/message_bus.py`
+- `dharma_swarm/artifact_store.py`
+- `dharma_swarm/tool_registry.py`
+- `tests/test_runtime_truth_spine_v2_adapters.py`
+- New tests for TaskBoard, MessageBus consume, artifact write, and tool dispatch identity requirements.
+
+Target architecture:
+
+Each boundary has a deterministic adapter:
+
+- accept an existing `ExecutionIdentity`,
+- derive only from approved fields,
+- fail closed when required,
+- emit a runtime receipt before side effects.
+
+Migration steps:
+
+1. Add `require_identity` toggles defaulting false for compatibility.
+2. Wire adapters into TaskBoard create/update metadata, MessageBus consume, RuntimeArtifactStore writes, and ToolRegistry dispatch.
+3. Add tests where missing identity fails when the toggle is true.
+4. Add tests proving artifacts/messages/tool calls carry `run_id`, `trace_id`, `correlation_id`, and idempotency where required.
+
+Success criteria:
+
+- At least four more surfaces become adapter-ready or joined without broad rewrites.
+- Field presence is no longer mistaken for enforcement.
+
+### Slice 3: Add Explicit Mapping Receipts for Parallel Lineages
+
+Problem:
+
+Workflow IDs, event IDs, message IDs, artifact IDs, proposal IDs, gate IDs, provider session IDs, and A2A legacy IDs currently have independent meanings. Some are valid local identities, but they are not always joinable to a runtime run.
+
+Why third:
+
+These systems should not all be renamed. They need mapping receipts that preserve local meaning while making runtime reconstruction possible.
+
+Files:
+
+- `dharma_swarm/runtime_state.py`
+- `dharma_swarm/runtime_contract.py`
+- `dharma_swarm/workflow.py`
+- `dharma_swarm/workflow_graph.py`
+- `dharma_swarm/durable_execution.py`
+- `dharma_swarm/message_bus.py`
+- `dharma_swarm/ontology.py`
+- `dharma_swarm/evolution.py`
+- `dharma_swarm/sealed_packet_apply.py`
+- `tests/test_runtime_truth_spine_v2_evidence.py`
+- New tests for workflow/proposal/ontology mapping receipts.
+
+Target architecture:
+
+Runtime ledger can answer:
+
+- which `run_id` owns `workflow_id X`,
+- which `run_id` owns `proposal_id X`,
+- which `run_id` emitted/consumed `event_id X`,
+- which `run_id` wrote `artifact_id X`,
+- which `run_id` requested/applied ontology action X.
+
+Migration steps:
+
+1. Add generic `identity_mapping` or typed receipt metadata for external/local IDs.
+2. Record `workflow_started`, `workflow_checkpointed`, `proposal_created`, `gate_evaluated`, `ontology_action_requested`, and `ontology_action_applied` receipts.
+3. Treat `a2a_task_id` as a read-only legacy alias mapping to `external_a2a_task_id`.
+4. Add ledger query tests for every mapped ID type.
+
+Success criteria:
+
+- Parallel local IDs remain valid but become ledger-queryable.
+- No major runtime artifact, event, proposal, workflow, or ontology action is unjoinable to `run_id` on selected paths.

--- a/reports/governance/runtime_truth_spine_v2_evidence_plan.md
+++ b/reports/governance/runtime_truth_spine_v2_evidence_plan.md
@@ -1,0 +1,150 @@
+# Runtime Truth Spine v2 Evidence Bundle Plan
+
+Subagent: Tracer/Evidence Captain
+
+Audit source boundary:
+
+- Clean audit baseline: `d5ebc456` from the clean-main architecture audit.
+- v2 worktree: `/Users/dhyana/worktrees/dharma_swarm_runtime_truth_spine_v2`.
+- v2 HEAD inspected by this subagent: `2737b26d7ed8dbee9c828ba64d5a6c9ec128b859`.
+- Source truth rule: tracked clean-main files are source truth. Current v2 working-tree edits are build candidates until committed. Untracked files are evidence candidates only after they are intentionally added.
+- External systems: no live Palantir, NATS, Temporal, or paid LLM calls.
+
+## Evidence Bundle Layout
+
+The final v2 evidence bundle should be written under:
+
+`reports/governance/runtime_truth_spine_v2_evidence/`
+
+Expected files:
+
+- `evidence_manifest.md` - SHA, branch, dirty status, test commands, runtime restrictions.
+- `surface_matrix.md` - every major organ with `joined`, `adapter-ready`, `quarantine`, or `missing`.
+- `surface_matrix.json` - machine-readable copy of the same matrix.
+- `tracer_payload.json` - fixed TRCR-9999-ALPHA IDs and expected fields.
+- `id_mapping_table.md` - external A2A task ID, task ID, run ID, trace ID, correlation ID, claim ID, idempotency key, artifact ID.
+- `trace_timeline.md` - ingress, claim, run, artifact, idempotency, completion receipts.
+- `sqlite_query_results.txt` - selected read-only SQL proving runtime tables contain the chain.
+- `pytest_results.txt` - exact test command and result.
+- `verdict.md` - coverage percentage, proven surfaces, quarantines, missing surfaces, next slices.
+
+## Surface Matrix
+
+Coverage definition:
+
+- `joined`: carries Canonical ExecutionIdentity and writes RuntimeStateStore facts/receipts on the selected path.
+- `adapter-ready`: can accept or emit ExecutionIdentity through a compatibility surface, but enforcement is not complete.
+- `quarantine`: intentionally excluded from runtime truth claims until wrapped or demoted.
+- `missing`: no sufficient identity/ledger enforcement on the selected evidence surface.
+
+| Surface | Status | Evidence expectation |
+| --- | --- | --- |
+| A2A local submit | joined | RuntimeStateStore identity, A2A receipt, idempotency record before handler side effect |
+| A2A HTTP node gateway | adapter-ready | Top-level identity fields are parsed/serialized across request/response |
+| RuntimeLifecycle task claim | joined | `record_task_claim(require_identity=True)` fails without identity and writes receipt with run/trace |
+| RuntimeLifecycle delegation run | joined | `record_delegation_run(require_identity=True)` writes run facts and receipt |
+| RuntimeLifecycle artifact record | joined | `record_artifact(require_identity=True)` persists artifact with run_id and trace_id |
+| MessageBus emit_event with idempotency_key | joined | RuntimeStateStore idempotency begins before event insert; duplicate emits no second event |
+| Orchestrator result persistence | adapter-ready | Provenance/artifact path carries run_id, trace_id, correlation_id; hard boundary still pending |
+| TaskBoard task metadata | adapter-ready | Metadata can carry execution_identity; mandatory enforcement still pending |
+| Checkpoint human interrupt | adapter-ready | Checkpoint can carry identity; durable wait/approval receipts still pending |
+| Ontology execute_action | missing | C2 tollbooth slice must enforce `ActionDef.modifies` and `requires_approval` |
+| Tool registry side effects | missing | Tool calls need mandatory identity plus side_effect_intent/complete receipts |
+| Graph/workflow checkpoints | missing | Graph checkpoint identity and resume receipts are not saturated |
+| Self-modification proposals | missing | proposal/gate/apply/verify/promote/revert receipts are not saturated |
+| NATS/JetStream path | quarantine | Not selected for local deterministic evidence; no live NATS calls |
+| MCP server/tool access | missing | MCP/tool boundary needs an adapter before side effects |
+| Free-text file extraction | quarantine | Regex path writes must stay quarantined until deterministic tollbooth exists |
+
+Coverage:
+
+- Classified surfaces: 16/16 = 100%.
+- Joined surfaces: 5/16 = 31.25%.
+- Joined or adapter-ready surfaces: 9/16 = 56.25%.
+- Missing or quarantined surfaces: 7/16 = 43.75%.
+
+## TRCR-9999-ALPHA Expectations
+
+Fixed IDs:
+
+- `external_a2a_task_id`: `TRCR-9999-ALPHA`
+- `task_id`: `task-trcr-9999-alpha`
+- `run_id`: `run-trcr-9999-alpha`
+- `trace_id`: `trc-trcr-9999-alpha`
+- `correlation_id`: `corr-trcr-9999-alpha`
+- `claim_id`: `claim-trcr-9999-alpha`
+- `artifact_id`: `artifact-trcr-9999-alpha`
+- `idempotency_key`: `idem-trcr-9999-alpha`
+
+Required proof:
+
+- `RuntimeStateStore.get_run_ledger(run_id)` returns identity, run, artifacts, receipts, children, and idempotency records.
+- A2A ingress maps `TRCR-9999-ALPHA` to internal `task_id`, `run_id`, `trace_id`, and `correlation_id`.
+- Parent run can answer "who spawned this child" through `list_child_runs(parent_run_id)` / `get_run_ledger(parent).children`.
+- Every selected artifact has non-empty `run_id` and `trace_id`.
+- A2A handler side effect sees an idempotency row with status `started` before handler execution.
+- MessageBus event insert sees RuntimeStateStore idempotency before the event row exists.
+- Duplicate idempotency key does not repeat the selected side effect.
+
+## Missing Identity Failure Boundaries
+
+Selected hard-fail boundaries:
+
+- `RuntimeLifecycle.record_task_claim(..., require_identity=True)`
+- `RuntimeLifecycle.record_delegation_run(..., require_identity=True)`
+- `RuntimeLifecycle.record_artifact(..., require_identity=True)`
+
+Expected result:
+
+- Missing trace/correlation/claim identity raises `MissingExecutionIdentity`.
+- No partial rows are written to `task_claims`, `delegation_runs`, or `artifact_records`.
+
+Not yet hard-fail by design:
+
+- A2A local ingress currently adapts and fills missing fields where possible. It is selected as an adapter/join surface, not as the missing-identity hard boundary.
+
+## Tests Added By This Subagent
+
+New test scaffold:
+
+`tests/test_runtime_truth_spine_v2_evidence.py`
+
+Test cases:
+
+- `test_v2_surface_matrix_is_classified_and_quantified`
+- `test_v2_missing_identity_fails_selected_runtime_boundaries`
+- `test_v2_trcr_9999_alpha_reconstructs_chain_of_custody`
+- `test_v2_a2a_idempotency_exists_before_handler_side_effect`
+- `test_v2_message_bus_idempotency_happens_before_event_insert`
+
+## Verification Commands
+
+Run from `/Users/dhyana/worktrees/dharma_swarm_runtime_truth_spine_v2`:
+
+```bash
+python -m compileall -q dharma_swarm/runtime_state.py dharma_swarm/runtime_lifecycle.py dharma_swarm/a2a/a2a_server.py dharma_swarm/a2a/node_gateway.py dharma_swarm/message_bus.py dharma_swarm/checkpoint.py dharma_swarm/orchestrator.py dharma_swarm/spine
+pytest -q tests/test_runtime_truth_spine_v1.py tests/test_runtime_truth_spine_v2_evidence.py
+pytest -q tests/test_runtime_state.py tests/test_runtime_lifecycle.py tests/test_a2a_spec_conformance.py tests/test_message_bus.py tests/test_checkpoint.py
+git diff --check
+```
+
+## Final Report Outline
+
+The synthesis report should include:
+
+1. Clean-Source Boundary
+2. Changed Files
+3. Surface Coverage Table
+4. TRCR-9999-ALPHA Chain of Custody
+5. Missing Identity Failure Results
+6. Idempotency Before Side Effect Results
+7. Artifact and Side-Effect Identity Results
+8. Quarantined Surfaces
+9. Remaining Gaps
+10. Next Three Slices
+
+Next three slices:
+
+1. Make A2A ingress require externally supplied identity for production-mode boundaries instead of always adapting missing fields.
+2. Convert C2 ontology tollbooth declarations into enforced `ActionDef.modifies` and `requires_approval` behavior with ontology action receipts.
+3. Add mandatory side_effect_intent and side_effect_complete receipts to tool, graph checkpoint, and self-modification proposal paths.

--- a/reports/governance/runtime_truth_spine_v2_report.md
+++ b/reports/governance/runtime_truth_spine_v2_report.md
@@ -1,0 +1,247 @@
+# Runtime Truth Spine v2 Report
+
+## Executive Summary
+
+Runtime Truth Spine v2 was built from a clean worktree at current `origin/main`, not from the dirty developer checkout.
+
+- Worktree: `/Users/dhyana/worktrees/dharma_swarm_runtime_truth_spine_v2`
+- Branch: `codex/runtime-truth-spine-v2`
+- Base SHA: `2737b26d7ed8dbee9c828ba64d5a6c9ec128b859`
+- Base commit: `feat(governance): schema-alignment gate (KARMA) + typed-proposal envelope [Stage-1 additive, post-OMS] (#408)`
+- Tracked files at base: 2737
+- External systems: no live Palantir, NATS, Temporal, or paid LLM calls were made.
+
+The v1 claim was independently verified and corrected:
+
+- Clean `HEAD` did not contain the v1 spine. Static checks found no `ExecutionIdentity`, `runtime_receipts`, idempotency ledger table, or `TRCR-9999-ALPHA` tracer.
+- The v1 spine was ported into this clean v2 branch from the v1 worktree, then verified with tests.
+- v2 broadens the spine with compatibility adapters, receipt vocabulary and helpers, fail-closed human interrupt behavior, a gated free-text result path, surface coverage tests, and evidence documentation.
+
+Final verification:
+
+- `159 passed, 2 warnings in 11.99s`
+- `python -m compileall` passed on the changed runtime modules.
+- `git diff --check` passed before the final report was written.
+
+## Six-Subagent Build
+
+Exactly six bounded subagents were spawned and all completed before synthesis.
+
+1. Surface Inventory Agent, Poincare, `019e830f-d1bf-7791-9c7f-9c361f2927c7`
+   - Mapped ingress, dispatch, event, artifact, tool, ontology, graph, and self-mod surfaces.
+   - Classified each as joined, adapter-ready, quarantine/transitional, or missing.
+
+2. V1 Verification Agent, Halley, `019e830f-e9fd-7ea3-bef9-f070c27de852`
+   - Falsified v1 presence on clean `HEAD`.
+   - Verified the ported v1 candidate with focused and adjacent test suites.
+   - Wrote `reports/governance/runtime_truth_spine_v2_subagent2_v1_verification.md`.
+
+3. Organ Adapter Agent, Sagan, `019e830f-fd39-7db0-be92-84621d5c0ea9`
+   - Added spine adapter helpers in `dharma_swarm/spine/adapters.py`.
+   - Covered A2A tasks, TaskBoard tasks, Orchestrator dispatch, MessageBus/event payloads, artifact records, tool calls, ontology action payloads, graph/checkpoint payloads, and self-mod/proposal payloads.
+
+4. Receipt Saturation Agent, Archimedes, `019e8310-1662-70b2-9809-bdecb8ae17f1`
+   - Added receipt vocabulary and RuntimeStateStore helper APIs.
+   - Added durable receipt support for side-effect intent/completion, artifact writes, message consumption, idempotency consumption, ontology action receipts, child run receipts, and self-mod receipts.
+
+5. Bypass/Tollbooth Agent, Huygens, `019e8310-35db-73c3-90bb-2369debda844`
+   - Changed `InterruptGate` to fail closed by default.
+   - Gated Orchestrator free-text file writes behind explicit structured metadata.
+   - Queued C2 ontology enforcement for the next slice instead of overmixing it into this runtime spine build.
+
+6. Tracer/Evidence Captain, Peirce, `019e8310-563d-7ed2-b86d-cbbd9b041897`
+   - Added v2 evidence tests and surface matrix.
+   - Verified tracer reconstruction, missing identity failures, idempotency before side effects, and artifact identity fields.
+   - Wrote `reports/governance/runtime_truth_spine_v2_evidence_plan.md`.
+
+## Changed Files
+
+Runtime spine and adapters:
+
+- `dharma_swarm/spine/identity.py`
+- `dharma_swarm/spine/adapters.py`
+- `dharma_swarm/spine/__init__.py`
+- `dharma_swarm/runtime_state.py`
+- `dharma_swarm/runtime_lifecycle.py`
+
+Ingress, dispatch, events, artifacts, and tollbooths:
+
+- `dharma_swarm/a2a/a2a_server.py`
+- `dharma_swarm/a2a/node_gateway.py`
+- `dharma_swarm/message_bus.py`
+- `dharma_swarm/orchestrator.py`
+- `dharma_swarm/checkpoint.py`
+
+Tests and evidence:
+
+- `tests/test_runtime_truth_spine_v1.py`
+- `tests/test_runtime_truth_spine_v2_adapters.py`
+- `tests/test_runtime_truth_spine_v2_evidence.py`
+- `tests/test_runtime_truth_spine_v2_tollbooth.py`
+- `tests/test_runtime_state.py`
+- `tests/test_runtime_lifecycle.py`
+- `tests/test_checkpoint.py`
+- `reports/governance/runtime_truth_spine_v2_subagent2_v1_verification.md`
+- `reports/governance/runtime_truth_spine_v2_evidence_plan.md`
+- `reports/governance/runtime_truth_spine_v2_report.md`
+
+## Main Implementation Points
+
+Canonical identity:
+
+- `ExecutionIdentity` is defined in `dharma_swarm/spine/identity.py:29`.
+- `RuntimeLifecycle.ensure_execution_identity` enforces identity creation and persistence for selected runtime paths in `dharma_swarm/runtime_lifecycle.py:76`.
+
+Compatibility adapters:
+
+- `identity_from_carrier` in `dharma_swarm/spine/adapters.py:155`
+- `adapt_execution_identity` in `dharma_swarm/spine/adapters.py:276`
+- `runtime_receipt_kwargs` in `dharma_swarm/spine/adapters.py:303`
+
+Durable ledger and receipts:
+
+- Runtime receipt vocabulary starts at `dharma_swarm/runtime_state.py:308`.
+- Side-effect intent/completion helpers start at `dharma_swarm/runtime_state.py:2229`.
+- Message consumption helper starts at `dharma_swarm/runtime_state.py:2299`.
+- Ontology action receipt helper starts at `dharma_swarm/runtime_state.py:2314`.
+- Self-mod receipt helper starts at `dharma_swarm/runtime_state.py:2364`.
+- Run ledger reconstruction starts at `dharma_swarm/runtime_state.py:2765`.
+
+Tollbooth changes:
+
+- `InterruptGate` now defaults to `auto_approve=False` in `dharma_swarm/checkpoint.py:78` and `dharma_swarm/checkpoint.py:102`.
+- Orchestrator free-text path extraction now requires `task_metadata.get("allow_free_text_result_path") is True` in `dharma_swarm/orchestrator.py:2467`.
+
+## Surface Coverage
+
+The v2 evidence matrix classifies 16 surfaces.
+
+- Classified: 16 / 16, 100%
+- Joined: 5 / 16, 31.25%
+- Joined or adapter-ready: 9 / 16, 56.25%
+
+Joined surfaces include the selected runtime spine path:
+
+- A2A/local ingress
+- RuntimeLifecycle delegation path
+- RuntimeStateStore ledger
+- selected artifact/completion receipt path
+- selected idempotency path
+
+Adapter-ready surfaces include:
+
+- TaskBoard task payloads
+- Orchestrator dispatch payloads
+- MessageBus/event payloads
+- tool call payloads
+- ontology action payloads
+- graph/checkpoint payloads
+- self-mod/proposal payloads
+
+Remaining quarantined or missing surfaces are listed in the evidence plan and should not be treated as canonical until joined or wrapped.
+
+## Done Criteria Status
+
+- V1 claims independently verified or corrected: done. Clean `HEAD` lacked v1; ported candidate passes tests.
+- Every major organ has status joined, adapter, quarantine, or missing: done in the v2 surface matrix.
+- At least three real surfaces beyond original tracer path wired or adapter-ready: done.
+  - Tool call payloads can carry adapted identity.
+  - Ontology action payloads can carry adapted identity.
+  - Graph/checkpoint payloads can carry adapted identity.
+  - Self-mod/proposal payloads can carry adapted identity.
+  - MessageBus/event payloads can carry adapted identity.
+- No artifact/side effect in selected surfaces lacks `run_id` and `trace_id`: done for selected tested surfaces.
+- Duplicate idempotency tested before side effects: done for selected RuntimeStateStore/A2A and MessageBus paths.
+- Missing identity fails on selected runtime boundaries: done for selected RuntimeStateStore and RuntimeLifecycle boundaries.
+- TRCR-9999-ALPHA tracer reconstructs ingress-to-artifact by `run_id`, `trace_id`, and `correlation_id`: done in `tests/test_runtime_truth_spine_v2_evidence.py`.
+
+## Tests Run
+
+Focused and adjacent verification:
+
+```bash
+env HOME=/private/tmp/dharma_spine_v2_test_home pytest -q \
+  tests/test_runtime_truth_spine_v1.py \
+  tests/test_runtime_truth_spine_v2_adapters.py \
+  tests/test_runtime_truth_spine_v2_evidence.py \
+  tests/test_runtime_truth_spine_v2_tollbooth.py \
+  tests/test_runtime_state.py \
+  tests/test_runtime_lifecycle.py \
+  tests/test_a2a_spec_conformance.py \
+  tests/test_message_bus.py \
+  tests/test_checkpoint.py \
+  tests/test_orchestrator.py
+```
+
+Result:
+
+```text
+159 passed, 2 warnings in 11.99s
+```
+
+Compile verification:
+
+```bash
+python -m compileall -q \
+  dharma_swarm/spine/identity.py \
+  dharma_swarm/spine/adapters.py \
+  dharma_swarm/runtime_state.py \
+  dharma_swarm/runtime_lifecycle.py \
+  dharma_swarm/a2a/a2a_server.py \
+  dharma_swarm/a2a/node_gateway.py \
+  dharma_swarm/message_bus.py \
+  dharma_swarm/orchestrator.py \
+  dharma_swarm/checkpoint.py
+```
+
+Result: passed.
+
+Diff whitespace check:
+
+```bash
+git diff --check
+```
+
+Result: passed before this final report was added.
+
+## Remaining Gaps
+
+1. C2 ontology tollbooth is still queued, not completed in this slice.
+   - `ActionDef.modifies` and `ActionDef.requires_approval` still need to become enforced runtime contracts.
+   - This was intentionally not mixed into the v2 runtime spine saturation work.
+
+2. Receipt helpers are broader than their call-site coverage.
+   - RuntimeStateStore can now record message, ontology, self-mod, idempotency, side-effect, artifact, and child receipts.
+   - Actual hot-path call sites still need to be wired one by one for MessageBus consumption, OntologyRegistry action execution, and self-mod proposal/gate/apply/verify/promote/revert.
+
+3. More runtime boundaries need mandatory identity.
+   - TaskBoard create/create_batch, ArtifactStore and EngineArtifactStore writes, ToolRegistry side effects, graph/checkpoint resume, and ontology action execution should reject missing identity or adapt from a parent identity.
+
+4. Compatibility adapters are intentionally permissive.
+   - They make identity carryable across organs.
+   - They do not yet make every organ canonical. Canonical enforcement belongs at the runtime ledger boundary and selected hot-path gateways.
+
+5. Context+ static analysis was not accepted as final evidence.
+   - The Context+ tool targeted `/Users/dhyana/dharma_swarm`, the dirty default checkout, not this clean v2 worktree.
+   - Compile and pytest results from this clean worktree are the valid evidence.
+
+## Next Three Slices
+
+1. Close the C2 ontology tollbooth.
+   - Enforce `ActionDef.modifies` and `ActionDef.requires_approval` in the action execution chokepoint.
+   - Write `ontology_action_requested` before the mutation and `ontology_action_applied` only after the mutation.
+   - Tests must prove that declared modifies actually mutate, approval-required actions block without approval, and missing identity fails.
+
+2. Wire receipt helpers into hot call sites.
+   - MessageBus: record `message_consumed` and idempotency receipts before handler side effects.
+   - Ontology: record action request/apply receipts around enforced mutations.
+   - Self-mod: record proposal, gate, apply, verify, promote, and revert receipts as a closed loop.
+   - Tests must prove ledger reconstruction by `run_id`, `trace_id`, `correlation_id`, and proposal/action/message IDs.
+
+3. Promote adapter-ready surfaces to mandatory identity boundaries.
+   - TaskBoard task creation, artifact stores, tool runner side effects, graph/checkpoint resume, and self-mod proposal ingestion should require identity or derive it from a parent identity.
+   - Tests must prove missing identity fails and duplicate idempotency does not repeat side effects.
+
+## Bottom Line
+
+The v2 branch does not claim the entire platform is canonical yet. It makes the spine real on one tracer-backed path, verifies v1 instead of trusting it, broadens identity compatibility across connected organs, adds durable receipt vocabulary and helper APIs, closes two concrete bypasses, and leaves a classified surface matrix for the remaining saturation work.

--- a/reports/governance/runtime_truth_spine_v2_subagent2_v1_verification.md
+++ b/reports/governance/runtime_truth_spine_v2_subagent2_v1_verification.md
@@ -1,0 +1,140 @@
+# Runtime Truth Spine v2 - Subagent 2 V1 Verification
+
+Role: V1 Verification Agent
+
+Worktree: `/Users/dhyana/worktrees/dharma_swarm_runtime_truth_spine_v2`
+
+HEAD: `2737b26d7ed8dbee9c828ba64d5a6c9ec128b859`
+
+## Verdict
+
+Clean HEAD at `2737b26d` does not contain the v1 Runtime Truth Spine implementation. The current v2 working tree does contain the v1 candidate implementation, but it is dirty: seven implementation files are staged, while `dharma_swarm/spine/identity.py` and `tests/test_runtime_truth_spine_v1.py` are untracked.
+
+Therefore:
+
+- Clean-HEAD claim status: falsified.
+- Dirty v2 working-tree candidate status: verified by focused and adjacent tests.
+
+## Exact Commands And Results
+
+```bash
+git -C /Users/dhyana/worktrees/dharma_swarm_runtime_truth_spine_v2 rev-parse HEAD
+```
+
+Result: `2737b26d7ed8dbee9c828ba64d5a6c9ec128b859`
+
+```bash
+git -C /Users/dhyana/worktrees/dharma_swarm_runtime_truth_spine_v2 status --short --branch
+```
+
+Initial result: `## codex/runtime-truth-spine-v2...origin/main`
+
+Later exact porcelain result after inspecting the working tree:
+
+```text
+M  dharma_swarm/a2a/a2a_server.py
+M  dharma_swarm/a2a/node_gateway.py
+M  dharma_swarm/message_bus.py
+M  dharma_swarm/orchestrator.py
+M  dharma_swarm/runtime_lifecycle.py
+M  dharma_swarm/runtime_state.py
+M  dharma_swarm/spine/__init__.py
+?? dharma_swarm/spine/identity.py
+?? tests/test_runtime_truth_spine_v1.py
+?? reports/governance/runtime_truth_spine_v2_subagent2_v1_verification.md
+```
+
+```bash
+git -C /Users/dhyana/worktrees/dharma_swarm_runtime_truth_spine_v2 grep -n "ExecutionIdentity\|MissingExecutionIdentity\|get_run_ledger\|runtime_receipts\|idempotency_records\|try_begin_idempotent_side_effect\|TRCR-9999-ALPHA\|trcr-9999-alpha\|external_a2a_task_id" HEAD -- dharma_swarm tests
+```
+
+Result: no matches, exit code 1.
+
+```bash
+git -C /Users/dhyana/worktrees/dharma_swarm_runtime_truth_spine_v2 ls-tree -r --name-only HEAD | rg "^(dharma_swarm/spine/identity.py|tests/test_runtime_truth_spine_v1.py)$"
+```
+
+Result: no matches, exit code 1.
+
+```bash
+git -C /Users/dhyana/worktrees/dharma_swarm_runtime_truth_spine_v2 ls-files --error-unmatch dharma_swarm/spine/identity.py
+git -C /Users/dhyana/worktrees/dharma_swarm_runtime_truth_spine_v2 ls-files --error-unmatch tests/test_runtime_truth_spine_v1.py
+```
+
+Result: both fail with `pathspec ... did not match any file(s) known to git`.
+
+```bash
+git -C /Users/dhyana/worktrees/dharma_swarm_runtime_truth_spine_v2 diff --cached --stat
+```
+
+Result:
+
+```text
+dharma_swarm/a2a/a2a_server.py    |  97 ++++++
+dharma_swarm/a2a/node_gateway.py  |  33 +-
+dharma_swarm/message_bus.py       |  79 ++++-
+dharma_swarm/orchestrator.py      |  39 ++-
+dharma_swarm/runtime_lifecycle.py | 219 +++++++++++-
+dharma_swarm/runtime_state.py     | 715 +++++++++++++++++++++++++++++++++++++-
+dharma_swarm/spine/__init__.py    |   8 +
+7 files changed, 1161 insertions(+), 29 deletions(-)
+```
+
+```bash
+env HOME=/private/tmp/dharma_spine_v2_verify_home python -m compileall -q dharma_swarm/spine/identity.py dharma_swarm/runtime_state.py dharma_swarm/runtime_lifecycle.py dharma_swarm/a2a/a2a_server.py dharma_swarm/a2a/node_gateway.py dharma_swarm/message_bus.py dharma_swarm/orchestrator.py
+```
+
+Result: passed, exit code 0.
+
+```bash
+env HOME=/private/tmp/dharma_spine_v2_verify_home pytest -q tests/test_runtime_truth_spine_v1.py
+```
+
+Result: `4 passed, 1 warning in 0.95s`.
+
+```bash
+env HOME=/private/tmp/dharma_spine_v2_verify_home pytest -q tests/test_runtime_truth_spine_v1.py tests/test_runtime_state.py tests/test_runtime_lifecycle.py tests/test_a2a_spec_conformance.py tests/test_message_bus.py tests/test_orchestrator.py
+```
+
+Result: `133 passed, 2 warnings in 11.62s`.
+
+```bash
+git -C /Users/dhyana/worktrees/dharma_swarm_runtime_truth_spine_v2 diff --cached --check
+git -C /Users/dhyana/worktrees/dharma_swarm_runtime_truth_spine_v2 diff --check
+```
+
+Result: both passed, exit code 0.
+
+## Working-Tree Candidate Evidence
+
+The current dirty v2 working tree contains:
+
+- `dharma_swarm/spine/identity.py`: defines `ExecutionIdentity`, `MissingExecutionIdentity`, and `require_execution_identity`.
+- `dharma_swarm/runtime_state.py`: adds `execution_identities`, `runtime_receipts`, `idempotency_records`, artifact `trace_id`, `record_execution_identity*`, `record_runtime_receipt*`, `try_begin_idempotent_side_effect*`, `complete_idempotent_side_effect*`, `was_side_effect_performed`, `list_child_runs`, `describe_run`, and `get_run_ledger`.
+- `dharma_swarm/runtime_lifecycle.py`: adds `ensure_execution_identity`, `require_identity` controls, task-claim/delegation/artifact receipts, and artifact `trace_id` propagation.
+- `dharma_swarm/a2a/a2a_server.py`: adds RuntimeStateStore-backed A2A identity mapping and idempotency before handler dispatch.
+- `dharma_swarm/message_bus.py`: adds optional RuntimeStateStore-backed idempotency before event insertion.
+- `tests/test_runtime_truth_spine_v1.py`: proves missing identity failure, TRCR-9999-ALPHA run reconstruction, A2A external/internal mapping, artifact run_id/trace_id, and duplicate idempotency suppression.
+
+## V1 Claim Status
+
+| Claim | Clean HEAD 2737b26d | Dirty v2 working-tree candidate |
+|---|---|---|
+| `ExecutionIdentity` exists | falsified | verified |
+| `RuntimeStateStore` has receipt tables/APIs | falsified | verified |
+| `RuntimeStateStore` has idempotency APIs | falsified | verified |
+| `get_run_ledger(run_id)` exists | falsified | verified |
+| TRCR-9999-ALPHA tests exist | falsified | verified |
+| A2A maps external task ID to internal run/task/trace/correlation | falsified | verified by test |
+| Artifacts carry `run_id` and `trace_id` in selected path | falsified | verified by test and SQL assertion |
+| Duplicate idempotency key gates before side effect | falsified | verified by A2A side-effect count and MessageBus event count |
+
+## Corrections Required
+
+1. Decide whether Subagent 2 should treat staged/untracked v2 working-tree changes as the implementation candidate. If yes, add the untracked `dharma_swarm/spine/identity.py` and `tests/test_runtime_truth_spine_v1.py` to the candidate patch; without them the staged code imports an untracked module and the proof test is not tracked.
+
+2. Do not claim the v1 spine exists on clean `HEAD 2737b26d`. It exists only in the current dirty v2 working tree at this verification point.
+
+3. Preserve the passing isolated test command using `HOME=/private/tmp/dharma_spine_v2_verify_home` or another explicit isolated home/state dir. This avoids accidental contention with developer-local `~/.dharma` runtime state.
+
+4. If the synthesis wants clean-main evidence, commit or otherwise materialize the candidate files on the v2 branch, then rerun the same commands against the new commit and replace the current dirty-working-tree evidence level with tracked-source/test-backed evidence.

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -153,6 +153,25 @@ class TestInterruptGate:
         assert "auto-approved" in resp.reason
 
     @pytest.mark.asyncio
+    async def test_default_no_callback_rejects_fail_closed(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "dharma_swarm.checkpoint.INTERRUPT_DIR", tmp_path
+        )
+        gate = InterruptGate()
+        req = InterruptRequest(
+            id="failclosed",
+            domain="code",
+            phase="gate",
+            reason="needs review",
+        )
+        resp = await gate.interrupt(req)
+        assert resp.decision == InterruptDecision.REJECT
+        assert "no interrupt handler" in resp.reason
+        assert (tmp_path / "failclosed.request.json").exists()
+        assert (tmp_path / "failclosed.response.json").exists()
+        assert read_pending_interrupts() == []
+
+    @pytest.mark.asyncio
     async def test_manual_resolve(self):
         callback_called = []
 

--- a/tests/test_runtime_lifecycle.py
+++ b/tests/test_runtime_lifecycle.py
@@ -7,6 +7,7 @@ import pytest
 
 from dharma_swarm.models import Task, TaskDispatch, TopologyType
 from dharma_swarm.runtime_lifecycle import RuntimeLifecycle
+from dharma_swarm.runtime_state import RuntimeStateStore
 from dharma_swarm.session_ledger import SessionLedger
 
 
@@ -109,3 +110,16 @@ async def test_runtime_lifecycle_preserves_structured_row_idempotence(tmp_path: 
     assert run_status == "completed"
     assert stored_run_id == run_id
     assert artifact_run_id == run_id
+
+    receipts = await RuntimeStateStore(runtime_db_path).list_runtime_receipts(
+        run_id=run_id,
+        limit=20,
+    )
+    receipt_types = {receipt.receipt_type for receipt in receipts}
+    assert {
+        "delegation_run",
+        "child_spawned",
+        "child_completed",
+        "artifact",
+        "artifact_written",
+    } <= receipt_types

--- a/tests/test_runtime_state.py
+++ b/tests/test_runtime_state.py
@@ -9,11 +9,13 @@ import pytest
 from dharma_swarm.runtime_state import (
     ContextBundleRecord,
     MemoryFact,
+    RUNTIME_RECEIPT_TYPES,
     RuntimeStateStore,
     SessionState,
     SessionEventRecord,
     build_session_event_from_ledger_record,
 )
+from dharma_swarm.spine.identity import ExecutionIdentity
 
 
 @pytest.mark.asyncio
@@ -171,3 +173,127 @@ def test_runtime_state_indexes_historic_ledgers(tmp_path) -> None:
     assert events_scanned == 2
     assert len(hits) == 1
     assert hits[0].event_id == rebuilt.event_id
+
+
+@pytest.mark.asyncio
+async def test_runtime_state_idempotency_writes_side_effect_receipts(tmp_path) -> None:
+    store = RuntimeStateStore(tmp_path / "runtime.db")
+    identity = ExecutionIdentity.new(
+        task_id="task-receipt",
+        run_id="run-receipt",
+        trace_id="trace-receipt",
+        correlation_id="corr-receipt",
+        claim_id="claim-receipt",
+        idempotency_key="idem-receipt",
+        agent_id="agent-receipt",
+    )
+    side_effect_key = "message_bus.emit_event:test:event-1"
+
+    should_execute = await store.try_begin_idempotent_side_effect(
+        identity,
+        side_effect_key,
+        metadata={"surface": "message_bus"},
+    )
+    await store.complete_idempotent_side_effect(
+        identity,
+        side_effect_key,
+        result_receipt_id="event-1",
+        metadata={"surface": "message_bus"},
+    )
+    duplicate = await store.try_begin_idempotent_side_effect(
+        identity,
+        side_effect_key,
+        metadata={"surface": "message_bus"},
+    )
+
+    receipts = await store.list_runtime_receipts(run_id=identity.run_id, limit=20)
+    by_type = [receipt.receipt_type for receipt in receipts]
+    consumed_statuses = [
+        receipt.status
+        for receipt in receipts
+        if receipt.receipt_type == "idempotency_consumed"
+    ]
+
+    assert should_execute is True
+    assert duplicate is False
+    assert by_type.count("side_effect_intent") == 1
+    assert by_type.count("side_effect_complete") == 1
+    assert consumed_statuses == ["accepted", "duplicate"]
+    assert all(receipt.trace_id == identity.trace_id for receipt in receipts)
+
+
+@pytest.mark.asyncio
+async def test_runtime_state_receipt_helpers_cover_saturation_types(tmp_path) -> None:
+    store = RuntimeStateStore(tmp_path / "runtime.db")
+    identity = ExecutionIdentity.new(
+        task_id="task-saturation",
+        run_id="run-saturation",
+        trace_id="trace-saturation",
+        correlation_id="corr-saturation",
+        claim_id="claim-saturation",
+        idempotency_key="idem-saturation",
+        agent_id="agent-saturation",
+        parent_run_id="run-parent",
+        proposal_id="proposal-saturation",
+    )
+
+    await store.record_message_consumed(
+        identity,
+        "message-saturation",
+        payload={"surface": "message_bus.consume_events"},
+    )
+    await store.record_ontology_action_receipt(
+        identity,
+        action_name="Approve",
+        object_type="ActionProposal",
+        object_id="proposal-saturation",
+    )
+    await store.record_ontology_action_receipt(
+        identity,
+        action_name="Approve",
+        object_type="ActionProposal",
+        object_id="proposal-saturation",
+        applied=True,
+    )
+    await store.record_receipt_for_identity(
+        identity,
+        receipt_type="child_spawned",
+        status="claimed",
+        side_effect_key="child:run-parent:run-saturation",
+        payload={"child_run_id": identity.run_id},
+    )
+    await store.record_receipt_for_identity(
+        identity,
+        receipt_type="child_completed",
+        status="completed",
+        side_effect_key="child:run-parent:run-saturation",
+        payload={"child_run_id": identity.run_id},
+    )
+    for stage in ("proposal", "gate", "apply", "verify", "promote", "revert"):
+        await store.record_self_mod_receipt(
+            identity,
+            stage=stage,
+            status="recorded",
+            proposal_id="proposal-saturation",
+        )
+
+    receipts = await store.list_runtime_receipts(run_id=identity.run_id, limit=50)
+    receipt_types = {receipt.receipt_type for receipt in receipts}
+    expected = {
+        "message_consumed",
+        "ontology_action_requested",
+        "ontology_action_applied",
+        "child_spawned",
+        "child_completed",
+        "self_mod_proposal",
+        "self_mod_gate",
+        "self_mod_apply",
+        "self_mod_verify",
+        "self_mod_promote",
+        "self_mod_revert",
+    }
+
+    assert expected <= receipt_types
+    assert expected <= RUNTIME_RECEIPT_TYPES
+    assert all(receipt.run_id == identity.run_id for receipt in receipts)
+    assert all(receipt.trace_id == identity.trace_id for receipt in receipts)

--- a/tests/test_runtime_truth_spine_v1.py
+++ b/tests/test_runtime_truth_spine_v1.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from dharma_swarm.a2a.a2a_server import A2AServer, A2ATask, A2ATaskStatus
+from dharma_swarm.message_bus import MessageBus
+from dharma_swarm.models import Task, TaskDispatch
+from dharma_swarm.runtime_lifecycle import RuntimeLifecycle
+from dharma_swarm.runtime_state import RuntimeStateStore
+from dharma_swarm.session_ledger import SessionLedger
+from dharma_swarm.spine.identity import MissingExecutionIdentity
+
+
+TASK_ID = "task-trcr-9999-alpha"
+RUN_ID = "run-trcr-9999-alpha"
+TRACE_ID = "trc-trcr-9999-alpha"
+CORRELATION_ID = "corr-trcr-9999-alpha"
+CLAIM_ID = "claim-trcr-9999-alpha"
+ARTIFACT_ID = "artifact-trcr-9999-alpha"
+IDEMPOTENCY_KEY = "idem-trcr-9999-alpha"
+AGENT_ID = "agent-trcr-9999-alpha"
+SESSION_ID = "sess-trcr-9999-alpha"
+EXTERNAL_A2A_TASK_ID = "TRCR-9999-ALPHA"
+
+
+def _runtime_lifecycle(tmp_path: Path) -> tuple[RuntimeLifecycle, Path]:
+    runtime_db_path = tmp_path / "state" / "runtime.db"
+    ledger = SessionLedger(
+        base_dir=tmp_path / "ledgers",
+        session_id=SESSION_ID,
+        runtime_db_path=runtime_db_path,
+    )
+    return RuntimeLifecycle(ledger), runtime_db_path
+
+
+def _task() -> Task:
+    return Task(
+        id=TASK_ID,
+        title="TRCR-9999-ALPHA tracer task",
+        description="deterministic runtime truth tracer",
+        metadata={
+            "trace_id": TRACE_ID,
+            "correlation_id": CORRELATION_ID,
+            "run_id": RUN_ID,
+            "runtime_run_id": RUN_ID,
+            "claim_id": CLAIM_ID,
+            "idempotency_key": IDEMPOTENCY_KEY,
+            "parent_run_id": "run-parent-trcr",
+        },
+    )
+
+
+def _dispatch() -> TaskDispatch:
+    return TaskDispatch(
+        task_id=TASK_ID,
+        agent_id=AGENT_ID,
+        metadata={
+            "trace_id": TRACE_ID,
+            "correlation_id": CORRELATION_ID,
+            "run_id": RUN_ID,
+            "runtime_run_id": RUN_ID,
+            "claim_id": CLAIM_ID,
+            "idempotency_key": IDEMPOTENCY_KEY,
+            "parent_run_id": "run-parent-trcr",
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_trcr_9999_alpha_missing_identity_fails(tmp_path: Path) -> None:
+    lifecycle, runtime_db_path = _runtime_lifecycle(tmp_path)
+    await RuntimeStateStore(runtime_db_path).init_db()
+    task = Task(id=TASK_ID, title="missing identity")
+    dispatch = TaskDispatch(
+        task_id=TASK_ID,
+        agent_id=AGENT_ID,
+        metadata={"claim_id": CLAIM_ID, "runtime_run_id": RUN_ID},
+    )
+
+    with pytest.raises(MissingExecutionIdentity):
+        await lifecycle.record_delegation_run(
+            dispatch,
+            task=task,
+            status="running",
+            require_identity=True,
+        )
+
+    artifact_path = tmp_path / "artifact.md"
+    artifact_path.write_text("artifact", encoding="utf-8")
+    with pytest.raises(MissingExecutionIdentity):
+        await lifecycle.record_artifact(
+            task=task,
+            artifact_id=ARTIFACT_ID,
+            artifact_kind="task_result",
+            payload_path=artifact_path,
+            checksum="abc123",
+            run_id=RUN_ID,
+            require_identity=True,
+        )
+
+    with sqlite3.connect(runtime_db_path) as db:
+        assert db.execute("SELECT COUNT(*) FROM delegation_runs").fetchone()[0] == 0
+        assert db.execute("SELECT COUNT(*) FROM artifact_records").fetchone()[0] == 0
+
+
+@pytest.mark.asyncio
+async def test_trcr_9999_alpha_lifecycle_artifact_and_run_reconstruct(tmp_path: Path) -> None:
+    lifecycle, runtime_db_path = _runtime_lifecycle(tmp_path)
+    task = _task()
+    dispatch = _dispatch()
+
+    await lifecycle.record_task_claim(
+        dispatch,
+        task=task,
+        status="claimed",
+        require_identity=True,
+    )
+    await lifecycle.record_delegation_run(
+        dispatch,
+        task=task,
+        status="claimed",
+        require_identity=True,
+    )
+    await lifecycle.record_delegation_run(
+        dispatch,
+        task=task,
+        status="completed",
+        result="TRACE_SUCCESS",
+        require_identity=True,
+    )
+
+    artifact_path = tmp_path / "artifact.md"
+    artifact_path.write_text("TRACE_SUCCESS", encoding="utf-8")
+    await lifecycle.record_artifact(
+        task=task,
+        artifact_id=ARTIFACT_ID,
+        artifact_kind="task_result",
+        payload_path=artifact_path,
+        checksum="abc123",
+        run_id=RUN_ID,
+        require_identity=True,
+    )
+
+    store = RuntimeStateStore(runtime_db_path)
+    chain = await store.get_run_ledger(RUN_ID)
+
+    assert chain["identity"].run_id == RUN_ID
+    assert chain["identity"].trace_id == TRACE_ID
+    assert chain["identity"].correlation_id == CORRELATION_ID
+    assert chain["run"].run_id == RUN_ID
+    assert chain["run"].parent_run_id == "run-parent-trcr"
+    assert chain["artifacts"][0].run_id == RUN_ID
+    assert chain["artifacts"][0].trace_id == TRACE_ID
+    assert chain["artifacts"][0].metadata["correlation_id"] == CORRELATION_ID
+    assert {receipt.receipt_type for receipt in chain["receipts"]} >= {
+        "task_claim",
+        "delegation_run",
+        "artifact",
+    }
+
+    with sqlite3.connect(runtime_db_path) as db:
+        run_trace, run_claim = db.execute(
+            "SELECT trace_id, claim_id FROM delegation_runs WHERE run_id = ?",
+            (RUN_ID,),
+        ).fetchone()
+        artifact_run, artifact_trace, artifact_meta = db.execute(
+            "SELECT run_id, trace_id, metadata_json FROM artifact_records WHERE artifact_id = ?",
+            (ARTIFACT_ID,),
+        ).fetchone()
+
+    assert run_trace == TRACE_ID
+    assert run_claim == CLAIM_ID
+    assert artifact_run == RUN_ID
+    assert artifact_trace == TRACE_ID
+    assert CORRELATION_ID in artifact_meta
+
+
+def test_trcr_9999_alpha_a2a_ingress_maps_ids_and_dedupes(tmp_path: Path) -> None:
+    runtime = RuntimeStateStore(tmp_path / "runtime.db")
+    side_effects: list[str] = []
+    server = A2AServer(runtime_state=runtime, require_execution_identity=True)
+
+    def handler(task: A2ATask) -> A2ATask:
+        side_effects.append(task.metadata["idempotency_key"])
+        task.status = A2ATaskStatus.COMPLETED
+        task.result = "TRACE_SUCCESS"
+        return task
+
+    server.set_default_handler(handler)
+    task = A2ATask(
+        id=EXTERNAL_A2A_TASK_ID,
+        to_agent=AGENT_ID,
+        trace_id=TRACE_ID,
+        metadata={
+            "task_id": TASK_ID,
+            "run_id": RUN_ID,
+            "correlation_id": CORRELATION_ID,
+            "claim_id": CLAIM_ID,
+            "idempotency_key": IDEMPOTENCY_KEY,
+        },
+    )
+    first = server.submit(task)
+    second = server.submit(
+        A2ATask(
+            id=EXTERNAL_A2A_TASK_ID,
+            to_agent=AGENT_ID,
+            trace_id=TRACE_ID,
+            metadata={
+                "task_id": TASK_ID,
+                "run_id": RUN_ID,
+                "correlation_id": CORRELATION_ID,
+                "claim_id": CLAIM_ID,
+                "idempotency_key": IDEMPOTENCY_KEY,
+            },
+        )
+    )
+
+    identity = runtime.get_execution_identity_sync(RUN_ID)
+    record = runtime.get_idempotency_record_sync(
+        IDEMPOTENCY_KEY,
+        f"a2a_handler:{EXTERNAL_A2A_TASK_ID}:default",
+    )
+
+    assert first.id == second.id == EXTERNAL_A2A_TASK_ID
+    assert side_effects == [IDEMPOTENCY_KEY]
+    assert identity is not None
+    assert identity.external_a2a_task_id == EXTERNAL_A2A_TASK_ID
+    assert identity.task_id == TASK_ID
+    assert identity.trace_id == TRACE_ID
+    assert identity.correlation_id == CORRELATION_ID
+    assert record is not None
+    assert record.status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_trcr_9999_alpha_message_bus_idempotency_suppresses_duplicate_event(
+    tmp_path: Path,
+) -> None:
+    runtime = RuntimeStateStore(tmp_path / "runtime.db")
+    bus = MessageBus(tmp_path / "messages.db", runtime_state=runtime)
+    await bus.init_db()
+
+    payload = {
+        "run_id": RUN_ID,
+        "trace_id": TRACE_ID,
+        "correlation_id": CORRELATION_ID,
+        "claim_id": CLAIM_ID,
+    }
+    first = await bus.emit_event(
+        "TRACE_PROBE",
+        task_id=TASK_ID,
+        agent_id=AGENT_ID,
+        payload=payload,
+        idempotency_key=IDEMPOTENCY_KEY,
+    )
+    second = await bus.emit_event(
+        "TRACE_PROBE",
+        task_id=TASK_ID,
+        agent_id=AGENT_ID,
+        payload=payload,
+        idempotency_key=IDEMPOTENCY_KEY,
+    )
+    events = await bus.consume_events("TRACE_PROBE")
+
+    assert second == first
+    assert len(events) == 1
+    assert events[0]["event_id"] == first
+    assert await runtime.was_side_effect_performed(
+        IDEMPOTENCY_KEY,
+        f"message_bus.emit_event:TRACE_PROBE:{first}",
+    )

--- a/tests/test_runtime_truth_spine_v2_adapters.py
+++ b/tests/test_runtime_truth_spine_v2_adapters.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import pytest
+
+from contracts.typed_proposal_envelope import ProposalProvenance
+from dharma_swarm.a2a.a2a_server import A2ATask
+from dharma_swarm.evolution import Proposal
+from dharma_swarm.models import Task, TaskDispatch
+from dharma_swarm.runtime_state import ArtifactRecord, RuntimeReceipt
+from dharma_swarm.spine.adapters import (
+    adapt_execution_identity,
+    identity_from_carrier,
+    runtime_receipt_kwargs,
+)
+from dharma_swarm.spine.identity import ExecutionIdentity, MissingExecutionIdentity
+
+
+TRACE_ID = "trace-adapter-v2"
+CORRELATION_ID = "corr-adapter-v2"
+TASK_ID = "task-adapter-v2"
+RUN_ID = "run-adapter-v2"
+CLAIM_ID = "claim-adapter-v2"
+IDEMPOTENCY_KEY = "idem-adapter-v2"
+AGENT_ID = "agent-adapter-v2"
+SESSION_ID = "session-adapter-v2"
+
+
+def _identity(**overrides: str) -> ExecutionIdentity:
+    payload = {
+        "trace_id": TRACE_ID,
+        "correlation_id": CORRELATION_ID,
+        "task_id": TASK_ID,
+        "run_id": RUN_ID,
+        "claim_id": CLAIM_ID,
+        "idempotency_key": IDEMPOTENCY_KEY,
+        "agent_id": AGENT_ID,
+        "session_id": SESSION_ID,
+    }
+    payload.update(overrides)
+    return ExecutionIdentity.new(**payload)
+
+
+def _assert_round_trip(carrier: object, surface: str, *, identity: ExecutionIdentity | None = None) -> object:
+    expected = identity or _identity()
+    _, adapted = adapt_execution_identity(carrier, surface=surface, task_id=expected.task_id)
+    attached = identity_from_carrier(adapted, surface=surface, require_existing=True)
+    assert attached.trace_id == expected.trace_id
+    assert attached.correlation_id == expected.correlation_id
+    assert attached.run_id == expected.run_id
+    assert attached.claim_id == expected.claim_id
+    assert attached.idempotency_key == expected.idempotency_key
+    return adapted
+
+
+def test_adapter_round_trips_taskboard_orchestrator_a2a_message_and_artifact_surfaces() -> None:
+    identity = _identity(external_a2a_task_id="a2a-adapter-v2", message_id="msg-adapter-v2")
+
+    task = Task(id=TASK_ID, title="adapter task", metadata=identity.to_metadata())
+    _assert_round_trip(task, "taskboard", identity=identity)
+    assert task.metadata["execution_identity"]["run_id"] == RUN_ID
+
+    dispatch = TaskDispatch(task_id=TASK_ID, agent_id=AGENT_ID, metadata=identity.to_metadata())
+    _assert_round_trip(dispatch, "orchestrator", identity=identity)
+    assert dispatch.metadata["trace_id"] == TRACE_ID
+
+    a2a_task = A2ATask(
+        id="a2a-adapter-v2",
+        to_agent=AGENT_ID,
+        dharma_task_id=TASK_ID,
+        metadata=identity.to_metadata(),
+    )
+    adapted_a2a = _assert_round_trip(a2a_task, "a2a", identity=identity)
+    assert adapted_a2a.trace_id == TRACE_ID
+    assert adapted_a2a.metadata["external_a2a_task_id"] == "a2a-adapter-v2"
+
+    message_payload = {"event_id": "evt-adapter-v2", "metadata": identity.to_metadata()}
+    adapted_message = _assert_round_trip(message_payload, "message_bus", identity=identity)
+    assert adapted_message["metadata"]["run_id"] == RUN_ID
+
+    artifact = ArtifactRecord(
+        artifact_id="artifact-adapter-v2",
+        artifact_kind="test",
+        task_id=TASK_ID,
+        metadata=identity.to_metadata(),
+    )
+    adapted_artifact = _assert_round_trip(artifact, "artifact", identity=identity)
+    assert adapted_artifact.trace_id == TRACE_ID
+    assert adapted_artifact.run_id == RUN_ID
+
+
+def test_adapter_round_trips_tools_ontology_checkpoints_and_self_mod_proposals() -> None:
+    identity = _identity(proposal_id="proposal-adapter-v2")
+
+    tool_call = {
+        "tool_call_id": "tool-call-adapter-v2",
+        "tool_name": "safe_probe",
+        "metadata": identity.to_metadata(),
+    }
+    adapted_tool = _assert_round_trip(tool_call, "tool", identity=identity)
+    assert adapted_tool["metadata"]["execution_identity_surface"] == "tool"
+
+    ontology_action = {
+        "object_type": "ActionProposal",
+        "object_id": "proposal-adapter-v2",
+        "action_name": "Approve",
+        "executed_by": AGENT_ID,
+        "metadata": identity.to_metadata(),
+    }
+    adapted_action = _assert_round_trip(ontology_action, "ontology_action", identity=identity)
+    assert adapted_action["metadata"]["proposal_id"] == "proposal-adapter-v2"
+
+    checkpoint = {
+        "checkpoint_id": "checkpoint-adapter-v2",
+        "cycle_id": "cycle-adapter-v2",
+        "metadata": identity.to_metadata(),
+    }
+    adapted_checkpoint = _assert_round_trip(checkpoint, "graph_checkpoint", identity=identity)
+    assert adapted_checkpoint["metadata"]["trace_id"] == TRACE_ID
+
+    proposal = Proposal(
+        id="proposal-adapter-v2",
+        component="dharma_swarm/orchestrator.py",
+        change_type="mutation",
+        description="adapter-ready proposal",
+        metadata=identity.to_metadata(),
+    )
+    _assert_round_trip(proposal, "self_mod_proposal", identity=identity)
+    assert proposal.metadata["proposal_id"] == "proposal-adapter-v2"
+
+    provenance = ProposalProvenance(
+        agent=AGENT_ID,
+        callsign="adapter-v2",
+        branch="codex/runtime-truth-spine-v2",
+        rationale="adapter test",
+    )
+    provenance_payload = provenance.model_dump()
+    provenance_payload["metadata"] = identity.to_metadata()
+    adapted_provenance = _assert_round_trip(provenance_payload, "proposal", identity=identity)
+    assert adapted_provenance["metadata"]["run_id"] == RUN_ID
+
+
+def test_adapter_can_generate_identity_for_legacy_carriers_but_required_boundaries_fail() -> None:
+    legacy_dispatch = TaskDispatch(task_id=TASK_ID, agent_id=AGENT_ID)
+    identity, adapted = adapt_execution_identity(legacy_dispatch, surface="orchestrator")
+    assert identity.task_id == TASK_ID
+    assert identity.agent_id == AGENT_ID
+    assert adapted.metadata["execution_identity"]["task_id"] == TASK_ID
+
+    with pytest.raises(MissingExecutionIdentity):
+        identity_from_carrier(Task(id=TASK_ID, title="missing"), surface="taskboard", require_existing=True)
+
+
+def test_adapter_receipt_kwargs_are_runtime_receipt_compatible() -> None:
+    identity = _identity()
+    receipt = RuntimeReceipt(
+        **runtime_receipt_kwargs(
+            identity,
+            receipt_type="side_effect_intent",
+            status="started",
+            side_effect_key="tool:safe_probe",
+            payload={"surface": "tool"},
+        )
+    )
+    assert receipt.run_id == RUN_ID
+    assert receipt.trace_id == TRACE_ID
+    assert receipt.correlation_id == CORRELATION_ID
+    assert receipt.idempotency_key == IDEMPOTENCY_KEY
+    assert receipt.side_effect_key == "tool:safe_probe"

--- a/tests/test_runtime_truth_spine_v2_evidence.py
+++ b/tests/test_runtime_truth_spine_v2_evidence.py
@@ -1,0 +1,425 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from dharma_swarm.a2a.a2a_server import A2AServer, A2ATask, A2ATaskStatus
+from dharma_swarm.message_bus import MessageBus
+from dharma_swarm.models import Task, TaskDispatch
+from dharma_swarm.runtime_lifecycle import RuntimeLifecycle
+from dharma_swarm.runtime_state import RuntimeStateStore
+from dharma_swarm.session_ledger import SessionLedger
+from dharma_swarm.spine.identity import ExecutionIdentity, MissingExecutionIdentity
+
+
+TASK_ID = "task-trcr-9999-alpha"
+CHILD_TASK_ID = "task-trcr-9999-alpha-child"
+RUN_ID = "run-trcr-9999-alpha"
+CHILD_RUN_ID = "run-trcr-9999-alpha-child"
+TRACE_ID = "trc-trcr-9999-alpha"
+CORRELATION_ID = "corr-trcr-9999-alpha"
+CLAIM_ID = "claim-trcr-9999-alpha"
+CHILD_CLAIM_ID = "claim-trcr-9999-alpha-child"
+ARTIFACT_ID = "artifact-trcr-9999-alpha"
+IDEMPOTENCY_KEY = "idem-trcr-9999-alpha"
+AGENT_ID = "agent-trcr-9999-alpha"
+SESSION_ID = "sess-trcr-9999-alpha"
+EXTERNAL_A2A_TASK_ID = "TRCR-9999-ALPHA"
+
+
+SURFACE_MATRIX: tuple[dict[str, str], ...] = (
+    {
+        "surface": "A2A local submit",
+        "status": "joined",
+        "evidence": "A2AServer records ExecutionIdentity, runtime receipt, and idempotency.",
+    },
+    {
+        "surface": "A2A HTTP node gateway",
+        "status": "adapter-ready",
+        "evidence": "node_gateway forwards identity fields in request/response payloads.",
+    },
+    {
+        "surface": "RuntimeLifecycle task claim",
+        "status": "joined",
+        "evidence": "record_task_claim(require_identity=True) writes RuntimeStateStore identity/receipt.",
+    },
+    {
+        "surface": "RuntimeLifecycle delegation run",
+        "status": "joined",
+        "evidence": "record_delegation_run(require_identity=True) writes run facts and receipt.",
+    },
+    {
+        "surface": "RuntimeLifecycle artifact record",
+        "status": "joined",
+        "evidence": "record_artifact(require_identity=True) requires and persists run_id plus trace_id.",
+    },
+    {
+        "surface": "MessageBus emit_event with idempotency_key",
+        "status": "joined",
+        "evidence": "emit_event checks RuntimeStateStore idempotency before inserting event row.",
+    },
+    {
+        "surface": "Orchestrator result persistence",
+        "status": "adapter-ready",
+        "evidence": "_persist_result emits provenance and RuntimeLifecycle artifact metadata.",
+    },
+    {
+        "surface": "TaskBoard task metadata",
+        "status": "adapter-ready",
+        "evidence": "Task metadata can carry execution_identity; mandatory enforcement is not complete.",
+    },
+    {
+        "surface": "Checkpoint human interrupt",
+        "status": "adapter-ready",
+        "evidence": "Checkpoint surfaces can carry identity, but wait-state receipt saturation is pending.",
+    },
+    {
+        "surface": "Ontology execute_action",
+        "status": "missing",
+        "evidence": "C2 tollbooth slice still must enforce modifies/requires_approval receipts.",
+    },
+    {
+        "surface": "Tool registry side effects",
+        "status": "missing",
+        "evidence": "Tool calls need mandatory identity and side_effect_intent/complete receipts.",
+    },
+    {
+        "surface": "Graph/workflow checkpoints",
+        "status": "missing",
+        "evidence": "Checkpoint identity and resume receipts are not saturated across graph paths.",
+    },
+    {
+        "surface": "Self-modification proposals",
+        "status": "missing",
+        "evidence": "proposal/gate/apply/verify/promote/revert receipt chain is not saturated.",
+    },
+    {
+        "surface": "NATS/JetStream path",
+        "status": "quarantine",
+        "evidence": "No live NATS path is selected for this deterministic local evidence bundle.",
+    },
+    {
+        "surface": "MCP server/tool access",
+        "status": "missing",
+        "evidence": "MCP/tool boundaries need a compatibility adapter before side effects.",
+    },
+    {
+        "surface": "Free-text file extraction",
+        "status": "quarantine",
+        "evidence": "Regex-driven path writes must stay quarantined until a deterministic tollbooth exists.",
+    },
+)
+
+
+def _coverage() -> dict[str, float]:
+    total = len(SURFACE_MATRIX)
+    joined = sum(1 for row in SURFACE_MATRIX if row["status"] == "joined")
+    adapter = sum(1 for row in SURFACE_MATRIX if row["status"] == "adapter-ready")
+    classified = sum(1 for row in SURFACE_MATRIX if row["status"])
+    return {
+        "joined_percent": round(joined / total * 100, 2),
+        "joined_or_adapter_ready_percent": round((joined + adapter) / total * 100, 2),
+        "classified_percent": round(classified / total * 100, 2),
+    }
+
+
+def _runtime_lifecycle(tmp_path: Path) -> tuple[RuntimeLifecycle, Path]:
+    runtime_db_path = tmp_path / "state" / "runtime.db"
+    ledger = SessionLedger(
+        base_dir=tmp_path / "ledgers",
+        session_id=SESSION_ID,
+        runtime_db_path=runtime_db_path,
+    )
+    return RuntimeLifecycle(ledger), runtime_db_path
+
+
+def _identity_metadata(
+    *,
+    task_id: str = TASK_ID,
+    run_id: str = RUN_ID,
+    claim_id: str = CLAIM_ID,
+    parent_run_id: str = "",
+) -> dict[str, str]:
+    return {
+        "task_id": task_id,
+        "trace_id": TRACE_ID,
+        "correlation_id": CORRELATION_ID,
+        "run_id": run_id,
+        "runtime_run_id": run_id,
+        "claim_id": claim_id,
+        "idempotency_key": IDEMPOTENCY_KEY,
+        "parent_run_id": parent_run_id,
+    }
+
+
+def _task() -> Task:
+    return Task(
+        id=TASK_ID,
+        title="TRCR-9999-ALPHA tracer task",
+        description="deterministic runtime truth tracer",
+        metadata=_identity_metadata(parent_run_id="run-root-trcr"),
+    )
+
+
+def _dispatch() -> TaskDispatch:
+    return TaskDispatch(
+        task_id=TASK_ID,
+        agent_id=AGENT_ID,
+        metadata=_identity_metadata(parent_run_id="run-root-trcr"),
+    )
+
+
+def test_v2_surface_matrix_is_classified_and_quantified() -> None:
+    allowed = {"joined", "adapter-ready", "quarantine", "missing"}
+    statuses = {row["status"] for row in SURFACE_MATRIX}
+    coverage = _coverage()
+
+    assert statuses <= allowed
+    assert len(SURFACE_MATRIX) == 16
+    assert coverage["classified_percent"] == 100.0
+    assert coverage["joined_percent"] == 31.25
+    assert coverage["joined_or_adapter_ready_percent"] == 56.25
+    assert any(row["status"] == "quarantine" for row in SURFACE_MATRIX)
+    assert any(row["status"] == "missing" for row in SURFACE_MATRIX)
+
+
+@pytest.mark.asyncio
+async def test_v2_missing_identity_fails_selected_runtime_boundaries(tmp_path: Path) -> None:
+    lifecycle, runtime_db_path = _runtime_lifecycle(tmp_path)
+    await RuntimeStateStore(runtime_db_path).init_db()
+    task = Task(id=TASK_ID, title="missing identity")
+    dispatch = TaskDispatch(
+        task_id=TASK_ID,
+        agent_id=AGENT_ID,
+        metadata={"claim_id": CLAIM_ID, "runtime_run_id": RUN_ID},
+    )
+
+    with pytest.raises(MissingExecutionIdentity):
+        await lifecycle.record_task_claim(
+            dispatch,
+            task=task,
+            status="claimed",
+            require_identity=True,
+        )
+
+    with pytest.raises(MissingExecutionIdentity):
+        await lifecycle.record_delegation_run(
+            dispatch,
+            task=task,
+            status="running",
+            require_identity=True,
+        )
+
+    artifact_path = tmp_path / "artifact.md"
+    artifact_path.write_text("artifact", encoding="utf-8")
+    with pytest.raises(MissingExecutionIdentity):
+        await lifecycle.record_artifact(
+            task=task,
+            artifact_id=ARTIFACT_ID,
+            artifact_kind="task_result",
+            payload_path=artifact_path,
+            checksum="abc123",
+            run_id=RUN_ID,
+            require_identity=True,
+        )
+
+    with sqlite3.connect(runtime_db_path) as db:
+        assert db.execute("SELECT COUNT(*) FROM task_claims").fetchone()[0] == 0
+        assert db.execute("SELECT COUNT(*) FROM delegation_runs").fetchone()[0] == 0
+        assert db.execute("SELECT COUNT(*) FROM artifact_records").fetchone()[0] == 0
+
+
+@pytest.mark.asyncio
+async def test_v2_trcr_9999_alpha_reconstructs_chain_of_custody(tmp_path: Path) -> None:
+    lifecycle, runtime_db_path = _runtime_lifecycle(tmp_path)
+    task = _task()
+    dispatch = _dispatch()
+
+    await lifecycle.record_task_claim(dispatch, task=task, status="claimed", require_identity=True)
+    await lifecycle.record_delegation_run(dispatch, task=task, status="claimed", require_identity=True)
+    await lifecycle.record_delegation_run(
+        dispatch,
+        task=task,
+        status="completed",
+        result="TRACE_SUCCESS",
+        require_identity=True,
+    )
+
+    child_task = Task(
+        id=CHILD_TASK_ID,
+        title="TRCR child tracer",
+        metadata=_identity_metadata(
+            task_id=CHILD_TASK_ID,
+            run_id=CHILD_RUN_ID,
+            claim_id=CHILD_CLAIM_ID,
+            parent_run_id=RUN_ID,
+        ),
+    )
+    child_dispatch = TaskDispatch(
+        task_id=CHILD_TASK_ID,
+        agent_id=AGENT_ID,
+        metadata=_identity_metadata(
+            task_id=CHILD_TASK_ID,
+            run_id=CHILD_RUN_ID,
+            claim_id=CHILD_CLAIM_ID,
+            parent_run_id=RUN_ID,
+        ),
+    )
+    await lifecycle.record_delegation_run(
+        child_dispatch,
+        task=child_task,
+        status="completed",
+        result="CHILD_TRACE_SUCCESS",
+        require_identity=True,
+    )
+
+    artifact_path = tmp_path / "artifact.md"
+    artifact_path.write_text("TRACE_SUCCESS", encoding="utf-8")
+    await lifecycle.record_artifact(
+        task=task,
+        artifact_id=ARTIFACT_ID,
+        artifact_kind="task_result",
+        payload_path=artifact_path,
+        checksum="abc123",
+        run_id=RUN_ID,
+        require_identity=True,
+    )
+
+    store = RuntimeStateStore(runtime_db_path)
+    chain = await store.get_run_ledger(RUN_ID)
+    receipt_types = {receipt.receipt_type for receipt in chain["receipts"]}
+
+    assert chain["identity"].run_id == RUN_ID
+    assert chain["identity"].trace_id == TRACE_ID
+    assert chain["identity"].correlation_id == CORRELATION_ID
+    assert chain["run"].parent_run_id == "run-root-trcr"
+    assert {child.run_id for child in chain["children"]} == {CHILD_RUN_ID}
+    assert chain["children"][0].parent_run_id == RUN_ID
+    assert {artifact.run_id for artifact in chain["artifacts"]} == {RUN_ID}
+    assert {artifact.trace_id for artifact in chain["artifacts"]} == {TRACE_ID}
+    assert receipt_types >= {"task_claim", "delegation_run", "artifact"}
+
+
+def test_v2_a2a_idempotency_exists_before_handler_side_effect(tmp_path: Path) -> None:
+    runtime = RuntimeStateStore(tmp_path / "runtime.db")
+    server = A2AServer(runtime_state=runtime, require_execution_identity=True)
+    side_effects: list[str] = []
+    observed_before_side_effect: list[tuple[str, str, str, str]] = []
+    side_effect_key = f"a2a_handler:{EXTERNAL_A2A_TASK_ID}:default"
+
+    def handler(task: A2ATask) -> A2ATask:
+        record = runtime.get_idempotency_record_sync(IDEMPOTENCY_KEY, side_effect_key)
+        assert record is not None
+        observed_before_side_effect.append(
+            (record.status, record.run_id, record.trace_id, record.correlation_id)
+        )
+        side_effects.append(task.metadata["idempotency_key"])
+        task.status = A2ATaskStatus.COMPLETED
+        task.result = "TRACE_SUCCESS"
+        return task
+
+    server.set_default_handler(handler)
+    payload = _identity_metadata()
+    first = server.submit(
+        A2ATask(
+            id=EXTERNAL_A2A_TASK_ID,
+            to_agent=AGENT_ID,
+            trace_id=TRACE_ID,
+            metadata=payload,
+        )
+    )
+    second = server.submit(
+        A2ATask(
+            id=EXTERNAL_A2A_TASK_ID,
+            to_agent=AGENT_ID,
+            trace_id=TRACE_ID,
+            metadata=payload,
+        )
+    )
+
+    record = runtime.get_idempotency_record_sync(IDEMPOTENCY_KEY, side_effect_key)
+    identity = runtime.get_execution_identity_sync(RUN_ID)
+
+    assert first.id == second.id == EXTERNAL_A2A_TASK_ID
+    assert observed_before_side_effect == [("started", RUN_ID, TRACE_ID, CORRELATION_ID)]
+    assert side_effects == [IDEMPOTENCY_KEY]
+    assert record is not None
+    assert record.status == "completed"
+    assert record.run_id == RUN_ID
+    assert record.trace_id == TRACE_ID
+    assert identity is not None
+    assert identity.external_a2a_task_id == EXTERNAL_A2A_TASK_ID
+
+
+class SpyRuntimeStateStore(RuntimeStateStore):
+    def __init__(self, db_path: Path, *, message_db_path: Path) -> None:
+        super().__init__(db_path)
+        self.message_db_path = message_db_path
+        self.event_counts_before_idempotency: list[int] = []
+        self.begin_calls: list[tuple[str, str, str]] = []
+
+    async def try_begin_idempotent_side_effect(
+        self,
+        identity: ExecutionIdentity,
+        side_effect_key: str,
+        *,
+        metadata: dict[str, Any] | None = None,
+    ) -> bool:
+        with sqlite3.connect(self.message_db_path) as db:
+            count = db.execute("SELECT COUNT(*) FROM events").fetchone()[0]
+        self.event_counts_before_idempotency.append(count)
+        self.begin_calls.append((identity.run_id, identity.trace_id, side_effect_key))
+        return await super().try_begin_idempotent_side_effect(
+            identity,
+            side_effect_key,
+            metadata=metadata,
+        )
+
+
+@pytest.mark.asyncio
+async def test_v2_message_bus_idempotency_happens_before_event_insert(tmp_path: Path) -> None:
+    message_db_path = tmp_path / "messages.db"
+    runtime = SpyRuntimeStateStore(tmp_path / "runtime.db", message_db_path=message_db_path)
+    bus = MessageBus(message_db_path, runtime_state=runtime)
+    await bus.init_db()
+
+    payload = {
+        "run_id": RUN_ID,
+        "trace_id": TRACE_ID,
+        "correlation_id": CORRELATION_ID,
+        "claim_id": CLAIM_ID,
+    }
+    first = await bus.emit_event(
+        "TRACE_PROBE_V2",
+        task_id=TASK_ID,
+        agent_id=AGENT_ID,
+        payload=payload,
+        idempotency_key=IDEMPOTENCY_KEY,
+    )
+    second = await bus.emit_event(
+        "TRACE_PROBE_V2",
+        task_id=TASK_ID,
+        agent_id=AGENT_ID,
+        payload=payload,
+        idempotency_key=IDEMPOTENCY_KEY,
+    )
+    events = await bus.consume_events("TRACE_PROBE_V2")
+
+    assert second == first
+    assert runtime.event_counts_before_idempotency == [0]
+    assert runtime.begin_calls == [
+        (RUN_ID, TRACE_ID, f"message_bus.emit_event:TRACE_PROBE_V2:{first}")
+    ]
+    assert len(events) == 1
+    assert events[0]["event_id"] == first
+    record = await runtime.get_idempotency_record(
+        IDEMPOTENCY_KEY,
+        f"message_bus.emit_event:TRACE_PROBE_V2:{first}",
+    )
+    assert record is not None
+    assert record.status == "completed"
+    assert record.run_id == RUN_ID
+    assert record.trace_id == TRACE_ID

--- a/tests/test_runtime_truth_spine_v2_tollbooth.py
+++ b/tests/test_runtime_truth_spine_v2_tollbooth.py
@@ -1,0 +1,18 @@
+"""Runtime Truth Spine v2 tollbooth regression checks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_orchestrator_free_text_result_path_requires_structured_opt_in() -> None:
+    source = (REPO_ROOT / "dharma_swarm" / "orchestrator.py").read_text(encoding="utf-8")
+    gate = 'task_metadata.get("allow_free_text_result_path") is True'
+    write = "target.write_text(result, encoding=\"utf-8\")"
+
+    assert gate in source
+    assert write in source
+    assert source.index(gate) < source.index(write)


### PR DESCRIPTION
## Summary

Adds the Runtime Truth Spine v2 execution identity layer: canonical ExecutionIdentity, RuntimeStateStore identity and receipt tables, idempotency records, runtime lifecycle receipts, and adapters through A2A, MessageBus, checkpoint, orchestrator, and artifact persistence.

## Coherence Delta

- Organ touched: runtime truth spine, RuntimeStateStore, RuntimeLifecycle, A2A submit, MessageBus event rail, checkpoint interrupts, orchestrator dispatch, artifact persistence.
- Declared-vs-actual gap closed: execution identity becomes a durable runtime join key with receipts and idempotency records instead of being scattered across trace_id, runtime_run_id, task_id, claim_id, and local metadata conventions.
- Proof that re-reads the map: read the runtime spine blast-radius report, active track evidence, RuntimeStateStore/RuntimeLifecycle/A2A/MessageBus/checkpoint/orchestrator hunks, ran GitNexus local indexing plus impact checks, and ran governance-all.
- New drift introduced: orchestrator.py is exactly at its grandfathered module-budget ceiling and runtime_state.py remains an inherited over-budget module; this PR does not introduce the runtime_state breach but future work must split these surfaces.

## Interface mismatch impact

- [x] No new mismatch introduced
- [ ] Existing mismatch resolved — INTERFACE_MISMATCH_MAP.md updated
- [ ] Net-new mismatch documented in the map (transitional)

## Pre-flight check

- [x] No BR-id cited in this PR body.
- [x] Collision risk handled by GitHub PR collision detect.

## Verification

- make governance-all passed
- make test-contracts passed
- make uplift-guards passed
- docops integrity passed
- module budget passed with grandfathered warnings only
- git diff --check origin/main..HEAD passed
- focused runtime/A2A/checkpoint/orchestrator suites passed: 159 passed
- adjacent A2A/checkpoint/cascade/runtime-adapter suites passed: 152 passed, 2 xfailed

## Risk

High-risk substrate PR. Touches RuntimeStateStore, A2A submit, MessageBus idempotency, checkpoint interrupt defaults, and orchestrator dispatch. Merge before ordinary queue cleanup PRs so later PRs build on the identity spine.

## Plan reference

- Plan: runtime-truth-spine-v2 active track and reports/governance/runtime_truth_spine_v2_evidence_plan.md
