### PR TITLE
feat(spine): saturate runtime boundary adapters [impact-checked]

### DIFF
--- a/dharma_swarm/artifact_manifest.py
+++ b/dharma_swarm/artifact_manifest.py
@@ -214,6 +214,7 @@ class ArtifactManifestStore:
             session_id=manifest.session_id,
             task_id=manifest.task_id,
             run_id=manifest.run_id,
+            trace_id=manifest.trace_id,
             manifest_path=str(manifest_path),
             payload_path=manifest.payload_path,
             checksum=manifest.payload_checksum,

--- a/dharma_swarm/artifact_store.py
+++ b/dharma_swarm/artifact_store.py
@@ -12,6 +12,8 @@ from uuid import uuid4
 from dharma_swarm.artifact_manifest import ArtifactManifestStore
 from dharma_swarm.engine.artifacts import ArtifactRef, ArtifactStore as EngineArtifactStore
 from dharma_swarm.runtime_state import ArtifactRecord, RuntimeStateStore
+from dharma_swarm.spine.adapters import identity_from_carrier, identity_metadata
+from dharma_swarm.spine.identity import ExecutionIdentity, MissingExecutionIdentity
 
 DEFAULT_ARTIFACT_ROOT = Path.home() / ".dharma" / "workspace" / "sessions"
 
@@ -31,11 +33,138 @@ class RuntimeArtifactStore:
         base_dir: Path | str | None = None,
         *,
         runtime_state: RuntimeStateStore | None = None,
+        require_identity: bool = False,
     ) -> None:
         self.base_dir = Path(base_dir or DEFAULT_ARTIFACT_ROOT)
         self.runtime_state = runtime_state
+        self.require_identity = require_identity
         self._engine = EngineArtifactStore(self.base_dir)
         self._manifests = ArtifactManifestStore()
+
+    def _resolve_identity(
+        self,
+        *,
+        surface: str,
+        session_id: str,
+        artifact_kind: str,
+        task_id: str,
+        run_id: str,
+        trace_id: str,
+        created_by: str,
+        metadata: dict[str, Any] | None,
+        execution_identity: ExecutionIdentity | None,
+        require_identity: bool,
+    ) -> ExecutionIdentity | None:
+        if execution_identity is not None:
+            return execution_identity.require_for_dispatch()
+        if require_identity and self.runtime_state is None:
+            raise MissingExecutionIdentity("RuntimeStateStore is required when RuntimeArtifactStore requires ExecutionIdentity")
+        carrier = {
+            "artifact_id": "",
+            "task_id": task_id,
+            "run_id": run_id,
+            "trace_id": trace_id,
+            "agent_id": created_by,
+            "session_id": session_id,
+            "metadata": metadata or {},
+        }
+        if require_identity:
+            return identity_from_carrier(carrier, surface=surface, require_existing=True)
+        existing = ExecutionIdentity.from_metadata(metadata, require=False)
+        if existing is not None:
+            return existing.require_for_dispatch()
+        if self.runtime_state is not None:
+            return identity_from_carrier(
+                carrier,
+                surface=surface,
+                task_id=task_id or f"artifact:{artifact_kind}",
+                agent_id=created_by,
+                session_id=session_id,
+            )
+        return None
+
+    def _prepare_identity_fields(
+        self,
+        *,
+        surface: str,
+        session_id: str,
+        artifact_kind: str,
+        task_id: str,
+        run_id: str,
+        trace_id: str,
+        created_by: str,
+        metadata: dict[str, Any] | None,
+        execution_identity: ExecutionIdentity | None,
+        require_identity: bool | None,
+    ) -> tuple[ExecutionIdentity | None, str, str, str, dict[str, Any] | None]:
+        effective_require = self.require_identity if require_identity is None else require_identity
+        meta = dict(metadata or {})
+        identity = self._resolve_identity(
+            surface=surface,
+            session_id=session_id,
+            artifact_kind=artifact_kind,
+            task_id=task_id,
+            run_id=run_id,
+            trace_id=trace_id,
+            created_by=created_by,
+            metadata=meta,
+            execution_identity=execution_identity,
+            require_identity=effective_require,
+        )
+        if identity is None:
+            return None, task_id, run_id, trace_id, metadata
+        meta.update(identity_metadata(identity, surface=surface))
+        return identity, task_id or identity.task_id, run_id or identity.run_id, trace_id or identity.trace_id, meta
+
+    def _record_artifact_intent_sync(
+        self,
+        identity: ExecutionIdentity | None,
+        *,
+        side_effect_key: str,
+        payload: dict[str, Any],
+    ) -> None:
+        if identity is None or self.runtime_state is None:
+            return
+        self.runtime_state.record_execution_identity_sync(
+            identity,
+            source="artifact_store",
+            metadata={"surface": "artifact_store", **payload},
+        )
+        self.runtime_state.record_side_effect_intent_sync(
+            identity,
+            side_effect_key,
+            payload=payload,
+        )
+
+    def _record_artifact_complete_sync(
+        self,
+        identity: ExecutionIdentity | None,
+        *,
+        side_effect_key: str,
+        artifact_id: str,
+        payload: dict[str, Any],
+    ) -> None:
+        if identity is None or self.runtime_state is None:
+            return
+        updated = identity.with_updates(artifact_id=artifact_id)
+        self.runtime_state.record_execution_identity_sync(
+            updated,
+            source="artifact_store",
+            metadata={"surface": "artifact_store", **payload},
+        )
+        self.runtime_state.record_receipt_for_identity_sync(
+            updated,
+            receipt_type="artifact_written",
+            status="completed",
+            side_effect_key=f"artifact:{artifact_id}",
+            payload={"artifact_id": artifact_id, **payload},
+        )
+        self.runtime_state.record_side_effect_complete_sync(
+            updated,
+            side_effect_key,
+            result_receipt_id=artifact_id,
+            payload={"artifact_id": artifact_id, **payload},
+        )
 
     def create_text_artifact(
         self,
@@ -57,7 +186,27 @@ class RuntimeArtifactStore:
         citations: list[str] | None = None,
         depends_on: list[str] | None = None,
         confidence: float = 0.0,
+        execution_identity: ExecutionIdentity | None = None,
+        require_identity: bool | None = None,
     ) -> StoredArtifact:
+        identity, task_id, run_id, trace_id, metadata = self._prepare_identity_fields(
+            surface="artifact_store",
+            session_id=session_id,
+            artifact_kind=artifact_kind,
+            task_id=task_id,
+            run_id=run_id,
+            trace_id=trace_id,
+            created_by=created_by,
+            metadata=metadata,
+            execution_identity=execution_identity,
+            require_identity=require_identity,
+        )
+        side_effect_key = f"artifact_store.write:{identity.idempotency_key}" if identity else ""
+        self._record_artifact_intent_sync(
+            identity,
+            side_effect_key=side_effect_key,
+            payload={"operation": "create_text_artifact", "artifact_kind": artifact_kind},
+        )
         ref = self._engine.create_artifact(
             session_id=session_id,
             artifact_type=artifact_type,
@@ -69,7 +218,7 @@ class RuntimeArtifactStore:
             depends_on=depends_on,
             metadata=metadata,
         )
-        return self._record_ref(
+        stored = self._record_ref(
             ref,
             artifact_kind=artifact_kind,
             task_id=task_id,
@@ -81,6 +230,13 @@ class RuntimeArtifactStore:
             provenance=provenance,
             metadata=metadata,
         )
+        self._record_artifact_complete_sync(
+            identity,
+            side_effect_key=side_effect_key,
+            artifact_id=ref.artifact_id,
+            payload={"operation": "create_text_artifact", "artifact_kind": artifact_kind},
+        )
+        return stored
 
     async def create_text_artifact_async(
         self,
@@ -102,6 +258,8 @@ class RuntimeArtifactStore:
         citations: list[str] | None = None,
         depends_on: list[str] | None = None,
         confidence: float = 0.0,
+        execution_identity: ExecutionIdentity | None = None,
+        require_identity: bool | None = None,
     ) -> StoredArtifact:
         stored = self.create_text_artifact(
             session_id=session_id,
@@ -121,6 +279,8 @@ class RuntimeArtifactStore:
             citations=citations,
             depends_on=depends_on,
             confidence=confidence,
+            execution_identity=execution_identity,
+            require_identity=require_identity,
         )
         return await self._persist_stored_artifact(stored)
 
@@ -143,10 +303,30 @@ class RuntimeArtifactStore:
         citations: list[str] | None = None,
         depends_on: list[str] | None = None,
         confidence: float = 0.0,
+        execution_identity: ExecutionIdentity | None = None,
+        require_identity: bool | None = None,
     ) -> StoredArtifact:
         payload_path = Path(path)
         if not payload_path.exists():
             raise FileNotFoundError(payload_path)
+        identity, task_id, run_id, trace_id, metadata = self._prepare_identity_fields(
+            surface="artifact_store",
+            session_id=session_id,
+            artifact_kind=artifact_kind,
+            task_id=task_id,
+            run_id=run_id,
+            trace_id=trace_id,
+            created_by=created_by,
+            metadata=metadata,
+            execution_identity=execution_identity,
+            require_identity=require_identity,
+        )
+        side_effect_key = f"artifact_store.write:{identity.idempotency_key}" if identity else ""
+        self._record_artifact_intent_sync(
+            identity,
+            side_effect_key=side_effect_key,
+            payload={"operation": "record_existing_artifact", "artifact_kind": artifact_kind},
+        )
         ref = ArtifactRef(
             artifact_id=uuid4().hex[:16],
             artifact_type=artifact_type,
@@ -159,7 +339,7 @@ class RuntimeArtifactStore:
             depends_on=list(depends_on or []),
             metadata=dict(metadata or {}),
         )
-        return self._record_ref(
+        stored = self._record_ref(
             ref,
             artifact_kind=artifact_kind,
             task_id=task_id,
@@ -171,6 +351,13 @@ class RuntimeArtifactStore:
             provenance=provenance,
             metadata=metadata,
         )
+        self._record_artifact_complete_sync(
+            identity,
+            side_effect_key=side_effect_key,
+            artifact_id=ref.artifact_id,
+            payload={"operation": "record_existing_artifact", "artifact_kind": artifact_kind},
+        )
+        return stored
 
     async def record_existing_artifact_async(
         self,
@@ -191,6 +378,8 @@ class RuntimeArtifactStore:
         citations: list[str] | None = None,
         depends_on: list[str] | None = None,
         confidence: float = 0.0,
+        execution_identity: ExecutionIdentity | None = None,
+        require_identity: bool | None = None,
     ) -> StoredArtifact:
         stored = self.record_existing_artifact(
             path,
@@ -209,6 +398,8 @@ class RuntimeArtifactStore:
             citations=citations,
             depends_on=depends_on,
             confidence=confidence,
+            execution_identity=execution_identity,
+            require_identity=require_identity,
         )
         return await self._persist_stored_artifact(stored)
 
@@ -227,10 +418,30 @@ class RuntimeArtifactStore:
         metadata: dict[str, Any] | None = None,
         provenance: dict[str, Any] | None = None,
         promotion_state: str = "ephemeral",
+        execution_identity: ExecutionIdentity | None = None,
+        require_identity: bool | None = None,
     ) -> StoredArtifact:
         source = Path(source_path)
         if not source.exists():
             raise FileNotFoundError(source)
+        identity, task_id, run_id, trace_id, metadata = self._prepare_identity_fields(
+            surface="artifact_store",
+            session_id=session_id,
+            artifact_kind=artifact_kind,
+            task_id=task_id,
+            run_id=run_id,
+            trace_id=trace_id,
+            created_by=created_by,
+            metadata=metadata,
+            execution_identity=execution_identity,
+            require_identity=require_identity,
+        )
+        side_effect_key = f"artifact_store.write:{identity.idempotency_key}" if identity else ""
+        self._record_artifact_intent_sync(
+            identity,
+            side_effect_key=side_effect_key,
+            payload={"operation": "import_file_artifact", "artifact_kind": artifact_kind},
+        )
         self._engine.ensure_session_dirs(session_id)
         artifact_id = uuid4().hex[:16]
         ext = extension or source.suffix.lstrip(".") or "bin"
@@ -252,7 +463,7 @@ class RuntimeArtifactStore:
             version=1,
             metadata=dict(metadata or {}),
         )
-        return self._record_ref(
+        stored = self._record_ref(
             ref,
             artifact_kind=artifact_kind,
             task_id=task_id,
@@ -262,6 +473,13 @@ class RuntimeArtifactStore:
             provenance=provenance,
             metadata=metadata,
         )
+        self._record_artifact_complete_sync(
+            identity,
+            side_effect_key=side_effect_key,
+            artifact_id=ref.artifact_id,
+            payload={"operation": "import_file_artifact", "artifact_kind": artifact_kind},
+        )
+        return stored
 
     async def import_file_artifact_async(
         self,
@@ -278,6 +496,8 @@ class RuntimeArtifactStore:
         metadata: dict[str, Any] | None = None,
         provenance: dict[str, Any] | None = None,
         promotion_state: str = "ephemeral",
+        execution_identity: ExecutionIdentity | None = None,
+        require_identity: bool | None = None,
     ) -> StoredArtifact:
         stored = self.import_file_artifact(
             source_path,
@@ -292,6 +512,8 @@ class RuntimeArtifactStore:
             metadata=metadata,
             provenance=provenance,
             promotion_state=promotion_state,
+            execution_identity=execution_identity,
+            require_identity=require_identity,
         )
         return await self._persist_stored_artifact(stored)
 

--- a/dharma_swarm/message_bus.py
+++ b/dharma_swarm/message_bus.py
@@ -28,7 +28,8 @@ from dharma_swarm.models import (
     _new_id,
 )
 from dharma_swarm.runtime_state import RuntimeStateStore
-from dharma_swarm.spine.identity import ExecutionIdentity
+from dharma_swarm.spine.adapters import identity_from_carrier, identity_metadata
+from dharma_swarm.spine.identity import ExecutionIdentity, MissingExecutionIdentity
 
 _MESSAGES_DDL = """
 CREATE TABLE IF NOT EXISTS messages (
@@ -122,9 +123,11 @@ class MessageBus:
         db_path: Path,
         *,
         runtime_state: RuntimeStateStore | None = None,
+        require_identity: bool = False,
     ) -> None:
         self.db_path = db_path
         self._runtime_state = runtime_state
+        self._require_identity = require_identity
 
     def _open(self) -> aiosqlite.Connection:
         """Open a connection with enough headroom for concurrent writers."""
@@ -181,8 +184,77 @@ class MessageBus:
                 await db.execute(idx)
             await db.commit()
 
-    async def send(self, message: Message) -> str:
+    def _resolve_message_identity(
+        self,
+        message: Message,
+        *,
+        require_identity: bool,
+        execution_identity: ExecutionIdentity | None,
+    ) -> ExecutionIdentity | None:
+        if execution_identity is not None:
+            return execution_identity.with_updates(message_id=message.id).require_for_dispatch()
+        if require_identity and self._runtime_state is None:
+            raise MissingExecutionIdentity("RuntimeStateStore is required when MessageBus requires ExecutionIdentity")
+        if require_identity:
+            return identity_from_carrier(
+                message,
+                surface="message_bus",
+                task_id=str(message.metadata.get("task_id") or message.id),
+                agent_id=message.from_agent,
+                require_existing=True,
+            ).with_updates(message_id=message.id)
+        existing = ExecutionIdentity.from_metadata(message.metadata, require=False)
+        if existing is not None:
+            return existing.with_updates(message_id=message.id).require_for_dispatch()
+        if self._runtime_state is not None:
+            return identity_from_carrier(
+                message,
+                surface="message_bus",
+                task_id=message.id,
+                agent_id=message.from_agent,
+            ).with_updates(message_id=message.id)
+        return None
+
+    async def send(
+        self,
+        message: Message,
+        *,
+        execution_identity: ExecutionIdentity | None = None,
+        require_identity: bool | None = None,
+    ) -> str:
         """Insert a message into the bus. Returns the message ID."""
+        effective_require = self._require_identity if require_identity is None else require_identity
+        identity = self._resolve_message_identity(
+            message,
+            require_identity=effective_require,
+            execution_identity=execution_identity,
+        )
+        side_effect_key = ""
+        if identity is not None:
+            metadata = {
+                **dict(message.metadata or {}),
+                **identity_metadata(identity, surface="message_bus"),
+            }
+            message = message.model_copy(update={"metadata": metadata})
+            if self._runtime_state is not None:
+                side_effect_key = f"message_bus.send:{identity.idempotency_key}"
+                should_execute = await self._runtime_state.try_begin_idempotent_side_effect(
+                    identity,
+                    side_effect_key,
+                    metadata={"message_id": message.id, "to_agent": message.to_agent},
+                )
+                if not should_execute:
+                    record = await self._runtime_state.get_idempotency_record(
+                        identity.idempotency_key,
+                        side_effect_key,
+                    )
+                    return (record.result_receipt_id if record else "") or message.id
+                await self._runtime_state.record_execution_identity(
+                    identity,
+                    source="message_bus.send",
+                    metadata={"surface": "message_bus"},
+                )
+
         async def _send() -> str:
             async with self._connect() as db:
                 await db.execute(
@@ -197,7 +269,15 @@ class MessageBus:
                 await db.commit()
             return message.id
 
-        return await self._run_with_lock_retry(_send)
+        message_id = await self._run_with_lock_retry(_send)
+        if identity is not None and self._runtime_state is not None:
+            await self._runtime_state.complete_idempotent_side_effect(
+                identity,
+                side_effect_key,
+                result_receipt_id=message_id,
+                metadata={"message_id": message_id},
+            )
+        return message_id
 
     async def receive(
         self, agent_id: str, status: str = "unread", limit: int = 50,
@@ -684,11 +764,37 @@ class MessageBus:
         self,
         event_type: str,
         limit: int = 100,
+        *,
+        execution_identity: ExecutionIdentity | None = None,
+        require_identity: bool | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> list[dict[str, Any]]:
         """Read and claim unconsumed events of a given type.
 
         Marks consumed events with a timestamp so they aren't re-read.
         """
+        effective_require = self._require_identity if require_identity is None else require_identity
+        identity: ExecutionIdentity | None = None
+        if execution_identity is not None:
+            identity = execution_identity.require_for_dispatch()
+        elif effective_require:
+            if self._runtime_state is None:
+                raise MissingExecutionIdentity("RuntimeStateStore is required when MessageBus requires ExecutionIdentity")
+            identity = identity_from_carrier(
+                {
+                    "id": f"consume:{event_type}",
+                    "task_id": f"consume:{event_type}",
+                    "metadata": metadata or {},
+                },
+                surface="event_bus",
+                require_existing=True,
+            )
+        elif self._runtime_state is not None and metadata:
+            identity = ExecutionIdentity.from_metadata(
+                metadata,
+                task_id=f"consume:{event_type}",
+                require=False,
+            )
 
         async def _consume() -> list[dict[str, Any]]:
             async with self._open() as db:
@@ -717,7 +823,23 @@ class MessageBus:
                 await db.commit()
             return events
 
-        return await self._run_with_lock_retry(_consume)
+        events = await self._run_with_lock_retry(_consume)
+        if identity is not None and self._runtime_state is not None:
+            await self._runtime_state.record_execution_identity(
+                identity,
+                source="message_bus.consume_events",
+                metadata={"event_type": event_type},
+            )
+            for event in events:
+                event_id = str(event.get("event_id") or "")
+                await self._runtime_state.record_receipt_for_identity(
+                    identity.with_updates(event_id=event_id),
+                    receipt_type="message_consumed",
+                    status="consumed",
+                    side_effect_key=f"event:{event_id}",
+                    payload={"event_id": event_id, "event_type": event_type},
+                )
+        return events
 
     async def event_stats(self) -> dict[str, Any]:
         """Return bus metrics: queued, consumed, stale heartbeats."""

--- a/dharma_swarm/task_board.py
+++ b/dharma_swarm/task_board.py
@@ -14,6 +14,12 @@ import aiosqlite
 
 from dharma_swarm.correlation_context import get_correlation
 from dharma_swarm.models import Task, TaskPriority, TaskStatus, _new_id, _utc_now
+from dharma_swarm.runtime_state import RuntimeStateStore
+from dharma_swarm.spine.adapters import (
+    identity_from_carrier,
+    identity_metadata,
+)
+from dharma_swarm.spine.identity import ExecutionIdentity, MissingExecutionIdentity
 from dharma_swarm.telos_gates import check_with_reflective_reroute
 
 _TRANSITIONS: dict[TaskStatus, set[TaskStatus]] = {
@@ -74,8 +80,16 @@ class TaskBoard:
 
     _BUSY_TIMEOUT_S = 30  # seconds — must survive contention with daemon + SwarmLens
 
-    def __init__(self, db_path: Path) -> None:
+    def __init__(
+        self,
+        db_path: Path,
+        *,
+        runtime_state: RuntimeStateStore | None = None,
+        require_identity: bool = False,
+    ) -> None:
         self._db_path = db_path
+        self._runtime_state = runtime_state
+        self._require_identity = require_identity
 
     def _open(self) -> aiosqlite.Connection:
         """Open connection with busy_timeout to prevent 'database is locked'."""
@@ -192,6 +206,82 @@ class TaskBoard:
                 f"Telos blocked transition ({think_phase}): {gate.result.reason}"
             )
 
+    def _resolve_identity(
+        self,
+        *,
+        task_id: str,
+        created_by: str,
+        metadata: dict[str, Any],
+        require_identity: bool,
+        execution_identity: ExecutionIdentity | None,
+    ) -> ExecutionIdentity | None:
+        if require_identity and self._runtime_state is None:
+            raise MissingExecutionIdentity("RuntimeStateStore is required when TaskBoard requires ExecutionIdentity")
+        if execution_identity is not None:
+            identity = execution_identity.with_updates(task_id=task_id, agent_id=created_by)
+            return identity.require_for_dispatch()
+        if require_identity:
+            return identity_from_carrier(
+                {"id": task_id, "created_by": created_by, "metadata": metadata},
+                surface="task_board",
+                task_id=task_id,
+                agent_id=created_by,
+                require_existing=True,
+            ).with_updates(task_id=task_id, agent_id=created_by).require_for_dispatch()
+        existing = ExecutionIdentity.from_metadata(metadata, require=False)
+        if existing is not None:
+            return existing.with_updates(task_id=task_id, agent_id=created_by).require_for_dispatch()
+        if self._runtime_state is not None:
+            return identity_from_carrier(
+                {"id": task_id, "created_by": created_by, "metadata": metadata},
+                surface="task_board",
+                task_id=task_id,
+                agent_id=created_by,
+            )
+        return None
+
+    async def _record_taskboard_intent(
+        self,
+        identity: ExecutionIdentity,
+        *,
+        source: str,
+        title: str,
+    ) -> None:
+        if self._runtime_state is None:
+            return
+        await self._runtime_state.record_execution_identity(
+            identity,
+            source=source,
+            metadata={"surface": "task_board", "title": title},
+        )
+        await self._runtime_state.record_side_effect_intent(
+            identity,
+            f"task_board:{identity.task_id}",
+            payload={"surface": "task_board", "title": title},
+        )
+
+    async def _record_taskboard_receipt(
+        self,
+        identity: ExecutionIdentity,
+        *,
+        title: str,
+    ) -> None:
+        if self._runtime_state is None:
+            return
+        await self._runtime_state.record_receipt_for_identity(
+            identity,
+            receipt_type="task_created",
+            status="created",
+            side_effect_key=f"task_board:{identity.task_id}",
+            payload={"surface": "task_board", "title": title},
+        )
+        await self._runtime_state.record_side_effect_complete(
+            identity,
+            f"task_board:{identity.task_id}",
+            result_receipt_id=identity.task_id,
+            payload={"surface": "task_board", "title": title},
+        )
+
     # -- CRUD ---------------------------------------------------------------
 
     async def create(
@@ -202,18 +292,39 @@ class TaskBoard:
         created_by: str = "system",
         depends_on: list[str] | None = None,
         metadata: dict[str, Any] | None = None,
+        execution_identity: ExecutionIdentity | None = None,
+        require_identity: bool | None = None,
     ) -> Task:
         """Create a new task and persist it."""
         task_id = _new_id()
         now = _utc_now()
         dep_ids: list[str] = depends_on or []
         meta = dict(metadata or {})
+        effective_require = self._require_identity if require_identity is None else require_identity
+        identity = self._resolve_identity(
+            task_id=task_id,
+            created_by=created_by,
+            metadata=meta,
+            require_identity=effective_require,
+            execution_identity=execution_identity,
+        )
+        if identity is not None:
+            meta.update(identity_metadata(identity, surface="task_board"))
         corr = get_correlation()
         trace_id = corr.trace_id
         if trace_id:
             meta.setdefault("trace_id", trace_id)
+        elif identity is not None:
+            trace_id = identity.trace_id
         if corr.cell_id:
             meta.setdefault("cell_id", corr.cell_id)
+        trace_id = str(meta.get("trace_id") or trace_id)
+        if identity is not None:
+            await self._record_taskboard_intent(
+                identity,
+                source="task_board.create",
+                title=title,
+            )
         async with self._open() as db:
             await db.execute(
                 "INSERT INTO tasks"
@@ -230,6 +341,11 @@ class TaskBoard:
                     "INSERT INTO task_dependencies VALUES (?,?)", (task_id, dep_id),
                 )
             await db.commit()
+        if identity is not None:
+            await self._record_taskboard_receipt(
+                identity,
+                title=title,
+            )
         return Task(
             id=task_id, title=title, description=description,
             priority=priority, created_by=created_by,
@@ -240,6 +356,8 @@ class TaskBoard:
     async def create_batch(
         self,
         tasks: list[dict[str, Any]],
+        *,
+        require_identity: bool | None = None,
     ) -> list[Task]:
         """Create multiple tasks in a single transaction.
 
@@ -261,21 +379,45 @@ class TaskBoard:
 
         corr = get_correlation()
         trace_id = corr.trace_id
+        effective_require = self._require_identity if require_identity is None else require_identity
+        prepared: list[tuple[str, dict[str, Any], list[str], str, ExecutionIdentity | None]] = []
+        for spec in tasks:
+            task_id = _new_id()
+            created_by = spec.get("created_by", "system")
+            metadata = dict(spec.get("metadata") or {})
+            identity = self._resolve_identity(
+                task_id=task_id,
+                created_by=created_by,
+                metadata=metadata,
+                require_identity=effective_require,
+                execution_identity=spec.get("execution_identity"),
+            )
+            if identity is not None:
+                metadata.update(identity_metadata(identity, surface="task_board"))
+            if trace_id:
+                metadata.setdefault("trace_id", trace_id)
+            elif identity is not None:
+                metadata.setdefault("trace_id", identity.trace_id)
+            if corr.cell_id:
+                metadata.setdefault("cell_id", corr.cell_id)
+            row_trace_id = str(metadata.get("trace_id") or trace_id or "")
+            prepared.append((task_id, metadata, spec.get("depends_on") or [], row_trace_id, identity))
+
+        for spec, (_, _, _, _, identity) in zip(tasks, prepared):
+            if identity is not None:
+                await self._record_taskboard_intent(
+                    identity,
+                    source="task_board.create_batch",
+                    title=spec["title"],
+                )
 
         async with self._open() as db:
             # Single transaction for all tasks
-            for spec in tasks:
-                task_id = _new_id()
+            for spec, (task_id, metadata, dep_ids, row_trace_id, identity) in zip(tasks, prepared):
                 title = spec["title"]
                 description = spec.get("description", "")
                 priority = spec.get("priority", TaskPriority.NORMAL)
                 created_by = spec.get("created_by", "system")
-                dep_ids = spec.get("depends_on") or []
-                metadata = dict(spec.get("metadata") or {})
-                if trace_id:
-                    metadata.setdefault("trace_id", trace_id)
-                if corr.cell_id:
-                    metadata.setdefault("cell_id", corr.cell_id)
 
                 await db.execute(
                     "INSERT INTO tasks"
@@ -285,7 +427,7 @@ class TaskBoard:
                     (task_id, title, description, TaskStatus.PENDING.value,
                      priority.value, None, created_by, now.isoformat(),
                      now.isoformat(), None, json.dumps(metadata, ensure_ascii=True),
-                     trace_id),
+                     row_trace_id),
                 )
 
                 for dep_id in dep_ids:
@@ -303,6 +445,13 @@ class TaskBoard:
 
             # Single commit for entire batch
             await db.commit()
+
+        for task, (_, _, _, _, identity) in zip(created_tasks, prepared):
+            if identity is not None:
+                await self._record_taskboard_receipt(
+                    identity,
+                    title=task.title,
+                )
 
         return created_tasks
 

--- a/dharma_swarm/tool_registry.py
+++ b/dharma_swarm/tool_registry.py
@@ -23,6 +23,10 @@ import json
 import logging
 from typing import Any, Callable, Optional
 
+from dharma_swarm.runtime_state import RuntimeStateStore
+from dharma_swarm.spine.adapters import identity_from_carrier
+from dharma_swarm.spine.identity import ExecutionIdentity, MissingExecutionIdentity
+
 logger = logging.getLogger(__name__)
 
 
@@ -62,9 +66,16 @@ class ToolRegistry:
     for schemas and dispatches calls through it.
     """
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        runtime_state: RuntimeStateStore | None = None,
+        require_identity: bool = False,
+    ) -> None:
         self._tools: dict[str, ToolEntry] = {}
         self._toolset_checks: dict[str, Callable] = {}
+        self._runtime_state = runtime_state
+        self._require_identity = require_identity
 
     # ── Registration ─────────────────────────────────────────────────
 
@@ -126,6 +137,33 @@ class ToolRegistry:
 
     # ── Dispatch ──────────────────────────────────────────────────────
 
+    def _resolve_identity(
+        self,
+        name: str,
+        args: dict,
+        *,
+        runtime_state: RuntimeStateStore | None,
+        require_identity: bool,
+        execution_identity: ExecutionIdentity | None,
+        metadata: dict[str, Any] | None,
+    ) -> ExecutionIdentity | None:
+        if require_identity and runtime_state is None:
+            raise MissingExecutionIdentity("RuntimeStateStore is required when ToolRegistry requires ExecutionIdentity")
+        if execution_identity is not None:
+            return execution_identity.require_for_dispatch()
+        carrier = {
+            "tool_call_id": args.get("tool_call_id") or f"tool:{name}",
+            "tool_name": name,
+            "task_id": args.get("task_id"),
+            "agent_id": args.get("agent_id"),
+            "metadata": metadata or args.get("metadata") or {},
+        }
+        if require_identity:
+            return identity_from_carrier(carrier, surface="tool", require_existing=True)
+        if runtime_state is not None:
+            return identity_from_carrier(carrier, surface="tool")
+        return ExecutionIdentity.from_metadata(carrier["metadata"], require=False)
+
     def dispatch(self, name: str, args: dict, **kwargs: Any) -> str:
         """Execute a tool handler by name.
 
@@ -135,7 +173,34 @@ class ToolRegistry:
         entry = self._tools.get(name)
         if not entry:
             return json.dumps({"error": f"Unknown tool: {name}"})
+        runtime_state = kwargs.pop("runtime_state", self._runtime_state)
+        require_identity = kwargs.pop("require_identity", self._require_identity)
+        execution_identity = kwargs.pop("execution_identity", None)
+        metadata = kwargs.pop("metadata", None)
+        identity: ExecutionIdentity | None = None
+        side_effect_key = f"tool_registry.dispatch:{name}"
         try:
+            identity = self._resolve_identity(
+                name,
+                args,
+                runtime_state=runtime_state,
+                require_identity=require_identity,
+                execution_identity=execution_identity,
+                metadata=metadata,
+            )
+            if identity is not None:
+                side_effect_key = f"tool_registry.dispatch:{name}:{identity.task_id}"
+            if identity is not None and runtime_state is not None:
+                runtime_state.record_execution_identity_sync(
+                    identity,
+                    source="tool_registry.dispatch",
+                    metadata={"tool_name": name},
+                )
+                runtime_state.record_side_effect_intent_sync(
+                    identity,
+                    side_effect_key,
+                    payload={"tool_name": name},
+                )
             if entry.is_async:
                 loop: asyncio.AbstractEventLoop | None = None
                 try:
@@ -146,10 +211,30 @@ class ToolRegistry:
                     import concurrent.futures
                     with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
                         future = pool.submit(asyncio.run, entry.handler(args, **kwargs))
-                        return future.result(timeout=120)
-                return asyncio.run(entry.handler(args, **kwargs))
-            return entry.handler(args, **kwargs)
+                        result = future.result(timeout=120)
+                else:
+                    result = asyncio.run(entry.handler(args, **kwargs))
+            else:
+                result = entry.handler(args, **kwargs)
+            if identity is not None and runtime_state is not None:
+                runtime_state.record_side_effect_complete_sync(
+                    identity,
+                    side_effect_key,
+                    result_receipt_id=f"tool:{name}",
+                    payload={"tool_name": name},
+                )
+            return result
         except Exception as e:
+            if identity is not None and runtime_state is not None:
+                try:
+                    runtime_state.record_side_effect_complete_sync(
+                        identity,
+                        side_effect_key,
+                        status="failed",
+                        payload={"tool_name": name, "error": type(e).__name__},
+                    )
+                except Exception:
+                    logger.exception("Tool %s failed to record runtime failure receipt", name)
             logger.exception("Tool %s dispatch error: %s", name, e)
             return json.dumps({"error": f"Tool execution failed: {type(e).__name__}: {e}"})
 

--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -8,11 +8,11 @@ Do not hand-edit the generated block.
 |---|---:|
 | Dharma Python modules | 661 |
 | Top-level Dharma Python modules | 389 |
-| Dharma Python LOC | 279,961 |
-| Test files | 618 |
-| Test function occurrences | 10,737 |
+| Dharma Python LOC | 280,540 |
+| Test files | 619 |
+| Test function occurrences | 10,743 |
 | Markdown files | 763 |
-| Markdown total lines | 191,504 |
+| Markdown total lines | 191,505 |
 | Bridge files | 24 |
 | Adapter files | 21 |
 | Orchestrator files | 4 |

--- a/docs/governance/SOVEREIGN_MANIFEST.md
+++ b/docs/governance/SOVEREIGN_MANIFEST.md
@@ -127,13 +127,13 @@ These are the ground-truth metrics. All other documents citing different numbers
 |--------|-------|-------------|
 | Total Python modules | **661** | find dharma_swarm -name "*.py" -type f |
 | Top-level (flat) modules | **389 (59.0%)** | find dharma_swarm -maxdepth 1 -name "*.py" -type f |
-| Total Python LOC | **279,695** | wc -l across dharma_swarm Python modules |
-| Test files | **618** | find tests -name "*.py" -type f |
-| Test functions | **10,737 `def test_` occurrences under tests/** | rg "def test_" tests |
+| Total Python LOC | **280,540** | wc -l across dharma_swarm Python modules |
+| Test files | **619** | find tests -name "*.py" -type f |
+| Test functions | **10,743 `def test_` occurrences under tests/** | rg "def test_" tests |
 | Tests collected (pytest) | **Needs write-permitted refresh** | not run during this DocOps count pass |
 | Collection errors | **Historical: 16 on 2026-04-04** | refresh before relying on this count |
 | Markdown files | **763** | find . -name "*.md" -type f |
-| Markdown total lines | **191,504** | wc -l across all .md |
+| Markdown total lines | **191,505** | wc -l across all .md |
 | Bridge files | **24** | find dharma_swarm -name "*bridge*.py" |
 | Adapter files | **21 across 8 locations** | find dharma_swarm -type f \| rg -i "adapter" |
 | Orchestrator files | **4** (6,034 LOC total) | find dharma_swarm -name "*orchestrat*" |

--- a/seams/spine-adoption/codex-runlog.md
+++ b/seams/spine-adoption/codex-runlog.md
@@ -1,1 +1,2 @@
 2026-06-01T15:03:46Z | slice-A | PR #430 | Opened Slice A sync legacy ledger bypass PR with identity-before-telic fix and passing v2 baseline.
+2026-06-01T18:40:41Z | slice-B | PR #435 | Opened adapter saturation PR; verification commands are listed in the PR body.

--- a/tests/test_runtime_truth_spine_adoption.py
+++ b/tests/test_runtime_truth_spine_adoption.py
@@ -1,0 +1,225 @@
+import asyncio
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from dharma_swarm.artifact_store import RuntimeArtifactStore
+from dharma_swarm.message_bus import MessageBus
+from dharma_swarm.models import Message
+from dharma_swarm.runtime_state import RuntimeStateStore
+from dharma_swarm.spine.adapters import identity_metadata
+from dharma_swarm.spine.identity import ExecutionIdentity, MissingExecutionIdentity
+from dharma_swarm.task_board import TaskBoard
+from dharma_swarm.tool_registry import ToolRegistry
+
+
+def _identity(**overrides: str) -> ExecutionIdentity:
+    payload = {
+        "task_id": "task-spine-adoption",
+        "agent_id": "agent-spine-adoption",
+        "session_id": "session-spine-adoption",
+        "trace_id": "trace-spine-adoption",
+        "correlation_id": "corr-spine-adoption",
+        "run_id": "run-spine-adoption",
+        "claim_id": "claim-spine-adoption",
+        "idempotency_key": "idem-spine-adoption",
+    }
+    payload.update(overrides)
+    return ExecutionIdentity.new(**payload)
+
+
+def _count_rows(db_path: Path, table: str) -> int:
+    with sqlite3.connect(db_path) as db:
+        return int(db.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0])
+
+
+@pytest.mark.asyncio
+async def test_task_board_required_identity_fails_closed_and_records_ledger(tmp_path: Path) -> None:
+    runtime = RuntimeStateStore(tmp_path / "runtime.db")
+    board = TaskBoard(tmp_path / "tasks.db", runtime_state=runtime, require_identity=True)
+    await board.init_db()
+
+    with pytest.raises(MissingExecutionIdentity):
+        await board.create("missing identity")
+    assert await board.get_by_title("missing identity") is None
+
+    identity = _identity()
+    task = await board.create(
+        "identity-backed task",
+        created_by=identity.agent_id,
+        metadata=identity_metadata(identity, surface="task_board"),
+    )
+
+    loaded_identity = await runtime.get_execution_identity(identity.run_id)
+    assert loaded_identity is not None
+    assert loaded_identity.task_id == task.id
+    assert loaded_identity.trace_id == identity.trace_id
+
+    ledger = await runtime.get_run_ledger(identity.run_id)
+    assert any(
+        receipt.receipt_type == "task_created"
+        and receipt.status == "created"
+        and receipt.task_id == task.id
+        for receipt in ledger["receipts"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_task_board_create_batch_preflights_identity_before_any_insert(tmp_path: Path) -> None:
+    runtime = RuntimeStateStore(tmp_path / "runtime.db")
+    board = TaskBoard(tmp_path / "tasks.db", runtime_state=runtime, require_identity=True)
+    await board.init_db()
+
+    identity = _identity(run_id="run-batch-good", idempotency_key="idem-batch-good")
+    with pytest.raises(MissingExecutionIdentity):
+        await board.create_batch(
+            [
+                {
+                    "title": "valid batch task",
+                    "created_by": identity.agent_id,
+                    "metadata": identity_metadata(identity, surface="task_board"),
+                },
+                {"title": "invalid batch task"},
+            ],
+        )
+
+    assert _count_rows(tmp_path / "tasks.db", "tasks") == 0
+
+
+@pytest.mark.asyncio
+async def test_message_bus_required_identity_dedupes_before_send_side_effect(tmp_path: Path) -> None:
+    runtime = RuntimeStateStore(tmp_path / "runtime.db")
+    bus = MessageBus(tmp_path / "messages.db", runtime_state=runtime, require_identity=True)
+    await bus.init_db()
+
+    with pytest.raises(MissingExecutionIdentity):
+        await bus.send(Message(from_agent="alice", to_agent="bob", body="missing"))
+
+    identity = _identity(
+        run_id="run-message",
+        task_id="task-message",
+        idempotency_key="idem-message-once",
+    )
+    metadata = identity_metadata(identity, surface="message_bus")
+    first = Message(from_agent="alice", to_agent="bob", body="first", metadata=metadata)
+    second = Message(from_agent="alice", to_agent="bob", body="second", metadata=metadata)
+
+    first_id = await bus.send(first)
+    second_id = await bus.send(second)
+
+    assert second_id == first_id
+    messages = await bus.receive("bob")
+    assert [message.id for message in messages] == [first_id]
+
+    ledger = await runtime.get_run_ledger(identity.run_id)
+    records = ledger["idempotency_records"]
+    assert len(records) == 1
+    assert records[0].result_receipt_id == first_id
+
+
+@pytest.mark.asyncio
+async def test_message_bus_consume_events_requires_identity_and_records_receipts(tmp_path: Path) -> None:
+    runtime = RuntimeStateStore(tmp_path / "runtime.db")
+    bus = MessageBus(tmp_path / "events.db", runtime_state=runtime)
+    await bus.init_db()
+    event_id = await bus.emit_event("spine.test", payload={"ok": True})
+
+    with pytest.raises(MissingExecutionIdentity):
+        await bus.consume_events("spine.test", require_identity=True)
+
+    identity = _identity(run_id="run-consume", idempotency_key="idem-consume")
+    consumed = await bus.consume_events(
+        "spine.test",
+        execution_identity=identity,
+        require_identity=True,
+    )
+
+    assert [event["event_id"] for event in consumed] == [event_id]
+    receipts = (await runtime.get_run_ledger(identity.run_id))["receipts"]
+    assert any(
+        receipt.receipt_type == "message_consumed"
+        and receipt.side_effect_key == f"event:{event_id}"
+        for receipt in receipts
+    )
+
+
+def test_tool_registry_required_identity_blocks_handler_and_records_side_effect(tmp_path: Path) -> None:
+    runtime = RuntimeStateStore(tmp_path / "runtime.db")
+    registry = ToolRegistry(runtime_state=runtime, require_identity=True)
+    calls: list[dict] = []
+
+    def handler(args: dict) -> str:
+        calls.append(args)
+        return json.dumps({"ok": True})
+
+    registry.register(
+        "safe_probe",
+        "test",
+        {"name": "safe_probe", "description": "probe", "parameters": {}},
+        handler,
+    )
+
+    missing = registry.dispatch("safe_probe", {})
+    assert json.loads(missing)["error"].startswith("Tool execution failed: MissingExecutionIdentity")
+    assert calls == []
+
+    identity = _identity(run_id="run-tool", task_id="task-tool", idempotency_key="idem-tool")
+    result = registry.dispatch(
+        "safe_probe",
+        {"value": 1},
+        execution_identity=identity,
+    )
+
+    assert json.loads(result) == {"ok": True}
+    assert calls[0]["value"] == 1
+    ledger = asyncio.run(runtime.get_run_ledger(identity.run_id))
+    receipt_types = {receipt.receipt_type for receipt in ledger["receipts"]}
+    assert {"side_effect_intent", "side_effect_complete"} <= receipt_types
+
+
+@pytest.mark.asyncio
+async def test_runtime_artifact_store_requires_identity_before_file_write(tmp_path: Path) -> None:
+    runtime = RuntimeStateStore(tmp_path / "runtime.db")
+    store = RuntimeArtifactStore(
+        tmp_path / "workspace",
+        runtime_state=runtime,
+        require_identity=True,
+    )
+
+    with pytest.raises(MissingExecutionIdentity):
+        await store.create_text_artifact_async(
+            session_id="session-artifact",
+            artifact_type="research",
+            artifact_kind="report",
+            content="missing identity",
+            created_by="agent-artifact",
+        )
+    assert not (tmp_path / "workspace" / "session-artifact").exists()
+
+    identity = _identity(
+        run_id="run-artifact",
+        task_id="task-artifact",
+        idempotency_key="idem-artifact",
+    )
+    stored = await store.create_text_artifact_async(
+        session_id=identity.session_id,
+        artifact_type="research",
+        artifact_kind="report",
+        content="identity backed",
+        created_by=identity.agent_id,
+        metadata=identity_metadata(identity, surface="artifact_store"),
+    )
+
+    assert stored.record.run_id == identity.run_id
+    assert stored.record.trace_id == identity.trace_id
+    assert Path(stored.ref.path).exists()
+    ledger = await runtime.get_run_ledger(identity.run_id)
+    assert any(artifact.artifact_id == stored.record.artifact_id for artifact in ledger["artifacts"])
+    assert any(
+        receipt.receipt_type == "artifact_written"
+        and receipt.run_id == identity.run_id
+        and receipt.trace_id == identity.trace_id
+        for receipt in ledger["receipts"]
+    )


### PR DESCRIPTION
## Summary

Slice B for Runtime Spine Adoption Saturation.

- Adds fail-closed `ExecutionIdentity` adapter mode to TaskBoard create/create_batch.
- Adds fail-closed `ExecutionIdentity` adapter mode to MessageBus send and event consume paths, including receiver-side idempotency before message insert.
- Adds fail-closed `ExecutionIdentity` adapter mode to ToolRegistry dispatch so handlers do not run without identity in required mode.
- Adds fail-closed `ExecutionIdentity` adapter mode to RuntimeArtifactStore writes and fixes ArtifactManifest -> ArtifactRecord trace_id propagation.
- Adds `tests/test_runtime_truth_spine_adoption.py` as the Slice B metric target.

## Coherence Delta

Organ touched: TaskBoard, MessageBus, ToolRegistry, RuntimeArtifactStore, artifact manifest projection.

Declared-vs-actual gap closed: selected boundary adapters can now require `ExecutionIdentity`, fail before side effects when missing, and record RuntimeStateStore identity/receipt evidence when present.

Proof that re-reads the map: `tests/test_runtime_truth_spine_adoption.py` checks missing identity failures, ledger reconstruction, idempotency-before-send, consumed-event receipts, tool side-effect receipts, and artifact run/trace linkage.

New drift introduced: TaskBoard creation uses a new `task_created` runtime receipt type by convention; broader adoption metric gating remains Slice D.

## Guardrails

- [impact-checked]
- No C2 ontology enforcement.
- No workflow engine unification.
- No Temporal/DBOS/Restate migration.
- No new agents or fleet changes.
- No seam spec edits to `MERGED_PLAN.md`, `01_gap_matrix.md`, `02_master_spec.md`, or `03_codex_55_plan.md`.
- Legacy paths remain compatible unless callers opt into `require_identity=True`.

## Triple Witness

1. Passing tests:
   - `pytest -q tests/test_runtime_truth_spine_adoption.py` -> `6 passed`
   - adjacent suites -> `42 passed` and `38 passed`
   - v2 baseline command -> `159 passed`

2. Code evidence:
   - `dharma_swarm/task_board.py`: required identity preflight and TaskBoard ledger receipts.
   - `dharma_swarm/message_bus.py`: required identity send/consume adapters and idempotency-before-insert.
   - `dharma_swarm/tool_registry.py`: required identity before handler execution.
   - `dharma_swarm/artifact_store.py` and `dharma_swarm/artifact_manifest.py`: artifact write identity and trace persistence.

3. External grounding:
   - Azure Strangler Fig Pattern: https://learn.microsoft.com/en-us/azure/architecture/patterns/strangler-fig
   - Temporal idempotency/durable execution framing: https://temporal.io/blog/idempotency-and-durable-execution

## Verification

```bash
pytest -q tests/test_runtime_truth_spine_adoption.py
pytest -q tests/test_message_bus.py tests/test_artifact_store.py tests/test_artifact_store_vnext.py tests/test_engine_artifacts.py
pytest -q tests/test_task_board.py tests/test_tool_registry.py
pytest -q tests/test_runtime_truth_spine_v2_adapters.py tests/test_runtime_truth_spine_v2_evidence.py tests/test_runtime_state_invariants.py
env HOME=/private/tmp/dharma_spine_slice_b_rebase_baseline_home pytest -q tests/test_runtime_truth_spine_v1.py tests/test_runtime_truth_spine_v2_adapters.py tests/test_runtime_truth_spine_v2_evidence.py tests/test_runtime_truth_spine_v2_tollbooth.py tests/test_runtime_state.py tests/test_runtime_lifecycle.py tests/test_a2a_spec_conformance.py tests/test_message_bus.py tests/test_checkpoint.py tests/test_orchestrator.py
git diff --check origin/main...HEAD
python3 scripts/docops/check_docops_integrity.py
env DHARMA_UPLIFT_ACK=impact-checked python3 scripts/uplift_guards/run_pre_commit.py
```

## Remaining Gaps

- This PR does not implement C2 ontology enforcement.
- Slice C owns generic foreign-ID mapping receipts.
- Slice D owns deterministic adoption percentage and CI gate.
