### PR TITLE
feat(runtime): close sync legacy ledger bypass [impact-checked]

### DIFF
--- a/dharma_swarm/opportunity_dispatcher.py
+++ b/dharma_swarm/opportunity_dispatcher.py
@@ -33,6 +33,7 @@ from dharma_swarm.runtime_state import (
     _utc_now,
     _utc_now_iso,
 )
+from dharma_swarm.spine.identity import ExecutionIdentity
 
 logger = logging.getLogger(__name__)
 
@@ -150,6 +151,8 @@ class OpportunityDispatcher:
         opp_type = str(
             opportunity.get("type") or opportunity.get("domain") or "external_revenue"
         )
+        trace_id = str(opportunity.get("trace_id") or _new_id("trace"))
+        correlation_id = str(opportunity.get("correlation_id") or trace_id)
 
         for stage in OPPORTUNITY_STAGES:
             task_id = _new_id("task")
@@ -171,6 +174,34 @@ class OpportunityDispatcher:
                 },
             )
 
+            identity = ExecutionIdentity.new(
+                task_id=task_id,
+                agent_id=agent_id,
+                session_id=self._session_id,
+                trace_id=trace_id,
+                correlation_id=correlation_id,
+                causation_id=f"opportunity:{opp_id}:{stage}",
+                run_id=run_id,
+                claim_id=claim_id,
+                idempotency_key=f"idem_{run_id}",
+                metadata={
+                    "source": "opportunity_dispatcher",
+                    "opportunity_id": opp_id,
+                    "opportunity_type": opp_type,
+                    "stage": stage,
+                },
+            )
+            identity_metadata = {
+                **identity.to_metadata(),
+                "trace_id": identity.trace_id,
+                "correlation_id": identity.correlation_id,
+                "run_id": identity.run_id,
+                "runtime_run_id": identity.run_id,
+                "claim_id": identity.claim_id,
+                "idempotency_key": identity.idempotency_key,
+            }
+            task.metadata.update(identity_metadata)
+
             proposal_id: str | None = None
             if self._telic_seam is not None:
                 try:
@@ -181,6 +212,20 @@ class OpportunityDispatcher:
                     logger.debug("Telic dispatch record failed: %s", exc)
 
             try:
+                if proposal_id:
+                    identity = identity.with_updates(proposal_id=proposal_id)
+                identity_metadata = {
+                    **identity.to_metadata(),
+                    "trace_id": identity.trace_id,
+                    "correlation_id": identity.correlation_id,
+                    "run_id": identity.run_id,
+                    "runtime_run_id": identity.run_id,
+                    "claim_id": identity.claim_id,
+                    "idempotency_key": identity.idempotency_key,
+                }
+                if identity.proposal_id:
+                    identity_metadata["proposal_id"] = identity.proposal_id
+                task.metadata.update(identity_metadata)
                 self._store.create_task_claim_sync(
                     TaskClaim(
                         claim_id=claim_id,
@@ -188,6 +233,12 @@ class OpportunityDispatcher:
                         agent_id=agent_id,
                         status="claimed",
                         session_id=self._session_id,
+                        metadata={
+                            "source": "opportunity_dispatcher",
+                            "opportunity_id": opp_id,
+                            "stage": stage,
+                            **identity_metadata,
+                        },
                     )
                 )
                 self._store.create_delegation_run_sync(
@@ -198,6 +249,12 @@ class OpportunityDispatcher:
                         status="running",
                         session_id=self._session_id,
                         claim_id=claim_id,
+                        metadata={
+                            "source": "opportunity_dispatcher",
+                            "opportunity_id": opp_id,
+                            "stage": stage,
+                            **identity_metadata,
+                        },
                     )
                 )
                 results.append(DispatchResult(

--- a/dharma_swarm/runtime_state.py
+++ b/dharma_swarm/runtime_state.py
@@ -12,7 +12,7 @@ import hashlib
 import json
 import re
 import sqlite3
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -25,7 +25,7 @@ from dharma_swarm.engine.event_memory import (
     ensure_memory_plane_schema_async,
     ensure_memory_plane_schema_sync,
 )
-from dharma_swarm.spine.identity import ExecutionIdentity
+from dharma_swarm.spine.identity import ExecutionIdentity, MissingExecutionIdentity
 
 DEFAULT_RUNTIME_DB = Path.home() / ".dharma" / "state" / "runtime.db"
 
@@ -849,6 +849,79 @@ def _identity_from_metadata(metadata: dict[str, Any] | None) -> ExecutionIdentit
     return ExecutionIdentity.from_metadata(metadata, require=False)
 
 
+def _required_identity_from_metadata(
+    metadata: dict[str, Any] | None,
+    *,
+    task_id: str,
+    agent_id: str = "",
+    session_id: str = "",
+) -> ExecutionIdentity:
+    identity = ExecutionIdentity.from_metadata(
+        metadata,
+        task_id=task_id,
+        agent_id=agent_id,
+        session_id=session_id,
+        require=True,
+    )
+    if identity is None:
+        raise MissingExecutionIdentity("ExecutionIdentity is required")
+    return identity.require_for_dispatch()
+
+
+def _legacy_no_identity_metadata(metadata: dict[str, Any] | None) -> dict[str, Any]:
+    return {
+        **dict(metadata or {}),
+        "legacy_no_identity_allowed": True,
+        "runtime_spine_status": "legacy_no_identity",
+    }
+
+
+def _metadata_with_identity(
+    metadata: dict[str, Any] | None,
+    identity: ExecutionIdentity,
+) -> dict[str, Any]:
+    return {
+        **dict(metadata or {}),
+        **identity.to_metadata(),
+        "trace_id": identity.trace_id,
+        "correlation_id": identity.correlation_id,
+        "run_id": identity.run_id,
+        "runtime_run_id": identity.run_id,
+        "claim_id": identity.claim_id,
+        "idempotency_key": identity.idempotency_key,
+        "agent_id": identity.agent_id,
+        "session_id": identity.session_id,
+    }
+
+
+def _require_identity_match(
+    identity: ExecutionIdentity,
+    *,
+    surface: str,
+    task_id: str = "",
+    claim_id: str = "",
+    run_id: str = "",
+    agent_id: str = "",
+    session_id: str = "",
+) -> None:
+    expected = {
+        "task_id": task_id,
+        "claim_id": claim_id,
+        "run_id": run_id,
+        "agent_id": agent_id,
+        "session_id": session_id,
+    }
+    mismatches = [
+        f"{name}={actual!r} expected {wanted!r}"
+        for name, wanted in expected.items()
+        if wanted and (actual := str(getattr(identity, name, "") or "")) and actual != wanted
+    ]
+    if mismatches:
+        raise MissingExecutionIdentity(
+            f"ExecutionIdentity does not match {surface}: " + ", ".join(mismatches)
+        )
+
+
 def _trace_from_metadata(metadata: dict[str, Any] | None) -> str:
     identity = _identity_from_metadata(metadata)
     if identity is not None and identity.trace_id:
@@ -1592,16 +1665,60 @@ class RuntimeStateStore:
 
     # ── Sync helpers (for non-async callers like OpportunityDispatcher) ──
 
-    def create_task_claim_sync(self, claim: TaskClaim) -> TaskClaim:
-        """Synchronous version of record_task_claim."""
+    def create_task_claim_sync(
+        self,
+        claim: TaskClaim,
+        *,
+        legacy_no_identity_allowed: bool = False,
+    ) -> TaskClaim:
+        """Synchronous version of record_task_claim.
+
+        Canonical callers must provide a full ExecutionIdentity in metadata.
+        Legacy callers may opt into the temporary compatibility path explicitly.
+        """
+        try:
+            identity = _required_identity_from_metadata(
+                claim.metadata,
+                task_id=claim.task_id,
+                agent_id=claim.agent_id,
+                session_id=claim.session_id,
+            )
+        except MissingExecutionIdentity:
+            if not legacy_no_identity_allowed:
+                raise
+            identity = None
+
+        if identity is None:
+            claim = replace(
+                claim,
+                metadata=_legacy_no_identity_metadata(claim.metadata),
+            )
+        else:
+            _require_identity_match(
+                identity,
+                surface="create_task_claim_sync",
+                task_id=claim.task_id,
+                claim_id=claim.claim_id,
+                agent_id=claim.agent_id,
+                session_id=claim.session_id,
+            )
+            claim = replace(
+                claim,
+                metadata=_metadata_with_identity(claim.metadata, identity),
+            )
+            self.record_execution_identity_sync(
+                identity,
+                source="runtime_state.create_task_claim_sync",
+            )
+        trace_id = identity.trace_id if identity is not None else _trace_from_metadata(claim.metadata)
         self.init_db_sync()
         with sqlite3.connect(self.db_path) as db:
             _apply_connection_pragmas_sync(db)
             db.execute(
                 "INSERT INTO task_claims (claim_id, task_id, session_id, agent_id, status,"
                 " claimed_at, acked_at, heartbeat_at, stale_after, recovered_at,"
-                " retry_count, metadata_json)"
-                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+                " retry_count, metadata_json, trace_id)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
                 " ON CONFLICT(claim_id) DO UPDATE SET"
                 " task_id = excluded.task_id,"
                 " session_id = excluded.session_id,"
@@ -1613,7 +1730,8 @@ class RuntimeStateStore:
                 " stale_after = excluded.stale_after,"
                 " recovered_at = excluded.recovered_at,"
                 " retry_count = excluded.retry_count,"
-                " metadata_json = excluded.metadata_json",
+                " metadata_json = excluded.metadata_json,"
+                " trace_id = excluded.trace_id",
                 (
                     claim.claim_id,
                     claim.task_id,
@@ -1627,9 +1745,18 @@ class RuntimeStateStore:
                     claim.recovered_at.isoformat() if claim.recovered_at else None,
                     int(claim.retry_count),
                     _json_dump(claim.metadata),
+                    trace_id,
                 ),
             )
             db.commit()
+        if identity is not None:
+            self.record_receipt_for_identity_sync(
+                identity,
+                receipt_id=f"rr_{identity.run_id}_{claim.status}_claim",
+                receipt_type="task_claim",
+                status=claim.status,
+                payload={"claim_id": claim.claim_id},
+            )
         return self.get_task_claim_sync(claim.claim_id) or claim
 
     def get_task_claim_sync(self, claim_id: str) -> TaskClaim | None:
@@ -1683,8 +1810,54 @@ class RuntimeStateStore:
             db.commit()
         return self.get_task_claim_sync(claim_id)
 
-    def create_delegation_run_sync(self, run: DelegationRun) -> DelegationRun:
-        """Synchronous version of record_delegation_run."""
+    def create_delegation_run_sync(
+        self,
+        run: DelegationRun,
+        *,
+        legacy_no_identity_allowed: bool = False,
+    ) -> DelegationRun:
+        """Synchronous version of record_delegation_run.
+
+        Canonical callers must provide a full ExecutionIdentity in metadata.
+        Legacy callers may opt into the temporary compatibility path explicitly.
+        """
+        try:
+            identity = _required_identity_from_metadata(
+                run.metadata,
+                task_id=run.task_id,
+                agent_id=run.assigned_to,
+                session_id=run.session_id,
+            )
+        except MissingExecutionIdentity:
+            if not legacy_no_identity_allowed:
+                raise
+            identity = None
+
+        if identity is None:
+            run = replace(
+                run,
+                metadata=_legacy_no_identity_metadata(run.metadata),
+            )
+        else:
+            _require_identity_match(
+                identity,
+                surface="create_delegation_run_sync",
+                task_id=run.task_id,
+                claim_id=run.claim_id,
+                run_id=run.run_id,
+                agent_id=run.assigned_to,
+                session_id=run.session_id,
+            )
+            run = replace(
+                run,
+                parent_run_id=run.parent_run_id or identity.parent_run_id,
+                metadata=_metadata_with_identity(run.metadata, identity),
+            )
+            self.record_execution_identity_sync(
+                identity,
+                source="runtime_state.create_delegation_run_sync",
+            )
+        trace_id = identity.trace_id if identity is not None else _trace_from_metadata(run.metadata)
         self.init_db_sync()
         with sqlite3.connect(self.db_path) as db:
             _apply_connection_pragmas_sync(db)
@@ -1692,8 +1865,8 @@ class RuntimeStateStore:
                 "INSERT INTO delegation_runs (run_id, session_id, task_id, claim_id,"
                 " parent_run_id, assigned_by, assigned_to, requested_output_json,"
                 " current_artifact_id, status, started_at, completed_at, failure_code,"
-                " metadata_json)"
-                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+                " metadata_json, trace_id)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
                 " ON CONFLICT(run_id) DO UPDATE SET"
                 " session_id = excluded.session_id,"
                 " task_id = excluded.task_id,"
@@ -1707,7 +1880,8 @@ class RuntimeStateStore:
                 " started_at = excluded.started_at,"
                 " completed_at = excluded.completed_at,"
                 " failure_code = excluded.failure_code,"
-                " metadata_json = excluded.metadata_json",
+                " metadata_json = excluded.metadata_json,"
+                " trace_id = excluded.trace_id",
                 (
                     run.run_id,
                     run.session_id,
@@ -1723,9 +1897,44 @@ class RuntimeStateStore:
                     run.completed_at.isoformat() if run.completed_at else None,
                     run.failure_code,
                     _json_dump(run.metadata),
+                    trace_id,
                 ),
             )
             db.commit()
+        if identity is not None:
+            self.record_receipt_for_identity_sync(
+                identity,
+                receipt_id=f"rr_{identity.run_id}_{run.status}_run",
+                receipt_type="delegation_run",
+                status=run.status,
+                payload={"failure_code": run.failure_code},
+            )
+            if identity.parent_run_id and run.status in {"queued", "claimed", "running"}:
+                self.record_receipt_for_identity_sync(
+                    identity,
+                    receipt_id=f"rr_{identity.parent_run_id}_{identity.run_id}_child_spawned",
+                    receipt_type="child_spawned",
+                    status=run.status,
+                    side_effect_key=f"child:{identity.parent_run_id}:{identity.run_id}",
+                    payload={
+                        "child_run_id": identity.run_id,
+                        "parent_run_id": identity.parent_run_id,
+                        "assigned_to": identity.agent_id,
+                    },
+                )
+            if identity.parent_run_id and run.status in {"completed", "failed"}:
+                self.record_receipt_for_identity_sync(
+                    identity,
+                    receipt_id=f"rr_{identity.parent_run_id}_{identity.run_id}_child_completed_{run.status}",
+                    receipt_type="child_completed",
+                    status=run.status,
+                    side_effect_key=f"child:{identity.parent_run_id}:{identity.run_id}",
+                    payload={
+                        "child_run_id": identity.run_id,
+                        "parent_run_id": identity.parent_run_id,
+                        "failure_code": run.failure_code,
+                    },
+                )
         return self.get_delegation_run_sync(run.run_id) or run
 
     def get_delegation_run_sync(self, run_id: str) -> DelegationRun | None:

--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -11,8 +11,8 @@ Do not hand-edit the generated block.
 | Dharma Python LOC | 279,961 |
 | Test files | 618 |
 | Test function occurrences | 10,737 |
-| Markdown files | 760 |
-| Markdown total lines | 191,305 |
+| Markdown files | 761 |
+| Markdown total lines | 191,306 |
 | Bridge files | 24 |
 | Adapter files | 21 |
 | Orchestrator files | 4 |

--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -8,9 +8,9 @@ Do not hand-edit the generated block.
 |---|---:|
 | Dharma Python modules | 661 |
 | Top-level Dharma Python modules | 389 |
-| Dharma Python LOC | 279,695 |
-| Test files | 617 |
-| Test function occurrences | 10,734 |
+| Dharma Python LOC | 279,961 |
+| Test files | 618 |
+| Test function occurrences | 10,737 |
 | Markdown files | 760 |
 | Markdown total lines | 191,305 |
 | Bridge files | 24 |

--- a/docs/governance/SOVEREIGN_MANIFEST.md
+++ b/docs/governance/SOVEREIGN_MANIFEST.md
@@ -132,8 +132,8 @@ These are the ground-truth metrics. All other documents citing different numbers
 | Test functions | **10,737 `def test_` occurrences under tests/** | rg "def test_" tests |
 | Tests collected (pytest) | **Needs write-permitted refresh** | not run during this DocOps count pass |
 | Collection errors | **Historical: 16 on 2026-04-04** | refresh before relying on this count |
-| Markdown files | **760** | find . -name "*.md" -type f |
-| Markdown total lines | **191,305** | wc -l across all .md |
+| Markdown files | **761** | find . -name "*.md" -type f |
+| Markdown total lines | **191,306** | wc -l across all .md |
 | Bridge files | **24** | find dharma_swarm -name "*bridge*.py" |
 | Adapter files | **21 across 8 locations** | find dharma_swarm -type f \| rg -i "adapter" |
 | Orchestrator files | **4** (6,034 LOC total) | find dharma_swarm -name "*orchestrat*" |

--- a/docs/governance/SOVEREIGN_MANIFEST.md
+++ b/docs/governance/SOVEREIGN_MANIFEST.md
@@ -127,9 +127,9 @@ These are the ground-truth metrics. All other documents citing different numbers
 |--------|-------|-------------|
 | Total Python modules | **661** | find dharma_swarm -name "*.py" -type f |
 | Top-level (flat) modules | **389 (59.0%)** | find dharma_swarm -maxdepth 1 -name "*.py" -type f |
-| Total Python LOC | **279,695** | wc -l across dharma_swarm Python modules |
-| Test files | **617** | find tests -name "*.py" -type f |
-| Test functions | **10,734 `def test_` occurrences under tests/** | rg "def test_" tests |
+| Total Python LOC | **279,961** | wc -l across dharma_swarm Python modules |
+| Test files | **618** | find tests -name "*.py" -type f |
+| Test functions | **10,737 `def test_` occurrences under tests/** | rg "def test_" tests |
 | Tests collected (pytest) | **Needs write-permitted refresh** | not run during this DocOps count pass |
 | Collection errors | **Historical: 16 on 2026-04-04** | refresh before relying on this count |
 | Markdown files | **760** | find . -name "*.md" -type f |

--- a/seams/spine-adoption/codex-runlog.md
+++ b/seams/spine-adoption/codex-runlog.md
@@ -1,0 +1,1 @@
+2026-06-01T15:03:46Z | slice-A | PR #430 | Opened Slice A sync legacy ledger bypass PR with identity-before-telic fix and passing v2 baseline.

--- a/tests/test_authority_revenue_loop.py
+++ b/tests/test_authority_revenue_loop.py
@@ -85,7 +85,7 @@ class TestRuntimeStateClaims:
             status="claimed",
             session_id="test-session",
         )
-        result = store.create_task_claim_sync(claim)
+        result = store.create_task_claim_sync(claim, legacy_no_identity_allowed=True)
         assert result.claim_id == claim.claim_id
         assert result.status == "claimed"
 
@@ -102,7 +102,7 @@ class TestRuntimeStateClaims:
             agent_id="agent_hb",
             status="claimed",
         )
-        store.create_task_claim_sync(claim)
+        store.create_task_claim_sync(claim, legacy_no_identity_allowed=True)
         updated = store.heartbeat_claim_sync(claim.claim_id)
         assert updated is not None
         assert updated.heartbeat_at is not None
@@ -116,7 +116,7 @@ class TestRuntimeStateClaims:
             agent_id="agent_close",
             status="claimed",
         )
-        store.create_task_claim_sync(claim)
+        store.create_task_claim_sync(claim, legacy_no_identity_allowed=True)
         closed = store.close_claim_sync(claim.claim_id, status="completed")
         assert closed is not None
         assert closed.status == "completed"
@@ -131,7 +131,7 @@ class TestRuntimeStateClaims:
             status="running",
             session_id="test-session",
         )
-        result = store.create_delegation_run_sync(run)
+        result = store.create_delegation_run_sync(run, legacy_no_identity_allowed=True)
         assert result.run_id == run.run_id
         assert result.status == "running"
 
@@ -148,7 +148,7 @@ class TestRuntimeStateClaims:
             assigned_to="agent_close_run",
             status="running",
         )
-        store.create_delegation_run_sync(run)
+        store.create_delegation_run_sync(run, legacy_no_identity_allowed=True)
         closed = store.close_delegation_run_sync(
             run.run_id, status="completed"
         )
@@ -169,7 +169,7 @@ class TestRuntimeStateClaims:
             status="claimed",
             stale_after=stale_time,
         )
-        store.create_task_claim_sync(claim)
+        store.create_task_claim_sync(claim, legacy_no_identity_allowed=True)
         loaded = store.get_task_claim_sync(claim.claim_id)
         assert loaded is not None
         assert loaded.stale_after is not None

--- a/tests/test_runtime_state_invariants.py
+++ b/tests/test_runtime_state_invariants.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from dharma_swarm.opportunity_dispatcher import OPPORTUNITY_STAGES, OpportunityDispatcher
+from dharma_swarm.runtime_state import DelegationRun, RuntimeStateStore, TaskClaim
+from dharma_swarm.spine.identity import ExecutionIdentity, MissingExecutionIdentity
+
+
+def _identity(
+    *,
+    task_id: str = "task-spine-a",
+    run_id: str = "run-spine-a",
+    claim_id: str = "claim-spine-a",
+    parent_run_id: str = "",
+) -> ExecutionIdentity:
+    return ExecutionIdentity.new(
+        task_id=task_id,
+        run_id=run_id,
+        claim_id=claim_id,
+        trace_id="trace-spine-a",
+        correlation_id="corr-spine-a",
+        idempotency_key="idem-spine-a",
+        agent_id="agent-spine-a",
+        session_id="session-spine-a",
+        parent_run_id=parent_run_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_sync_legacy_helpers_fail_closed_without_identity_unless_flagged(
+    tmp_path: Path,
+) -> None:
+    store = RuntimeStateStore(tmp_path / "runtime.db")
+    claim = TaskClaim(
+        claim_id="claim-legacy",
+        task_id="task-legacy",
+        agent_id="agent-legacy",
+        status="claimed",
+        session_id="session-legacy",
+    )
+
+    with pytest.raises(MissingExecutionIdentity):
+        store.create_task_claim_sync(claim)
+
+    legacy_claim = store.create_task_claim_sync(
+        claim,
+        legacy_no_identity_allowed=True,
+    )
+    assert legacy_claim.metadata["legacy_no_identity_allowed"] is True
+
+    run = DelegationRun(
+        run_id="run-legacy",
+        task_id="task-legacy",
+        assigned_to="agent-legacy",
+        status="running",
+        session_id="session-legacy",
+        claim_id="claim-legacy",
+    )
+
+    with pytest.raises(MissingExecutionIdentity):
+        store.create_delegation_run_sync(run)
+
+    legacy_run = store.create_delegation_run_sync(
+        run,
+        legacy_no_identity_allowed=True,
+    )
+    ledger = await store.get_run_ledger(run.run_id)
+
+    assert legacy_run.metadata["legacy_no_identity_allowed"] is True
+    assert ledger["identity"] is None
+    assert ledger["receipts"] == []
+
+
+@pytest.mark.asyncio
+async def test_sync_helpers_record_identity_trace_and_receipts(tmp_path: Path) -> None:
+    store = RuntimeStateStore(tmp_path / "runtime.db")
+    identity = _identity(parent_run_id="run-parent-spine-a")
+
+    stored_claim = store.create_task_claim_sync(
+        TaskClaim(
+            claim_id=identity.claim_id,
+            task_id=identity.task_id,
+            agent_id=identity.agent_id,
+            status="claimed",
+            session_id=identity.session_id,
+            metadata=identity.to_metadata(),
+        )
+    )
+    stored_run = store.create_delegation_run_sync(
+        DelegationRun(
+            run_id=identity.run_id,
+            task_id=identity.task_id,
+            assigned_to=identity.agent_id,
+            status="running",
+            session_id=identity.session_id,
+            claim_id=identity.claim_id,
+            metadata=identity.to_metadata(),
+        )
+    )
+    ledger = await store.get_run_ledger(identity.run_id)
+    receipt_types = {receipt.receipt_type for receipt in ledger["receipts"]}
+
+    with sqlite3.connect(tmp_path / "runtime.db") as db:
+        claim_trace = db.execute(
+            "SELECT trace_id FROM task_claims WHERE claim_id = ?",
+            (identity.claim_id,),
+        ).fetchone()[0]
+        run_trace = db.execute(
+            "SELECT trace_id FROM delegation_runs WHERE run_id = ?",
+            (identity.run_id,),
+        ).fetchone()[0]
+
+    assert stored_claim.metadata["execution_identity"]["run_id"] == identity.run_id
+    assert stored_run.metadata["execution_identity"]["trace_id"] == identity.trace_id
+    assert claim_trace == identity.trace_id
+    assert run_trace == identity.trace_id
+    assert ledger["identity"].run_id == identity.run_id
+    assert ledger["identity"].trace_id == identity.trace_id
+    assert ledger["run"].run_id == identity.run_id
+    assert receipt_types >= {"task_claim", "delegation_run", "child_spawned"}
+
+
+@pytest.mark.asyncio
+async def test_opportunity_dispatcher_creates_canonical_identity_per_stage(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DHARMA_STATE_DIR", str(tmp_path))
+    store = RuntimeStateStore(tmp_path / "runtime.db")
+    observed_telic_tasks: list[dict[str, object]] = []
+
+    class TelicProbe:
+        def record_dispatch(self, task, agent_id: str, topology: str) -> str:
+            observed_telic_tasks.append(dict(task.metadata))
+            return f"proposal-{task.metadata['stage']}"
+
+    dispatcher = OpportunityDispatcher(
+        state_store=store,
+        telic_seam=TelicProbe(),
+        session_id="session-opp",
+    )
+
+    results = dispatcher.dispatch_opportunity_sync(
+        {
+            "id": "opp-spine-a",
+            "title": "Spine A Opportunity",
+            "type": "external_revenue",
+            "trace_id": "trace-opp-spine-a",
+            "correlation_id": "corr-opp-spine-a",
+        }
+    )
+
+    assert len(results) == len(OPPORTUNITY_STAGES)
+    assert all(result.success for result in results)
+
+    for result in results:
+        ledger = await store.get_run_ledger(result.run_id)
+        receipt_types = {receipt.receipt_type for receipt in ledger["receipts"]}
+
+        assert ledger["identity"] is not None
+        assert ledger["identity"].run_id == result.run_id
+        assert ledger["identity"].claim_id == result.claim_id
+        assert ledger["identity"].task_id == result.task_id
+        assert ledger["identity"].trace_id == "trace-opp-spine-a"
+        assert ledger["identity"].proposal_id == result.proposal_id
+        assert ledger["run"].metadata.get("legacy_no_identity_allowed") is None
+        assert receipt_types >= {"task_claim", "delegation_run"}
+
+    assert len(observed_telic_tasks) == len(OPPORTUNITY_STAGES)
+    assert all("execution_identity" in metadata for metadata in observed_telic_tasks)
+    assert all(metadata["trace_id"] == "trace-opp-spine-a" for metadata in observed_telic_tasks)
+
+    with sqlite3.connect(tmp_path / "runtime.db") as db:
+        legacy_claims = db.execute(
+            "SELECT COUNT(*) FROM task_claims WHERE metadata_json LIKE '%legacy_no_identity_allowed%'"
+        ).fetchone()[0]
+        legacy_runs = db.execute(
+            "SELECT COUNT(*) FROM delegation_runs WHERE metadata_json LIKE '%legacy_no_identity_allowed%'"
+        ).fetchone()[0]
+
+    assert legacy_claims == 0
+    assert legacy_runs == 0


### PR DESCRIPTION
## Summary

Slice A for Runtime Spine Adoption Saturation.

- Closes the sync legacy RuntimeStateStore bypass by requiring `ExecutionIdentity` in `create_task_claim_sync` and `create_delegation_run_sync`, unless callers explicitly opt into `legacy_no_identity_allowed=True`.
- Wires `OpportunityDispatcher` to create and attach canonical identity before TelicSeam dispatch projection, then persist identity-backed task claims, delegation runs, and runtime receipts.
- Adds `tests/test_runtime_state_invariants.py` as the Slice A metric test target.
- Refreshes generated DocOps counts caused by adding the new invariant test file.

## Coherence Delta

Organ touched: RuntimeStateStore sync helper seam and OpportunityDispatcher ingress/projection path.

Declared-vs-actual gap closed: `create_task_claim_sync` and `create_delegation_run_sync` no longer silently create canonical-looking task/run rows without `ExecutionIdentity`; legacy writes must opt into `legacy_no_identity_allowed=True`. OpportunityDispatcher now attaches identity before TelicSeam projection.

Proof that re-reads the map: `tests/test_runtime_state_invariants.py` reconstructs each dispatched run through `RuntimeStateStore.get_run_ledger(run_id)` and verifies identity, trace, claim, task, receipts, and absence of legacy tags.

New drift introduced: limited to mechanical DocOps count refresh and the new runlog file; direct async RuntimeStateStore raw writes remain a known queued gap, not claimed as fixed here.

## Guardrails

- [impact-checked]
- No C2 ontology enforcement.
- No workflow engine unification.
- No Temporal/DBOS/Restate migration.
- No legacy helper removal; legacy path remains behind explicit `legacy_no_identity_allowed=True`.
- No seam spec edits to `MERGED_PLAN.md`, `01_gap_matrix.md`, `02_master_spec.md`, or `03_codex_55_plan.md`.

## Triple Witness

1. Passing tests:
   - `pytest -q tests/test_runtime_state_invariants.py` -> `3 passed`
   - `pytest -q tests/test_authority_revenue_loop.py tests/test_runtime_state.py tests/test_runtime_lifecycle.py tests/test_runtime_truth_spine_v1.py tests/test_runtime_truth_spine_v2_evidence.py` -> `38 passed, 1 skipped`
   - v2 baseline command -> `159 passed`

2. Code evidence:
   - `dharma_swarm/runtime_state.py`: sync helpers now require identity or explicit legacy flag.
   - `dharma_swarm/opportunity_dispatcher.py`: identity is attached before `record_dispatch`.
   - `tests/test_runtime_state_invariants.py`: proves missing identity fails closed on sync helpers, legacy path is tagged/noncanonical, and OpportunityDispatcher emits identity-backed ledgers.

3. External grounding:
   - Azure Strangler Fig Pattern: https://learn.microsoft.com/en-us/azure/architecture/patterns/strangler-fig
   - Temporal idempotency/durable execution framing: https://temporal.io/blog/idempotency-and-durable-execution

## Verification

```bash
python -m compileall -q dharma_swarm/runtime_state.py dharma_swarm/opportunity_dispatcher.py tests/test_runtime_state_invariants.py tests/test_authority_revenue_loop.py
pytest -q tests/test_runtime_state_invariants.py
pytest -q tests/test_authority_revenue_loop.py tests/test_runtime_state.py tests/test_runtime_lifecycle.py tests/test_runtime_truth_spine_v1.py tests/test_runtime_truth_spine_v2_evidence.py
env HOME=/private/tmp/dharma_spine_slice_a_baseline_home2 pytest -q tests/test_runtime_truth_spine_v1.py tests/test_runtime_truth_spine_v2_adapters.py tests/test_runtime_truth_spine_v2_evidence.py tests/test_runtime_truth_spine_v2_tollbooth.py tests/test_runtime_state.py tests/test_runtime_lifecycle.py tests/test_a2a_spec_conformance.py tests/test_message_bus.py tests/test_checkpoint.py tests/test_orchestrator.py
git diff --check
env DHARMA_UPLIFT_ACK=impact-checked python3 scripts/uplift_guards/run_pre_commit.py
python3 scripts/docops/check_docops_integrity.py
```

## Known Remaining Gaps

- Direct async `RuntimeStateStore.record_task_claim`, `record_delegation_run`, and `record_artifact` remain permissive raw-store surfaces. They are not claimed as fixed by Slice A and should be handled by the next adapter/receipt slices.
- Orchestrator artifact file writes still need side-effect intent before file write in a later slice.
- C2 ontology enforcement remains queued by design; this PR does not implement `ActionDef.modifies` or `requires_approval`.
