### PR TITLE
feat(spine): add runtime identity mapping receipts [impact-checked]

### DIFF
--- a/dharma_swarm/runtime_state.py
+++ b/dharma_swarm/runtime_state.py
@@ -314,6 +314,7 @@ RUNTIME_RECEIPT_TYPES = frozenset(
         "artifact",
         "artifact_written",
         "message_consumed",
+        "identity_mapping",
         "idempotency_consumed",
         "ontology_action_requested",
         "ontology_action_applied",
@@ -327,6 +328,24 @@ RUNTIME_RECEIPT_TYPES = frozenset(
         "self_mod_revert",
     }
 )
+
+MAPPING_ID_KINDS = frozenset(
+    {
+        "workflow_id",
+        "proposal_id",
+        "event_id",
+        "message_id",
+        "ontology_action_id",
+        "engine_artifact_id",
+    }
+)
+
+MAPPING_IDENTITY_FIELDS = {
+    "proposal_id": "proposal_id",
+    "event_id": "event_id",
+    "message_id": "message_id",
+    "engine_artifact_id": "artifact_id",
+}
 
 SELF_MOD_RECEIPT_TYPES = frozenset(
     {
@@ -2612,6 +2631,274 @@ class RuntimeStateStore:
             payload={"proposal_id": proposal_id or identity.proposal_id, **dict(payload or {})},
         )
 
+    @staticmethod
+    def _normalize_mapping_id_kind(id_kind: str) -> str:
+        normalized = str(id_kind or "").strip()
+        if normalized not in MAPPING_ID_KINDS:
+            raise ValueError(f"unknown runtime identity mapping kind: {id_kind}")
+        return normalized
+
+    @staticmethod
+    def _mapping_side_effect_key(id_kind: str, external_id: str) -> str:
+        return f"mapping:{id_kind}:{external_id}"
+
+    @staticmethod
+    def _mapping_receipt_id(
+        identity: ExecutionIdentity,
+        *,
+        id_kind: str,
+        external_id: str,
+    ) -> str:
+        digest = hashlib.sha256(
+            f"{identity.run_id}:{id_kind}:{external_id}".encode("utf-8")
+        ).hexdigest()[:16]
+        return f"rr_{identity.run_id}_mapping_{digest}"
+
+    @staticmethod
+    def _identity_with_mapping_field(
+        identity: ExecutionIdentity,
+        *,
+        id_kind: str,
+        external_id: str,
+    ) -> ExecutionIdentity:
+        field_name = MAPPING_IDENTITY_FIELDS.get(id_kind)
+        if not field_name:
+            return identity
+        current = str(getattr(identity, field_name, "") or "").strip()
+        if current and current != external_id:
+            return identity.with_updates(metadata={f"mapped_{id_kind}": external_id})
+        return identity.with_updates(**{field_name: external_id})
+
+    @staticmethod
+    def _mapping_payload(
+        identity: ExecutionIdentity,
+        *,
+        id_kind: str,
+        external_id: str,
+        source: str,
+        payload: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        return {
+            "id_kind": id_kind,
+            "external_id": external_id,
+            "run_id": identity.run_id,
+            "task_id": identity.task_id,
+            "trace_id": identity.trace_id,
+            "correlation_id": identity.correlation_id,
+            "source": source,
+            **dict(payload or {}),
+        }
+
+    async def record_mapping_receipt(
+        self,
+        identity: ExecutionIdentity,
+        *,
+        id_kind: str,
+        external_id: str,
+        source: str = "runtime_state.mapping",
+        status: str = "mapped",
+        payload: dict[str, Any] | None = None,
+    ) -> RuntimeReceipt:
+        identity.require_for_dispatch()
+        normalized_kind = self._normalize_mapping_id_kind(id_kind)
+        normalized_external_id = str(external_id or "").strip()
+        if not normalized_external_id:
+            raise ValueError("external_id is required for runtime identity mapping")
+        mapped_identity = self._identity_with_mapping_field(
+            identity,
+            id_kind=normalized_kind,
+            external_id=normalized_external_id,
+        )
+        mapping_payload = self._mapping_payload(
+            identity,
+            id_kind=normalized_kind,
+            external_id=normalized_external_id,
+            source=source,
+            payload=payload,
+        )
+        await self.record_execution_identity(
+            mapped_identity,
+            source=f"mapping:{normalized_kind}",
+            metadata={"runtime_mapping": mapping_payload},
+        )
+        return await self.record_receipt_for_identity(
+            mapped_identity,
+            receipt_type="identity_mapping",
+            status=status,
+            side_effect_key=self._mapping_side_effect_key(
+                normalized_kind,
+                normalized_external_id,
+            ),
+            payload=mapping_payload,
+            receipt_id=self._mapping_receipt_id(
+                mapped_identity,
+                id_kind=normalized_kind,
+                external_id=normalized_external_id,
+            ),
+        )
+
+    def record_mapping_receipt_sync(
+        self,
+        identity: ExecutionIdentity,
+        *,
+        id_kind: str,
+        external_id: str,
+        source: str = "runtime_state.mapping",
+        status: str = "mapped",
+        payload: dict[str, Any] | None = None,
+    ) -> RuntimeReceipt:
+        identity.require_for_dispatch()
+        normalized_kind = self._normalize_mapping_id_kind(id_kind)
+        normalized_external_id = str(external_id or "").strip()
+        if not normalized_external_id:
+            raise ValueError("external_id is required for runtime identity mapping")
+        mapped_identity = self._identity_with_mapping_field(
+            identity,
+            id_kind=normalized_kind,
+            external_id=normalized_external_id,
+        )
+        mapping_payload = self._mapping_payload(
+            identity,
+            id_kind=normalized_kind,
+            external_id=normalized_external_id,
+            source=source,
+            payload=payload,
+        )
+        self.record_execution_identity_sync(
+            mapped_identity,
+            source=f"mapping:{normalized_kind}",
+            metadata={"runtime_mapping": mapping_payload},
+        )
+        return self.record_receipt_for_identity_sync(
+            mapped_identity,
+            receipt_type="identity_mapping",
+            status=status,
+            side_effect_key=self._mapping_side_effect_key(
+                normalized_kind,
+                normalized_external_id,
+            ),
+            payload=mapping_payload,
+            receipt_id=self._mapping_receipt_id(
+                mapped_identity,
+                id_kind=normalized_kind,
+                external_id=normalized_external_id,
+            ),
+        )
+
+    async def list_mapping_receipts(
+        self,
+        *,
+        run_id: str | None = None,
+        id_kind: str | None = None,
+        external_id: str | None = None,
+        limit: int = 100,
+    ) -> list[RuntimeReceipt]:
+        normalized_kind = self._normalize_mapping_id_kind(id_kind) if id_kind else None
+        normalized_external_id: str | None = None
+        if external_id is not None:
+            normalized_external_id = str(external_id or "").strip()
+            if not normalized_external_id:
+                raise ValueError("external_id is required for runtime identity mapping")
+            if not normalized_kind:
+                raise ValueError("id_kind is required when external_id is provided")
+        await self.init_db()
+        query = (
+            "SELECT receipt_id, receipt_type, run_id, task_id, trace_id,"
+            " correlation_id, causation_id, parent_run_id, agent_id,"
+            " idempotency_key, side_effect_key, status, payload_json, created_at"
+            " FROM runtime_receipts WHERE receipt_type = 'identity_mapping'"
+        )
+        params: list[Any] = []
+        if run_id is not None:
+            query += " AND run_id = ?"
+            params.append(run_id)
+        if normalized_kind and normalized_external_id:
+            query += " AND side_effect_key = ?"
+            params.append(
+                self._mapping_side_effect_key(normalized_kind, normalized_external_id)
+            )
+        elif normalized_kind:
+            query += " AND side_effect_key LIKE ?"
+            params.append(f"mapping:{normalized_kind}:%")
+        query += " ORDER BY created_at ASC LIMIT ?"
+        params.append(max(1, limit))
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            rows = await (await db.execute(query, params)).fetchall()
+        receipts = [_row_to_runtime_receipt(row) for row in rows]
+        if normalized_kind and not normalized_external_id:
+            receipts = [
+                receipt
+                for receipt in receipts
+                if receipt.payload.get("id_kind") == normalized_kind
+            ]
+        return receipts
+
+    def list_mapping_receipts_sync(
+        self,
+        *,
+        run_id: str | None = None,
+        id_kind: str | None = None,
+        external_id: str | None = None,
+        limit: int = 100,
+    ) -> list[RuntimeReceipt]:
+        normalized_kind = self._normalize_mapping_id_kind(id_kind) if id_kind else None
+        normalized_external_id: str | None = None
+        if external_id is not None:
+            normalized_external_id = str(external_id or "").strip()
+            if not normalized_external_id:
+                raise ValueError("external_id is required for runtime identity mapping")
+            if not normalized_kind:
+                raise ValueError("id_kind is required when external_id is provided")
+        self.init_db_sync()
+        query = (
+            "SELECT receipt_id, receipt_type, run_id, task_id, trace_id,"
+            " correlation_id, causation_id, parent_run_id, agent_id,"
+            " idempotency_key, side_effect_key, status, payload_json, created_at"
+            " FROM runtime_receipts WHERE receipt_type = 'identity_mapping'"
+        )
+        params: list[Any] = []
+        if run_id is not None:
+            query += " AND run_id = ?"
+            params.append(run_id)
+        if normalized_kind and normalized_external_id:
+            query += " AND side_effect_key = ?"
+            params.append(
+                self._mapping_side_effect_key(normalized_kind, normalized_external_id)
+            )
+        elif normalized_kind:
+            query += " AND side_effect_key LIKE ?"
+            params.append(f"mapping:{normalized_kind}:%")
+        query += " ORDER BY created_at ASC LIMIT ?"
+        params.append(max(1, limit))
+        with sqlite3.connect(self.db_path) as db:
+            db.row_factory = sqlite3.Row
+            rows = db.execute(query, params).fetchall()
+        receipts = [_row_to_runtime_receipt(row) for row in rows]
+        if normalized_kind and not normalized_external_id:
+            receipts = [
+                receipt
+                for receipt in receipts
+                if receipt.payload.get("id_kind") == normalized_kind
+            ]
+        return receipts
+
+    async def find_run_id_by_mapping(self, id_kind: str, external_id: str) -> str | None:
+        receipts = await self.list_mapping_receipts(
+            id_kind=id_kind,
+            external_id=external_id,
+            limit=1,
+        )
+        return receipts[0].run_id if receipts else None
+
+    def find_run_id_by_mapping_sync(self, id_kind: str, external_id: str) -> str | None:
+        receipts = self.list_mapping_receipts_sync(
+            id_kind=id_kind,
+            external_id=external_id,
+            limit=1,
+        )
+        return receipts[0].run_id if receipts else None
+
     async def record_runtime_receipt(self, receipt: RuntimeReceipt) -> RuntimeReceipt:
         await self.init_db()
         async with aiosqlite.connect(self.db_path) as db:
@@ -2945,6 +3232,7 @@ class RuntimeStateStore:
         run = await self.get_delegation_run(run_id)
         artifacts = await self.list_artifacts(run_id=run_id, limit=100)
         receipts = await self.list_runtime_receipts(run_id=run_id, limit=200)
+        mappings = await self.list_mapping_receipts(run_id=run_id, limit=200)
         children = await self.list_child_runs(run_id)
         idempotency_records: list[IdempotencyRecord] = []
         if identity is not None:
@@ -2967,6 +3255,7 @@ class RuntimeStateStore:
             "run": run,
             "artifacts": artifacts,
             "receipts": receipts,
+            "mappings": mappings,
             "children": children,
             "idempotency_records": idempotency_records,
         }

--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -8,11 +8,11 @@ Do not hand-edit the generated block.
 |---|---:|
 | Dharma Python modules | 661 |
 | Top-level Dharma Python modules | 389 |
-| Dharma Python LOC | 280,540 |
-| Test files | 619 |
-| Test function occurrences | 10,743 |
+| Dharma Python LOC | 280,829 |
+| Test files | 620 |
+| Test function occurrences | 10,748 |
 | Markdown files | 763 |
-| Markdown total lines | 191,505 |
+| Markdown total lines | 191,506 |
 | Bridge files | 24 |
 | Adapter files | 21 |
 | Orchestrator files | 4 |

--- a/docs/governance/SOVEREIGN_MANIFEST.md
+++ b/docs/governance/SOVEREIGN_MANIFEST.md
@@ -127,13 +127,13 @@ These are the ground-truth metrics. All other documents citing different numbers
 |--------|-------|-------------|
 | Total Python modules | **661** | find dharma_swarm -name "*.py" -type f |
 | Top-level (flat) modules | **389 (59.0%)** | find dharma_swarm -maxdepth 1 -name "*.py" -type f |
-| Total Python LOC | **280,540** | wc -l across dharma_swarm Python modules |
-| Test files | **619** | find tests -name "*.py" -type f |
-| Test functions | **10,743 `def test_` occurrences under tests/** | rg "def test_" tests |
+| Total Python LOC | **280,829** | wc -l across dharma_swarm Python modules |
+| Test files | **620** | find tests -name "*.py" -type f |
+| Test functions | **10,748 `def test_` occurrences under tests/** | rg "def test_" tests |
 | Tests collected (pytest) | **Needs write-permitted refresh** | not run during this DocOps count pass |
 | Collection errors | **Historical: 16 on 2026-04-04** | refresh before relying on this count |
 | Markdown files | **763** | find . -name "*.md" -type f |
-| Markdown total lines | **191,505** | wc -l across all .md |
+| Markdown total lines | **191,506** | wc -l across all .md |
 | Bridge files | **24** | find dharma_swarm -name "*bridge*.py" |
 | Adapter files | **21 across 8 locations** | find dharma_swarm -type f \| rg -i "adapter" |
 | Orchestrator files | **4** (6,034 LOC total) | find dharma_swarm -name "*orchestrat*" |

--- a/seams/spine-adoption/codex-runlog.md
+++ b/seams/spine-adoption/codex-runlog.md
@@ -1,2 +1,3 @@
 2026-06-01T15:03:46Z | slice-A | PR #430 | Opened Slice A sync legacy ledger bypass PR with identity-before-telic fix and passing v2 baseline.
 2026-06-01T18:40:41Z | slice-B | PR #435 | Opened adapter saturation PR; verification commands are listed in the PR body.
+2026-06-01T18:40:41Z | slice-C | PR #436 | Opened mapping receipt PR; verification commands are listed in the PR body.

--- a/tests/test_spine_mapping_receipts.py
+++ b/tests/test_spine_mapping_receipts.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import pytest
+
+from dharma_swarm.runtime_state import (
+    MAPPING_ID_KINDS,
+    RUNTIME_RECEIPT_TYPES,
+    RuntimeStateStore,
+)
+from dharma_swarm.spine.identity import ExecutionIdentity
+
+
+def _identity() -> ExecutionIdentity:
+    return ExecutionIdentity.new(
+        task_id="task-map",
+        run_id="run-map",
+        trace_id="trace-map",
+        correlation_id="corr-map",
+        claim_id="claim-map",
+        idempotency_key="idem-map",
+        agent_id="agent-map",
+        parent_run_id="run-parent",
+    )
+
+
+@pytest.mark.asyncio
+async def test_record_mapping_receipts_cover_slice_c_external_ids(tmp_path) -> None:
+    store = RuntimeStateStore(tmp_path / "runtime.db")
+    identity = _identity()
+    mappings = {
+        "workflow_id": "workflow-map-1",
+        "proposal_id": "proposal-map-1",
+        "event_id": "event-map-1",
+        "message_id": "message-map-1",
+        "ontology_action_id": "ontology-action-map-1",
+        "engine_artifact_id": "engine-artifact-map-1",
+    }
+
+    for id_kind, external_id in mappings.items():
+        await store.record_mapping_receipt(
+            identity,
+            id_kind=id_kind,
+            external_id=external_id,
+            source=f"slice-c:{id_kind}",
+            payload={"surface": id_kind},
+        )
+
+    ledger = await store.get_run_ledger(identity.run_id)
+    receipts = ledger["mappings"]
+    by_kind = {receipt.payload["id_kind"]: receipt for receipt in receipts}
+
+    assert set(mappings) == MAPPING_ID_KINDS
+    assert "identity_mapping" in RUNTIME_RECEIPT_TYPES
+    assert set(by_kind) == set(mappings)
+    for id_kind, external_id in mappings.items():
+        receipt = by_kind[id_kind]
+        assert receipt.receipt_type == "identity_mapping"
+        assert receipt.run_id == identity.run_id
+        assert receipt.task_id == identity.task_id
+        assert receipt.trace_id == identity.trace_id
+        assert receipt.correlation_id == identity.correlation_id
+        assert receipt.parent_run_id == identity.parent_run_id
+        assert receipt.idempotency_key == identity.idempotency_key
+        assert receipt.side_effect_key == f"mapping:{id_kind}:{external_id}"
+        assert receipt.payload["external_id"] == external_id
+        assert receipt.payload["source"] == f"slice-c:{id_kind}"
+        assert receipt.payload["surface"] == id_kind
+
+
+@pytest.mark.asyncio
+async def test_mapping_receipts_are_idempotent_per_run_kind_and_external_id(tmp_path) -> None:
+    store = RuntimeStateStore(tmp_path / "runtime.db")
+    identity = _identity()
+
+    first = await store.record_mapping_receipt(
+        identity,
+        id_kind="workflow_id",
+        external_id="workflow-repeat",
+        payload={"attempt": 1},
+    )
+    duplicate = await store.record_mapping_receipt(
+        identity,
+        id_kind="workflow_id",
+        external_id="workflow-repeat",
+        payload={"attempt": 2},
+    )
+    receipts = await store.list_mapping_receipts(
+        run_id=identity.run_id,
+        id_kind="workflow_id",
+        external_id="workflow-repeat",
+        limit=10,
+    )
+
+    assert first.receipt_id == duplicate.receipt_id
+    assert len(receipts) == 1
+    assert receipts[0].payload["attempt"] == 2
+
+
+@pytest.mark.asyncio
+async def test_mapping_lookup_returns_run_id_for_each_slice_c_surface(tmp_path) -> None:
+    store = RuntimeStateStore(tmp_path / "runtime.db")
+    identity = _identity()
+
+    await store.record_mapping_receipt(
+        identity,
+        id_kind="proposal_id",
+        external_id="proposal-before-event",
+    )
+    await store.record_mapping_receipt(
+        identity,
+        id_kind="event_id",
+        external_id="event-find",
+    )
+    store.record_mapping_receipt_sync(
+        identity,
+        id_kind="engine_artifact_id",
+        external_id="engine-artifact-find",
+    )
+
+    assert (
+        await store.find_run_id_by_mapping("event_id", "event-find")
+        == identity.run_id
+    )
+    assert (
+        store.find_run_id_by_mapping_sync(
+            "engine_artifact_id",
+            "engine-artifact-find",
+        )
+        == identity.run_id
+    )
+    event_receipts = await store.list_mapping_receipts(id_kind="event_id", limit=1)
+    assert len(event_receipts) == 1
+    assert event_receipts[0].payload["external_id"] == "event-find"
+
+
+@pytest.mark.asyncio
+async def test_mapping_receipts_update_identity_optional_fields_without_losing_run_mapping(
+    tmp_path,
+) -> None:
+    store = RuntimeStateStore(tmp_path / "runtime.db")
+    identity = _identity()
+
+    await store.record_mapping_receipt(
+        identity,
+        id_kind="proposal_id",
+        external_id="proposal-canonical",
+    )
+    await store.record_mapping_receipt(
+        identity,
+        id_kind="message_id",
+        external_id="message-canonical",
+    )
+    await store.record_mapping_receipt(
+        identity,
+        id_kind="engine_artifact_id",
+        external_id="artifact-canonical",
+    )
+
+    loaded = await store.get_execution_identity(identity.run_id)
+    assert loaded is not None
+    assert loaded.proposal_id == "proposal-canonical"
+    assert loaded.message_id == "message-canonical"
+    assert loaded.artifact_id == "artifact-canonical"
+    assert (
+        await store.find_run_id_by_mapping("proposal_id", "proposal-canonical")
+        == identity.run_id
+    )
+
+
+@pytest.mark.asyncio
+async def test_mapping_receipts_reject_unknown_or_empty_ids(tmp_path) -> None:
+    store = RuntimeStateStore(tmp_path / "runtime.db")
+    identity = _identity()
+
+    with pytest.raises(ValueError, match="unknown runtime identity mapping kind"):
+        await store.record_mapping_receipt(
+            identity,
+            id_kind="thread_id",
+            external_id="thread-1",
+        )
+
+    with pytest.raises(ValueError, match="external_id is required"):
+        await store.record_mapping_receipt(
+            identity,
+            id_kind="workflow_id",
+            external_id=" ",
+        )
+
+    with pytest.raises(ValueError, match="external_id is required"):
+        await store.find_run_id_by_mapping("workflow_id", "")
+
+    with pytest.raises(ValueError, match="id_kind is required"):
+        await store.list_mapping_receipts(external_id="workflow-1")


### PR DESCRIPTION
## Summary

Slice C for Runtime Spine Adoption Saturation.

- Adds `identity_mapping` runtime receipts to RuntimeStateStore.
- Supports mapping/querying `workflow_id`, `proposal_id`, `event_id`, `message_id`, `ontology_action_id`, and `engine_artifact_id` to canonical `run_id`.
- Adds async and sync helpers for recording, listing, and resolving mappings.
- Extends `get_run_ledger(run_id)` with a `mappings` section.
- Adds `tests/test_spine_mapping_receipts.py` as the Slice C metric target.

## Coherence Delta

Organ touched: RuntimeStateStore durable runtime ledger.

Declared-vs-actual gap closed: foreign workflow/message/event/proposal/ontology/artifact IDs can now be durably joined back to a canonical run through ledger receipts instead of in-memory or name-only association.

Proof that re-reads the map: `tests/test_spine_mapping_receipts.py` records every Slice C mapping kind, reconstructs by run ledger, verifies duplicate mapping idempotency, and resolves mappings back to `run_id`.

New drift introduced: helper-level mapping receipts are present before full organ auto-wiring; that wiring remains adapter work for later slices and should not be claimed as complete here.

## Guardrails

- [impact-checked]
- Mapping only; no C2 ontology enforcement.
- No workflow engine unification.
- No Temporal/DBOS/Restate migration.
- No new agents or fleet changes.
- No seam spec edits to `MERGED_PLAN.md`, `01_gap_matrix.md`, `02_master_spec.md`, or `03_codex_55_plan.md`.

## Triple Witness

1. Passing tests:
   - `pytest -q tests/test_spine_mapping_receipts.py` -> `5 passed`
   - `pytest -q tests/test_runtime_state.py tests/test_runtime_lifecycle.py tests/test_runtime_state_invariants.py` -> `10 passed`
   - v2 baseline command -> `159 passed`

2. Code evidence:
   - `dharma_swarm/runtime_state.py`: `record_mapping_receipt`, sync variant, mapping list/find helpers, `MAPPING_ID_KINDS`, and `get_run_ledger(...)[\"mappings\"]`.
   - `tests/test_spine_mapping_receipts.py`: one query/reconstruction path for every mapping kind.

3. External grounding:
   - Temporal durable execution/idempotency framing: https://temporal.io/blog/idempotency-and-durable-execution
   - Lydtech transactional outbox/idempotent consumer framing: https://www.lydtechconsulting.com/blog/kafka-idempotent-consumer-transactional-outbox

## Verification

```bash
pytest -q tests/test_spine_mapping_receipts.py
pytest -q tests/test_runtime_state.py tests/test_runtime_lifecycle.py tests/test_runtime_state_invariants.py
env HOME=/private/tmp/dharma_spine_slice_c_rebase_baseline_home pytest -q tests/test_runtime_truth_spine_v1.py tests/test_runtime_truth_spine_v2_adapters.py tests/test_runtime_truth_spine_v2_evidence.py tests/test_runtime_truth_spine_v2_tollbooth.py tests/test_runtime_state.py tests/test_runtime_lifecycle.py tests/test_a2a_spec_conformance.py tests/test_message_bus.py tests/test_checkpoint.py tests/test_orchestrator.py
git diff --check origin/main...HEAD
python3 scripts/docops/check_docops_integrity.py
env DHARMA_UPLIFT_ACK=impact-checked python3 scripts/uplift_guards/run_pre_commit.py
```

## Remaining Gaps

- This PR does not auto-wire every organ to emit mappings.
- This PR does not implement C2 ontology enforcement.
- Slice D owns deterministic adoption percentage and CI gate.
