### PR TITLE
feat(kaizen): bind reviews to runtime truth refs

### DIFF
--- a/dharma_swarm/daily_operating_brief.py
+++ b/dharma_swarm/daily_operating_brief.py
@@ -233,8 +233,21 @@ def _kaizen_lines(reports_dir: Path | None, missing: list[str]) -> list[str]:
         status = _string(report.get("status") or report.get("verdict") or "recorded")
         score = report.get("score") or report.get("quality_score") or report.get("forge_score")
         suffix = f", advisory score `{score}`" if score is not None else ""
+        suffix += _kaizen_runtime_suffix(report)
         lines.append(f"KaizenReview `{label}` {status}{suffix}.")
     return lines
+
+
+def _kaizen_runtime_suffix(report: dict[str, Any]) -> str:
+    summary = report.get("runtime_truth_summary")
+    if not isinstance(summary, dict):
+        return ""
+    jobs_with_refs = _intish(summary.get("jobs_with_refs"))
+    jobs_without_refs = _intish(summary.get("jobs_without_refs"))
+    total = jobs_with_refs + jobs_without_refs
+    if not total:
+        return ""
+    return f", runtime refs `{jobs_with_refs}/{total}`"
 
 
 def _yds_lines(path: Path | None, missing: list[str]) -> list[str]:

--- a/dharma_swarm/operator_core/operating_facts.py
+++ b/dharma_swarm/operator_core/operating_facts.py
@@ -15,6 +15,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable
 
+from dharma_swarm.operator_core.runtime_truth_refs import runtime_ref_values
 from dharma_swarm.operator_core.telic_value_reader import read_telic_value_summary
 
 
@@ -183,6 +184,12 @@ class KaizenReviewFact:
     waste_patterns: tuple[str, ...] = ()
     stop_doing_items: tuple[str, ...] = ()
     playbook_update_candidates: tuple[str, ...] = ()
+    runtime_truth_ref_keys: tuple[str, ...] = ()
+    runtime_truth_jobs_with_refs: int = 0
+    runtime_truth_jobs_without_refs: int = 0
+    receipt_refs: tuple[str, ...] = ()
+    correlation_ids: tuple[str, ...] = ()
+    identity_invariant_digests: tuple[str, ...] = ()
     has_human_yds_rating: bool = False
 
 
@@ -287,6 +294,9 @@ def load_agentops_run_facts(path: Path | None) -> list[AgentOpsRunFact]:
 def load_kaizen_review_facts(path: Path | None) -> list[KaizenReviewFact]:
     facts: list[KaizenReviewFact] = []
     for report_path, report in _json_reports(path, "kaizen_review.json"):
+        runtime_summary = report.get("runtime_truth_summary")
+        if not isinstance(runtime_summary, dict):
+            runtime_summary = {}
         facts.append(
             KaizenReviewFact(
                 source_path=report_path.as_posix(),
@@ -295,6 +305,14 @@ def load_kaizen_review_facts(path: Path | None) -> list[KaizenReviewFact]:
                 waste_patterns=_strings(report.get("waste_patterns")),
                 stop_doing_items=_strings(report.get("stop_doing_items")),
                 playbook_update_candidates=_strings(report.get("playbook_update_candidates")),
+                runtime_truth_ref_keys=_strings(runtime_summary.get("ref_keys")),
+                runtime_truth_jobs_with_refs=_int(runtime_summary.get("jobs_with_refs")),
+                runtime_truth_jobs_without_refs=_int(runtime_summary.get("jobs_without_refs")),
+                receipt_refs=runtime_ref_values(
+                    report, ("receipt_id", "receipt_hash", "receipt_refs", "runtime_receipt_refs")
+                ),
+                correlation_ids=runtime_ref_values(report, ("run_id", "trace_id", "correlation_id")),
+                identity_invariant_digests=runtime_ref_values(report, ("identity_invariant_digest",)),
                 has_human_yds_rating=bool(report.get("human_yds_rating")),
             )
         )
@@ -575,13 +593,34 @@ def _kaizen_organ_state(boundary: OrganBoundary, bundle: OperatingFactBundle) ->
             "KaizenReview has no report fact in this bundle",
             "run KaizenReview from a completed AgentOps report",
         )
-    evidence = tuple(review.source_path for review in bundle.kaizen)
-    if any(review.next_recommendation for review in bundle.kaizen):
+    evidence = tuple(
+        ref
+        for review in bundle.kaizen
+        for ref in (
+            review.source_path,
+            *review.receipt_refs,
+            *review.correlation_ids,
+            *review.identity_invariant_digests,
+        )
+        if ref
+    )
+    has_next = any(review.next_recommendation for review in bundle.kaizen)
+    has_runtime_refs = any(review.runtime_truth_jobs_with_refs for review in bundle.kaizen)
+    if has_next and has_runtime_refs:
         return _state(
             boundary,
-            observed_state="KaizenReview report includes next-packet recommendation",
+            observed_state="KaizenReview report includes next-packet recommendation and runtime truth refs",
             coherence_state="bound",
             evidence_refs=evidence,
+        )
+    if has_next:
+        return _state(
+            boundary,
+            observed_state="KaizenReview report includes next-packet recommendation without runtime truth refs",
+            coherence_state="partial",
+            evidence_refs=evidence,
+            open_gap="review feeds the next packet but is not tied to runtime truth refs",
+            next_packet_hint="rerun KaizenReview from AgentOps reports carrying trace, receipt, or identity refs",
         )
     return _state(
         boundary,

--- a/dharma_swarm/operator_core/runtime_truth_refs.py
+++ b/dharma_swarm/operator_core/runtime_truth_refs.py
@@ -1,0 +1,41 @@
+"""Read-only helpers for carrying runtime truth references across organs."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def runtime_ref_values(report: dict[str, Any], keys: tuple[str, ...]) -> tuple[str, ...]:
+    values: list[str] = []
+    _collect(report.get("runtime_truth_refs"), keys, values)
+    _collect(report.get("runtime_truth"), keys, values)
+    _collect(report.get("runtime_state"), keys, values)
+    return tuple(sorted(set(values)))
+
+
+def _collect(value: Any, keys: tuple[str, ...], values: list[str]) -> None:
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if str(key) in keys:
+                _append(item, values)
+            else:
+                _collect(item, keys, values)
+        return
+    if isinstance(value, list):
+        for item in value:
+            _collect(item, keys, values)
+
+
+def _append(value: Any, values: list[str]) -> None:
+    if isinstance(value, (str, int, float, bool)):
+        cleaned = str(value).strip()
+        if cleaned:
+            values.append(cleaned)
+        return
+    if isinstance(value, list):
+        for item in value:
+            _append(item, values)
+        return
+    if isinstance(value, dict):
+        for item in value.values():
+            _append(item, values)

--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -6,13 +6,13 @@ Do not hand-edit the generated block.
 <!-- DOCOPS:START metric=repo_inventory -->
 | Metric | Value |
 |---|---:|
-| Dharma Python modules | 665 |
+| Dharma Python modules | 666 |
 | Top-level Dharma Python modules | 391 |
-| Dharma Python LOC | 283,151 |
+| Dharma Python LOC | 283,244 |
 | Test files | 637 |
-| Test function occurrences | 10,982 |
+| Test function occurrences | 10,984 |
 | Markdown files | 843 |
-| Markdown total lines | 209,252 |
+| Markdown total lines | 209,264 |
 | Bridge files | 24 |
 | Adapter files | 21 |
 | Orchestrator files | 4 |

--- a/docs/governance/KAIZENOPS.md
+++ b/docs/governance/KAIZENOPS.md
@@ -8,7 +8,9 @@ It is intentionally narrow:
 - input: one or more AgentOps `report.json` files (or directories)
 - output: `kaizen_review.json` and `kaizen_review.md`
 - scope: local file processing only
-- no dashboard/API/runtime/ontology wiring
+- runtime truth: read-only trace, receipt, and identity references copied from
+  source AgentOps reports
+- no dashboard/API/runtime/ontology ownership
 
 ## Command
 
@@ -35,6 +37,16 @@ The review includes:
 - stop-doing items
 - playbook candidates
 - exactly one next-work-packet recommendation
+- runtime truth reference summary when the source reports include trace,
+  receipt, or identity refs
+
+## Runtime Truth Boundary
+
+KaizenReview may copy runtime truth references from AgentOps reports so the
+review can be traced back to execution evidence. It does not create receipt
+authority, claim NATS live contact, dispatch work, mutate ontology, or decide
+Forge fitness. Missing runtime refs make the review less bound to the runtime
+truth spine; invented refs are invalid.
 
 ## Human YDS Boundary
 

--- a/docs/governance/SOVEREIGN_MANIFEST.md
+++ b/docs/governance/SOVEREIGN_MANIFEST.md
@@ -117,15 +117,15 @@ These are the ground-truth metrics. All other documents citing different numbers
 
 | Metric | Value | Verification |
 |--------|-------|-------------|
-| Total Python modules | **665** | find dharma_swarm -name "*.py" -type f |
-| Top-level (flat) modules | **391 (58.8%)** | find dharma_swarm -maxdepth 1 -name "*.py" -type f |
-| Total Python LOC | **283,151** | wc -l across dharma_swarm Python modules |
+| Total Python modules | **666** | find dharma_swarm -name "*.py" -type f |
+| Top-level (flat) modules | **391 (58.7%)** | find dharma_swarm -maxdepth 1 -name "*.py" -type f |
+| Total Python LOC | **283,244** | wc -l across dharma_swarm Python modules |
 | Test files | **637** | find tests -name "*.py" -type f |
-| Test functions | **10,982 `def test_` occurrences under tests/** | rg "def test_" tests |
+| Test functions | **10,984 `def test_` occurrences under tests/** | rg "def test_" tests |
 | Tests collected (pytest) | **Needs write-permitted refresh** | not run during this DocOps count pass |
 | Collection errors | **Historical: 16 on 2026-04-04** | refresh before relying on this count |
 | Markdown files | **843** | find . -name "*.md" -type f |
-| Markdown total lines | **209,252** | wc -l across all .md |
+| Markdown total lines | **209,264** | wc -l across all .md |
 | Bridge files | **24** | find dharma_swarm -name "*bridge*.py" |
 | Adapter files | **21 across 8 locations** | find dharma_swarm -type f \| rg -i "adapter" |
 | Orchestrator files | **4** (6,034 LOC total) | find dharma_swarm -name "*orchestrat*" |

--- a/scripts/governance/kaizen_review_from_agentops.py
+++ b/scripts/governance/kaizen_review_from_agentops.py
@@ -37,6 +37,7 @@ class AgentOpsSnapshot:
     changed_files: list[str]
     failed_gates: list[str]
     commit_hash: str | None
+    runtime_truth_refs: dict[str, Any]
 
 
 class KaizenBridgeError(Exception):
@@ -108,6 +109,63 @@ def _commit_state(report: dict[str, Any]) -> tuple[str, str | None]:
     return "no_commit", None
 
 
+def _jsonable(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, list):
+        return [_jsonable(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _jsonable(item) for key, item in value.items()}
+    return str(value)
+
+
+def _clean_string(value: Any) -> str:
+    return str(value).strip() if value is not None else ""
+
+
+def _runtime_truth_refs(report: dict[str, Any]) -> dict[str, Any]:
+    refs: dict[str, Any] = {}
+    scalar_keys = (
+        "agent_uid",
+        "run_id",
+        "trace_id",
+        "correlation_id",
+        "receipt_id",
+        "receipt_hash",
+        "identity_invariant_digest",
+    )
+    list_keys = (
+        "receipt_refs",
+        "runtime_receipt_refs",
+        "runtime_receipts",
+        "evidence_refs",
+    )
+    nested_keys = (
+        "runtime_truth",
+        "runtime_state",
+        "runtime",
+        "spine",
+        "identity",
+    )
+
+    for key in scalar_keys:
+        cleaned = _clean_string(report.get(key))
+        if cleaned:
+            refs[key] = cleaned
+
+    for key in list_keys:
+        value = report.get(key)
+        if isinstance(value, list) and value:
+            refs[key] = _jsonable(value)
+
+    for key in nested_keys:
+        value = report.get(key)
+        if isinstance(value, dict) and value:
+            refs[key] = _jsonable(value)
+
+    return refs
+
+
 def _to_snapshot(report_path: Path, report: dict[str, Any]) -> AgentOpsSnapshot:
     gate_state, failed_gates = _gate_state(report)
     scope_state, changed_files = _scope_state(report)
@@ -131,6 +189,7 @@ def _to_snapshot(report_path: Path, report: dict[str, Any]) -> AgentOpsSnapshot:
         changed_files=changed_files,
         failed_gates=failed_gates,
         commit_hash=commit_hash,
+        runtime_truth_refs=_runtime_truth_refs(report),
     )
 
 
@@ -239,6 +298,27 @@ def build_kaizen_review(report_paths: list[Path], *, review_id: str) -> dict[str
         "human_approval_needed": commit_approval_blocked,
         "human_approval_not_needed": len(snapshots) - commit_approval_blocked,
     }
+    runtime_truth_refs = [
+        {
+            "job_id": s.job_id,
+            "source_report": str(s.report_path),
+            "refs": s.runtime_truth_refs,
+        }
+        for s in snapshots
+        if s.runtime_truth_refs
+    ]
+    runtime_ref_keys = sorted(
+        {
+            key
+            for snapshot in snapshots
+            for key in snapshot.runtime_truth_refs
+        }
+    )
+    runtime_truth_summary = {
+        "jobs_with_refs": len(runtime_truth_refs),
+        "jobs_without_refs": len(snapshots) - len(runtime_truth_refs),
+        "ref_keys": runtime_ref_keys,
+    }
     playbook_candidates = _playbook_candidates(snapshots)
 
     return {
@@ -253,11 +333,14 @@ def build_kaizen_review(report_paths: list[Path], *, review_id: str) -> dict[str
         "scope_summary": scope_summary,
         "commit_summary": commit_summary,
         "approval_summary": approval_summary,
+        "runtime_truth_summary": runtime_truth_summary,
+        "runtime_truth_refs": runtime_truth_refs,
         "summary": {
             "jobs": len(snapshots),
             "gate_counts": gate_summary,
             "scope_counts": scope_summary,
             "commit_counts": commit_summary,
+            "runtime_truth": runtime_truth_summary,
         },
         "jobs": [
             {
@@ -269,6 +352,7 @@ def build_kaizen_review(report_paths: list[Path], *, review_id: str) -> dict[str
                 "failed_gates": s.failed_gates,
                 "changed_files": s.changed_files,
                 "commit_hash": s.commit_hash,
+                "runtime_truth_refs": s.runtime_truth_refs,
             }
             for s in snapshots
         ],
@@ -311,6 +395,22 @@ def render_markdown(review: dict[str, Any]) -> str:
     lines.extend(f"- {item}" for item in review.get("stop_doing_items", []))
     lines.extend(["", "## Playbook Candidates", ""])
     lines.extend(f"- {item}" for item in review.get("playbook_candidates", []))
+    runtime_summary = review.get("runtime_truth_summary")
+    lines.extend(["", "## Runtime Truth References", ""])
+    if isinstance(runtime_summary, dict):
+        lines.append(
+            "- Jobs with runtime refs: "
+            f"`{runtime_summary.get('jobs_with_refs', 0)}`; "
+            "without refs: "
+            f"`{runtime_summary.get('jobs_without_refs', 0)}`."
+        )
+        ref_keys = runtime_summary.get("ref_keys", [])
+        if isinstance(ref_keys, list) and ref_keys:
+            lines.append(f"- Ref keys copied from AgentOps reports: `{', '.join(str(k) for k in ref_keys)}`.")
+        else:
+            lines.append("- No runtime truth reference keys were present in the source reports.")
+    else:
+        lines.append("- No runtime truth references were present in this review.")
     lines.extend(
         [
             "",

--- a/tests/test_daily_operating_brief.py
+++ b/tests/test_daily_operating_brief.py
@@ -87,6 +87,11 @@ def test_reads_kaizen_review_from_agentops_bridge_output(tmp_path: Path) -> None
                 "title": "KaizenReview for kaizen-v0",
                 "status": "recorded",
                 "quality_score": 0.82,
+                "runtime_truth_summary": {
+                    "jobs_with_refs": 1,
+                    "jobs_without_refs": 0,
+                    "ref_keys": ["trace_id", "receipt_refs"],
+                },
                 "human_yds_rating": None,
             }
         ),
@@ -98,7 +103,10 @@ def test_reads_kaizen_review_from_agentops_bridge_output(tmp_path: Path) -> None
     )
 
     rendered = render_markdown(brief)
-    assert "KaizenReview `KaizenReview for kaizen-v0` recorded, advisory score `0.82`." in rendered
+    assert (
+        "KaizenReview `KaizenReview for kaizen-v0` recorded, "
+        "advisory score `0.82`, runtime refs `1/1`."
+    ) in rendered
 
 
 def test_reads_human_yds_jsonl_rating_and_includes_it(tmp_path: Path) -> None:

--- a/tests/test_kaizen_review_from_agentops.py
+++ b/tests/test_kaizen_review_from_agentops.py
@@ -18,6 +18,7 @@ def _write_agentops_report(
     gates: list[dict[str, object]],
     commit_hash: str | None = None,
     commit_decision: str = "not evaluated",
+    runtime_refs: dict[str, object] | None = None,
 ) -> Path:
     report_dir = root / job_id / "20260506T000000000000Z"
     report_dir.mkdir(parents=True, exist_ok=True)
@@ -35,6 +36,8 @@ def _write_agentops_report(
         "commit_hash": commit_hash,
         "commit_decision": commit_decision,
     }
+    if runtime_refs:
+        payload.update(runtime_refs)
     path = report_dir / "report.json"
     path.write_text(json.dumps(payload), encoding="utf-8")
     return path
@@ -95,6 +98,9 @@ def test_bridge_generates_json_and_markdown_from_reports_directory(tmp_path: Pat
     assert review["scope_summary"] == review["summary"]["scope_counts"]
     assert review["commit_summary"] == review["summary"]["commit_counts"]
     assert review["approval_summary"]["human_approval_needed"] == 1
+    assert review["runtime_truth_summary"]["jobs_with_refs"] == 0
+    assert review["runtime_truth_summary"]["jobs_without_refs"] == 2
+    assert review["runtime_truth_refs"] == []
     assert review["summary"]["gate_counts"]["green"] == 1
     assert review["summary"]["gate_counts"]["red"] == 1
     assert review["summary"]["scope_counts"]["clean"] == 1
@@ -110,8 +116,59 @@ def test_bridge_generates_json_and_markdown_from_reports_directory(tmp_path: Pat
     assert review["next_work_packet_recommendation"].strip() != ""
 
     markdown = md_path.read_text(encoding="utf-8")
+    assert "## Runtime Truth References" in markdown
+    assert "No runtime truth reference keys were present" in markdown
     assert "## Human YDS Boundary" in markdown
     assert "AI does not assign authoritative YDS ratings." in markdown
+
+
+def test_bridge_copies_runtime_truth_refs_without_inventing_authority(tmp_path: Path) -> None:
+    reports_root = tmp_path / "reports" / "agentops"
+    _write_agentops_report(
+        reports_root,
+        job_id="job-traced",
+        status="passed",
+        scope_passed=True,
+        gates=[{"name": "pytest", "exit_code": 0, "passed": True}],
+        commit_hash="abc123",
+        runtime_refs={
+            "trace_id": "trace-1",
+            "correlation_id": "corr-1",
+            "receipt_refs": ["receipt://agentops/job-traced"],
+            "identity_invariant_digest": "identity-digest-1",
+            "runtime_truth": {"nats_contact": "HANDLER_ACKED"},
+        },
+    )
+
+    result = _run_cli(
+        str(reports_root),
+        "--id",
+        "kaizen-runtime",
+        "--output-root",
+        str(tmp_path / "reports" / "kaizen"),
+        cwd=Path.cwd(),
+    )
+    assert result.returncode == 0, result.stderr
+
+    review_path = tmp_path / "reports" / "kaizen" / "kaizen-runtime" / "kaizen_review.json"
+    review = json.loads(review_path.read_text(encoding="utf-8"))
+
+    assert review["runtime_truth_summary"] == {
+        "jobs_with_refs": 1,
+        "jobs_without_refs": 0,
+        "ref_keys": [
+            "correlation_id",
+            "identity_invariant_digest",
+            "receipt_refs",
+            "runtime_truth",
+            "trace_id",
+        ],
+    }
+    assert review["jobs"][0]["runtime_truth_refs"]["trace_id"] == "trace-1"
+    assert review["runtime_truth_refs"][0]["refs"]["receipt_refs"] == [
+        "receipt://agentops/job-traced"
+    ]
+    assert review["human_yds_rating"] is None
 
 
 def test_bridge_accepts_explicit_report_file_inputs(tmp_path: Path) -> None:

--- a/tests/test_operating_facts.py
+++ b/tests/test_operating_facts.py
@@ -10,6 +10,7 @@ from dharma_swarm.operator_core.operating_facts import (
     build_operating_fact_bundle,
     bundle_to_dict,
     load_agentops_run_facts,
+    load_kaizen_review_facts,
     load_human_yds_rating_facts,
     organ_boundary_map,
     organ_state_facts,
@@ -72,7 +73,11 @@ def test_load_agentops_run_facts_normalizes_report_shape(tmp_path: Path) -> None
     assert fact.scope_violations == ("api/main.py",)
 
 
-def test_organ_state_facts_project_declared_vs_observed_state(tmp_path: Path) -> None:
+def test_organ_state_facts_project_declared_vs_observed_state(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
     report_path = tmp_path / "reports" / "agentops" / "job-red" / "20260505" / "report.json"
     _write_json(
         report_path,
@@ -124,6 +129,22 @@ def test_operating_fact_bundle_reads_all_organs_without_mutating(tmp_path: Path)
             "waste_patterns": [],
             "stop_doing_items": [],
             "playbook_update_candidates": ["Promote the green packet shape."],
+            "runtime_truth_summary": {
+                "jobs_with_refs": 1,
+                "jobs_without_refs": 0,
+                "ref_keys": ["trace_id", "receipt_refs", "identity_invariant_digest"],
+            },
+            "runtime_truth_refs": [
+                {
+                    "job_id": "job-green",
+                    "source_report": "report.json",
+                    "refs": {
+                        "trace_id": "trace-1",
+                        "receipt_refs": ["receipt://job-green"],
+                        "identity_invariant_digest": "identity-digest-1",
+                    },
+                }
+            ],
             "human_yds_rating": None,
         },
     )
@@ -156,9 +177,64 @@ def test_operating_fact_bundle_reads_all_organs_without_mutating(tmp_path: Path)
     assert bundle.missing_sources == ()
     assert bundle.agentops[0].commit_state == "commit_created"
     assert bundle.kaizen[0].next_recommendation == "request human YDS rating"
+    assert bundle.kaizen[0].runtime_truth_jobs_with_refs == 1
+    assert bundle.kaizen[0].receipt_refs == ("receipt://job-green",)
+    assert bundle.kaizen[0].correlation_ids == ("trace-1",)
+    assert bundle.kaizen[0].identity_invariant_digests == ("identity-digest-1",)
     assert bundle.human_yds[0].authoritative is True
     assert bundle.burn[0].total_cost_usd == 0.03
     assert bundle.revenue[0].keywords == ("wedge", "pricing")
+
+
+def test_kaizen_review_state_requires_runtime_truth_refs_to_be_bound(tmp_path: Path) -> None:
+    kaizen_root = tmp_path / "kaizen"
+    review_path = kaizen_root / "latest" / "kaizen_review.json"
+    _write_json(
+        review_path,
+        {
+            "jobs_reviewed": 1,
+            "next_work_packet_recommendation": "rerun with trace refs",
+            "runtime_truth_summary": {
+                "jobs_with_refs": 0,
+                "jobs_without_refs": 1,
+                "ref_keys": [],
+            },
+            "runtime_truth_refs": [],
+        },
+    )
+
+    reviews = load_kaizen_review_facts(kaizen_root)
+    states = {fact.name: fact for fact in organ_state_facts(OperatingFactBundle(kaizen=tuple(reviews)))}
+
+    assert states["kaizen_review"].coherence_state == "partial"
+    assert "not tied to runtime truth refs" in states["kaizen_review"].open_gap
+
+    _write_json(
+        review_path,
+        {
+            "jobs_reviewed": 1,
+            "next_work_packet_recommendation": "promote traced packet shape",
+            "runtime_truth_summary": {
+                "jobs_with_refs": 1,
+                "jobs_without_refs": 0,
+                "ref_keys": ["trace_id", "receipt_refs"],
+            },
+            "runtime_truth_refs": [
+                {
+                    "job_id": "job-green",
+                    "refs": {
+                        "trace_id": "trace-1",
+                        "receipt_refs": ["receipt://job-green"],
+                    },
+                }
+            ],
+        },
+    )
+    reviews = load_kaizen_review_facts(kaizen_root)
+    states = {fact.name: fact for fact in organ_state_facts(OperatingFactBundle(kaizen=tuple(reviews)))}
+
+    assert states["kaizen_review"].coherence_state == "bound"
+    assert "receipt://job-green" in states["kaizen_review"].evidence_refs
 
 
 def test_non_human_yds_records_are_advisory_only(tmp_path: Path) -> None:

--- a/tests/test_operating_facts_and_daily_brief.py
+++ b/tests/test_operating_facts_and_daily_brief.py
@@ -78,7 +78,11 @@ def test_load_agentops_run_facts_normalizes_report_shape(tmp_path: Path) -> None
     assert fact.scope_violations == ("api/main.py",)
 
 
-def test_organ_state_facts_project_declared_vs_observed_state(tmp_path: Path) -> None:
+def test_organ_state_facts_project_declared_vs_observed_state(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
     report_path = tmp_path / "reports" / "agentops" / "job-red" / "20260505" / "report.json"
     _write_json(
         report_path,
@@ -101,7 +105,7 @@ def test_organ_state_facts_project_declared_vs_observed_state(tmp_path: Path) ->
 
     assert states["agentops"].coherence_state == "drifted"
     assert states["kaizen_review"].coherence_state == "declared_only"
-    assert states["telic_value"].coherence_state == "unknown"
+    assert states["telic_value"].coherence_state == "declared_only"
     assert payload["organ_states"][0]["name"] == "agentops"
 
 


### PR DESCRIPTION
## Summary
- Carry runtime truth refs from AgentOps reports into KaizenReview JSON/Markdown without creating receipt authority.
- Project Kaizen runtime refs into operating facts and daily operating brief lines.
- Document the Kaizen runtime-truth boundary, split the runtime-ref flattener under module budget, and refresh DocOps inventory metrics.

## Coherence Delta
- Organ touched: KaizenReview Bridge, operating facts, Daily Operating Brief.
- Declared-vs-actual gap closed: KaizenReview was declared as continuous-improvement evidence but could not re-read runtime truth refs; it now carries trace/receipt/identity refs from AgentOps reports into the operating-fact membrane.
- Proof that re-reads the map: make onboard; python scripts/governance/check_track_status.py; make governance-all; targeted Kaizen/operating-facts/daily-brief tests.
- New drift introduced: None intentional. Kaizen still does not own NATS live contact, receipt authority, ontology mutation, dispatch, Human YDS, or Forge fitness. CI module-budget drift was fixed by moving runtime ref flattening to dharma_swarm/operator_core/runtime_truth_refs.py.

## Verification
- make onboard
- python scripts/governance/check_track_status.py
- python -m pytest -q tests/test_kaizen_review_from_agentops.py tests/test_operating_facts.py tests/test_operating_facts_and_daily_brief.py tests/test_daily_operating_brief.py --tb=short
- python3 scripts/governance/check_module_budget.py --base-ref origin/main --head-ref HEAD
- make test-contracts
- make docops-integrity
- make governance-all
- git diff --check