### PR TITLE
spine(slice-1): add adoption metric gate

### DIFF
--- a/dharma_swarm/a2a/README.md
+++ b/dharma_swarm/a2a/README.md
@@ -1,0 +1,18 @@
+# A2A Runtime Spine Boundary
+
+This directory contains the external agent interoperability boundary for
+dharma_swarm. The A2A layer may accept or return remote task identifiers, but
+runtime lineage joins through `ExecutionIdentity` and `RuntimeStateStore`
+receipts.
+
+The correlation spine has three receipt layers:
+
+- A2A request/response receipts use `correlation_id` for external task joins.
+- Runtime spine receipts use `run_id`, `trace_id`, and `correlation_id` for
+  internal execution lineage.
+- Test and acceptance receipts must preserve the same correlation value when a
+  request crosses layers.
+
+A2A is not the workflow ledger, graph checkpoint store, or internal transport.
+Remote task IDs should be mapped to runtime IDs through explicit receipt or
+identity metadata before side effects.

--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -12,7 +12,7 @@ Do not hand-edit the generated block.
 | Test files | 621 |
 | Test function occurrences | 10,761 |
 | Markdown files | 764 |
-| Markdown total lines | 191,524 |
+| Markdown total lines | 191,525 |
 | Bridge files | 24 |
 | Adapter files | 21 |
 | Orchestrator files | 4 |

--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -9,10 +9,10 @@ Do not hand-edit the generated block.
 | Dharma Python modules | 661 |
 | Top-level Dharma Python modules | 389 |
 | Dharma Python LOC | 280,829 |
-| Test files | 620 |
-| Test function occurrences | 10,748 |
-| Markdown files | 763 |
-| Markdown total lines | 191,506 |
+| Test files | 621 |
+| Test function occurrences | 10,761 |
+| Markdown files | 764 |
+| Markdown total lines | 191,524 |
 | Bridge files | 24 |
 | Adapter files | 21 |
 | Orchestrator files | 4 |

--- a/docs/governance/SOVEREIGN_MANIFEST.md
+++ b/docs/governance/SOVEREIGN_MANIFEST.md
@@ -133,7 +133,7 @@ These are the ground-truth metrics. All other documents citing different numbers
 | Tests collected (pytest) | **Needs write-permitted refresh** | not run during this DocOps count pass |
 | Collection errors | **Historical: 16 on 2026-04-04** | refresh before relying on this count |
 | Markdown files | **764** | find . -name "*.md" -type f |
-| Markdown total lines | **191,524** | wc -l across all .md |
+| Markdown total lines | **191,525** | wc -l across all .md |
 | Bridge files | **24** | find dharma_swarm -name "*bridge*.py" |
 | Adapter files | **21 across 8 locations** | find dharma_swarm -type f \| rg -i "adapter" |
 | Orchestrator files | **4** (6,034 LOC total) | find dharma_swarm -name "*orchestrat*" |

--- a/docs/governance/SOVEREIGN_MANIFEST.md
+++ b/docs/governance/SOVEREIGN_MANIFEST.md
@@ -128,12 +128,12 @@ These are the ground-truth metrics. All other documents citing different numbers
 | Total Python modules | **661** | find dharma_swarm -name "*.py" -type f |
 | Top-level (flat) modules | **389 (59.0%)** | find dharma_swarm -maxdepth 1 -name "*.py" -type f |
 | Total Python LOC | **280,829** | wc -l across dharma_swarm Python modules |
-| Test files | **620** | find tests -name "*.py" -type f |
-| Test functions | **10,748 `def test_` occurrences under tests/** | rg "def test_" tests |
+| Test files | **621** | find tests -name "*.py" -type f |
+| Test functions | **10,761 `def test_` occurrences under tests/** | rg "def test_" tests |
 | Tests collected (pytest) | **Needs write-permitted refresh** | not run during this DocOps count pass |
 | Collection errors | **Historical: 16 on 2026-04-04** | refresh before relying on this count |
-| Markdown files | **763** | find . -name "*.md" -type f |
-| Markdown total lines | **191,506** | wc -l across all .md |
+| Markdown files | **764** | find . -name "*.md" -type f |
+| Markdown total lines | **191,524** | wc -l across all .md |
 | Bridge files | **24** | find dharma_swarm -name "*bridge*.py" |
 | Adapter files | **21 across 8 locations** | find dharma_swarm -type f \| rg -i "adapter" |
 | Orchestrator files | **4** (6,034 LOC total) | find dharma_swarm -name "*orchestrat*" |

--- a/reports/governance/spine_adoption_metric.json
+++ b/reports/governance/spine_adoption_metric.json
@@ -1,0 +1,1784 @@
+{
+  "audit_sha": "b3dbf94f00a0e7a72e23d5985cc34256c275f686",
+  "classification_rule": "joined requires all joined evidence patterns; adapter-ready requires all adapter evidence patterns when joined is incomplete; quarantine and legacy require explicit source markers; missing means no tracked surface or insufficient evidence.",
+  "classification_vocabulary": [
+    "joined",
+    "adapter-ready",
+    "missing",
+    "quarantine",
+    "legacy"
+  ],
+  "doc_anchor_status": "ok",
+  "metric": "spine_adoption_metric",
+  "missing_doc_anchors": [],
+  "source_status": "clean",
+  "source_status_entries": [],
+  "summary": {
+    "adapter_ready_count": 4,
+    "adoption_pct": 75.0,
+    "joined_count": 8,
+    "joined_or_adapter_ready_count": 12,
+    "joined_or_adapter_ready_percent": 75.0,
+    "joined_percent": 50.0,
+    "legacy_count": 2,
+    "missing_count": 1,
+    "non_joined_surface_ids": [
+      "tool_registry_dispatch",
+      "ontology_action_tollbooth",
+      "self_modification_loop",
+      "workflow_checkpoint_replay",
+      "mcp_tool_access",
+      "nats_jetstream_transport",
+      "opportunity_refill_research_backend",
+      "legacy_no_identity_escape_hatch"
+    ],
+    "quarantine_count": 1,
+    "status_counts": {
+      "adapter-ready": 4,
+      "joined": 8,
+      "legacy": 2,
+      "missing": 1,
+      "quarantine": 1
+    },
+    "total_surfaces": 16
+  },
+  "surfaces": [
+    {
+      "adapter_ready_evidence": [
+        {
+          "description": "identity symbol is present",
+          "hits": [
+            {
+              "line": 16,
+              "path": "dharma_swarm/spine/identity.py",
+              "text": "class MissingExecutionIdentity(ValueError):"
+            }
+          ],
+          "key": "identity_name_seen",
+          "matched": true,
+          "regex": "ExecutionIdentity"
+        }
+      ],
+      "category": "identity",
+      "files": [
+        "dharma_swarm/spine/identity.py"
+      ],
+      "id": "identity_contract",
+      "joined_evidence": [
+        {
+          "description": "ExecutionIdentity type exists",
+          "hits": [
+            {
+              "line": 29,
+              "path": "dharma_swarm/spine/identity.py",
+              "text": "class ExecutionIdentity:"
+            }
+          ],
+          "key": "execution_identity_class",
+          "matched": true,
+          "regex": "\\bclass ExecutionIdentity\\b"
+        },
+        {
+          "description": "identity can be recovered from metadata",
+          "hits": [
+            {
+              "line": 103,
+              "path": "dharma_swarm/spine/identity.py",
+              "text": "def from_metadata("
+            }
+          ],
+          "key": "metadata_hydration",
+          "matched": true,
+          "regex": "\\bdef from_metadata\\b"
+        },
+        {
+          "description": "dispatch can require mandatory identity fields",
+          "hits": [
+            {
+              "line": 146,
+              "path": "dharma_swarm/spine/identity.py",
+              "text": "def require_for_dispatch(self) -> \"ExecutionIdentity\":"
+            }
+          ],
+          "key": "dispatch_requirement",
+          "matched": true,
+          "regex": "\\bdef require_for_dispatch\\b"
+        }
+      ],
+      "label": "Canonical ExecutionIdentity contract",
+      "legacy_evidence": [],
+      "missing_joined_patterns": [],
+      "path_patterns": [
+        "dharma_swarm/spine/identity.py"
+      ],
+      "priority": 1,
+      "quarantine_evidence": [],
+      "status": "joined"
+    },
+    {
+      "adapter_ready_evidence": [
+        {
+          "description": "runtime store symbol is present",
+          "hits": [
+            {
+              "line": 1048,
+              "path": "dharma_swarm/runtime_state.py",
+              "text": "class RuntimeStateStore:"
+            }
+          ],
+          "key": "runtime_state_name_seen",
+          "matched": true,
+          "regex": "RuntimeStateStore"
+        }
+      ],
+      "category": "ledger",
+      "files": [
+        "dharma_swarm/runtime_state.py"
+      ],
+      "id": "runtime_state_ledger",
+      "joined_evidence": [
+        {
+          "description": "RuntimeStateStore type exists",
+          "hits": [
+            {
+              "line": 1048,
+              "path": "dharma_swarm/runtime_state.py",
+              "text": "class RuntimeStateStore:"
+            }
+          ],
+          "key": "store_class",
+          "matched": true,
+          "regex": "\\bclass RuntimeStateStore\\b"
+        },
+        {
+          "description": "execution identity table is declared",
+          "hits": [
+            {
+              "line": 211,
+              "path": "dharma_swarm/runtime_state.py",
+              "text": "CREATE TABLE IF NOT EXISTS execution_identities ("
+            }
+          ],
+          "key": "identity_table",
+          "matched": true,
+          "regex": "execution_identities"
+        },
+        {
+          "description": "runtime receipt table is declared",
+          "hits": [
+            {
+              "line": 234,
+              "path": "dharma_swarm/runtime_state.py",
+              "text": "CREATE TABLE IF NOT EXISTS runtime_receipts ("
+            }
+          ],
+          "key": "receipt_table",
+          "matched": true,
+          "regex": "runtime_receipts"
+        },
+        {
+          "description": "idempotency table is declared",
+          "hits": [
+            {
+              "line": 252,
+              "path": "dharma_swarm/runtime_state.py",
+              "text": "CREATE TABLE IF NOT EXISTS idempotency_records ("
+            }
+          ],
+          "key": "idempotency_table",
+          "matched": true,
+          "regex": "idempotency_records"
+        },
+        {
+          "description": "run ledger query exists",
+          "hits": [
+            {
+              "line": 3263,
+              "path": "dharma_swarm/runtime_state.py",
+              "text": "async def get_run_ledger(self, run_id: str) -> dict[str, Any]:"
+            }
+          ],
+          "key": "run_ledger_query",
+          "matched": true,
+          "regex": "\\bdef get_run_ledger\\b"
+        }
+      ],
+      "label": "RuntimeStateStore durable ledger",
+      "legacy_evidence": [
+        {
+          "description": "legacy identity bypass flag is present",
+          "hits": [
+            {
+              "line": 893,
+              "path": "dharma_swarm/runtime_state.py",
+              "text": "\"legacy_no_identity_allowed\": True,"
+            }
+          ],
+          "key": "legacy_bypass_flag",
+          "matched": true,
+          "regex": "legacy_no_identity_allowed"
+        }
+      ],
+      "missing_joined_patterns": [],
+      "path_patterns": [
+        "dharma_swarm/runtime_state.py"
+      ],
+      "priority": 1,
+      "quarantine_evidence": [],
+      "status": "joined"
+    },
+    {
+      "adapter_ready_evidence": [
+        {
+          "description": "identity imported",
+          "hits": [
+            {
+              "line": 18,
+              "path": "dharma_swarm/runtime_lifecycle.py",
+              "text": "from dharma_swarm.spine.identity import ExecutionIdentity, MissingExecutionIdentity"
+            }
+          ],
+          "key": "identity_import",
+          "matched": true,
+          "regex": "ExecutionIdentity"
+        }
+      ],
+      "category": "dispatch",
+      "files": [
+        "dharma_swarm/runtime_lifecycle.py"
+      ],
+      "id": "runtime_lifecycle_adapter",
+      "joined_evidence": [
+        {
+          "description": "lifecycle can create/require identity",
+          "hits": [
+            {
+              "line": 76,
+              "path": "dharma_swarm/runtime_lifecycle.py",
+              "text": "def ensure_execution_identity("
+            }
+          ],
+          "key": "ensure_identity",
+          "matched": true,
+          "regex": "\\bdef ensure_execution_identity\\b"
+        },
+        {
+          "description": "task claim lifecycle path exists",
+          "hits": [
+            {
+              "line": 206,
+              "path": "dharma_swarm/runtime_lifecycle.py",
+              "text": "async def record_task_claim("
+            }
+          ],
+          "key": "task_claim_receipt",
+          "matched": true,
+          "regex": "\\basync def record_task_claim\\b"
+        },
+        {
+          "description": "delegation run lifecycle path exists",
+          "hits": [
+            {
+              "line": 285,
+              "path": "dharma_swarm/runtime_lifecycle.py",
+              "text": "async def record_delegation_run("
+            }
+          ],
+          "key": "delegation_receipt",
+          "matched": true,
+          "regex": "\\basync def record_delegation_run\\b"
+        },
+        {
+          "description": "artifact lifecycle path exists",
+          "hits": [
+            {
+              "line": 394,
+              "path": "dharma_swarm/runtime_lifecycle.py",
+              "text": "async def record_artifact("
+            }
+          ],
+          "key": "artifact_receipt",
+          "matched": true,
+          "regex": "\\basync def record_artifact\\b"
+        },
+        {
+          "description": "runtime receipts are emitted",
+          "hits": [
+            {
+              "line": 14,
+              "path": "dharma_swarm/runtime_lifecycle.py",
+              "text": "RuntimeReceipt,"
+            }
+          ],
+          "key": "runtime_receipt",
+          "matched": true,
+          "regex": "RuntimeReceipt"
+        }
+      ],
+      "label": "Runtime lifecycle adapter",
+      "legacy_evidence": [],
+      "missing_joined_patterns": [],
+      "path_patterns": [
+        "dharma_swarm/runtime_lifecycle.py"
+      ],
+      "priority": 2,
+      "quarantine_evidence": [],
+      "status": "joined"
+    },
+    {
+      "adapter_ready_evidence": [
+        {
+          "description": "task create path exists",
+          "hits": [
+            {
+              "line": 287,
+              "path": "dharma_swarm/task_board.py",
+              "text": "async def create("
+            }
+          ],
+          "key": "task_create",
+          "matched": true,
+          "regex": "\\basync def create\\b"
+        }
+      ],
+      "category": "ingress",
+      "files": [
+        "dharma_swarm/task_board.py"
+      ],
+      "id": "task_board_ingress",
+      "joined_evidence": [
+        {
+          "description": "identity imported",
+          "hits": [
+            {
+              "line": 22,
+              "path": "dharma_swarm/task_board.py",
+              "text": "from dharma_swarm.spine.identity import ExecutionIdentity, MissingExecutionIdentity"
+            }
+          ],
+          "key": "identity_import",
+          "matched": true,
+          "regex": "ExecutionIdentity"
+        },
+        {
+          "description": "required identity option exists",
+          "hits": [
+            {
+              "line": 88,
+              "path": "dharma_swarm/task_board.py",
+              "text": "require_identity: bool = False,"
+            }
+          ],
+          "key": "require_identity",
+          "matched": true,
+          "regex": "require_identity"
+        },
+        {
+          "description": "runtime store accepted",
+          "hits": [
+            {
+              "line": 17,
+              "path": "dharma_swarm/task_board.py",
+              "text": "from dharma_swarm.runtime_state import RuntimeStateStore"
+            }
+          ],
+          "key": "runtime_store",
+          "matched": true,
+          "regex": "RuntimeStateStore"
+        },
+        {
+          "description": "task receipts are written to the ledger",
+          "hits": [
+            {
+              "line": 271,
+              "path": "dharma_swarm/task_board.py",
+              "text": "await self._runtime_state.record_receipt_for_identity("
+            }
+          ],
+          "key": "identity_receipt",
+          "matched": true,
+          "regex": "record_receipt_for_identity"
+        }
+      ],
+      "label": "TaskBoard local ingress",
+      "legacy_evidence": [],
+      "missing_joined_patterns": [],
+      "path_patterns": [
+        "dharma_swarm/task_board.py"
+      ],
+      "priority": 2,
+      "quarantine_evidence": [],
+      "status": "joined"
+    },
+    {
+      "adapter_ready_evidence": [
+        {
+          "description": "orchestrator has lifecycle adapter seam",
+          "hits": [
+            {
+              "line": 115,
+              "path": "dharma_swarm/orchestrator.py",
+              "text": "self._runtime_lifecycle = RuntimeLifecycle(self._ledger)"
+            }
+          ],
+          "key": "runtime_lifecycle",
+          "matched": true,
+          "regex": "_runtime_lifecycle"
+        }
+      ],
+      "category": "dispatch",
+      "files": [
+        "dharma_swarm/orchestrator.py"
+      ],
+      "id": "orchestrator_dispatch",
+      "joined_evidence": [
+        {
+          "description": "dispatch attaches identity",
+          "hits": [
+            {
+              "line": 2003,
+              "path": "dharma_swarm/orchestrator.py",
+              "text": "self._runtime_lifecycle.ensure_execution_identity(td, task=task_for_gate)"
+            }
+          ],
+          "key": "ensure_identity",
+          "matched": true,
+          "regex": "ensure_execution_identity"
+        },
+        {
+          "description": "dispatch records task claims",
+          "hits": [
+            {
+              "line": 1766,
+              "path": "dharma_swarm/orchestrator.py",
+              "text": "await self._runtime_lifecycle.record_task_claim("
+            }
+          ],
+          "key": "claim_receipt",
+          "matched": true,
+          "regex": "record_task_claim"
+        },
+        {
+          "description": "dispatch records delegation runs",
+          "hits": [
+            {
+              "line": 1773,
+              "path": "dharma_swarm/orchestrator.py",
+              "text": "await self._runtime_lifecycle.record_delegation_run("
+            }
+          ],
+          "key": "delegation_receipt",
+          "matched": true,
+          "regex": "record_delegation_run"
+        }
+      ],
+      "label": "Orchestrator dispatch path",
+      "legacy_evidence": [],
+      "missing_joined_patterns": [],
+      "path_patterns": [
+        "dharma_swarm/orchestrator.py"
+      ],
+      "priority": 3,
+      "quarantine_evidence": [],
+      "status": "joined"
+    },
+    {
+      "adapter_ready_evidence": [
+        {
+          "description": "event table exists",
+          "hits": [
+            {
+              "line": 68,
+              "path": "dharma_swarm/message_bus.py",
+              "text": "CREATE TABLE IF NOT EXISTS events ("
+            }
+          ],
+          "key": "events_table",
+          "matched": true,
+          "regex": "\\bCREATE TABLE IF NOT EXISTS events\\b"
+        }
+      ],
+      "category": "event",
+      "files": [
+        "dharma_swarm/message_bus.py"
+      ],
+      "id": "message_bus_transport",
+      "joined_evidence": [
+        {
+          "description": "identity imported",
+          "hits": [
+            {
+              "line": 32,
+              "path": "dharma_swarm/message_bus.py",
+              "text": "from dharma_swarm.spine.identity import ExecutionIdentity, MissingExecutionIdentity"
+            }
+          ],
+          "key": "identity_import",
+          "matched": true,
+          "regex": "ExecutionIdentity"
+        },
+        {
+          "description": "required identity option exists",
+          "hits": [
+            {
+              "line": 126,
+              "path": "dharma_swarm/message_bus.py",
+              "text": "require_identity: bool = False,"
+            }
+          ],
+          "key": "require_identity",
+          "matched": true,
+          "regex": "require_identity"
+        },
+        {
+          "description": "idempotency is checked before send/emit side effects",
+          "hits": [
+            {
+              "line": 241,
+              "path": "dharma_swarm/message_bus.py",
+              "text": "should_execute = await self._runtime_state.try_begin_idempotent_side_effect("
+            }
+          ],
+          "key": "begin_idempotent",
+          "matched": true,
+          "regex": "try_begin_idempotent_side_effect"
+        },
+        {
+          "description": "idempotency completion is recorded",
+          "hits": [
+            {
+              "line": 274,
+              "path": "dharma_swarm/message_bus.py",
+              "text": "await self._runtime_state.complete_idempotent_side_effect("
+            }
+          ],
+          "key": "complete_idempotent",
+          "matched": true,
+          "regex": "complete_idempotent_side_effect"
+        },
+        {
+          "description": "message consumption receipt exists",
+          "hits": [
+            {
+              "line": 837,
+              "path": "dharma_swarm/message_bus.py",
+              "text": "receipt_type=\"message_consumed\","
+            }
+          ],
+          "key": "message_consumed_receipt",
+          "matched": true,
+          "regex": "message_consumed"
+        }
+      ],
+      "label": "MessageBus internal event transport",
+      "legacy_evidence": [],
+      "missing_joined_patterns": [],
+      "path_patterns": [
+        "dharma_swarm/message_bus.py"
+      ],
+      "priority": 3,
+      "quarantine_evidence": [],
+      "status": "joined"
+    },
+    {
+      "adapter_ready_evidence": [
+        {
+          "description": "A2A task model exists",
+          "hits": [
+            {
+              "line": 186,
+              "path": "dharma_swarm/a2a/a2a_server.py",
+              "text": "class A2ATask:"
+            }
+          ],
+          "key": "a2a_task_model",
+          "matched": true,
+          "regex": "\\bclass A2ATask\\b"
+        }
+      ],
+      "category": "external-agent",
+      "files": [
+        "dharma_swarm/a2a/a2a_server.py"
+      ],
+      "id": "a2a_server_ingress",
+      "joined_evidence": [
+        {
+          "description": "identity imported",
+          "hits": [
+            {
+              "line": 38,
+              "path": "dharma_swarm/a2a/a2a_server.py",
+              "text": "from dharma_swarm.spine.identity import ExecutionIdentity, MissingExecutionIdentity"
+            }
+          ],
+          "key": "identity_import",
+          "matched": true,
+          "regex": "ExecutionIdentity"
+        },
+        {
+          "description": "runtime store accepted",
+          "hits": [
+            {
+              "line": 37,
+              "path": "dharma_swarm/a2a/a2a_server.py",
+              "text": "from dharma_swarm.runtime_state import RuntimeReceipt, RuntimeStateStore"
+            }
+          ],
+          "key": "runtime_store",
+          "matched": true,
+          "regex": "RuntimeStateStore"
+        },
+        {
+          "description": "external A2A task ID maps into identity",
+          "hits": [
+            {
+              "line": 384,
+              "path": "dharma_swarm/a2a/a2a_server.py",
+              "text": "\"external_a2a_task_id\": result.id,"
+            }
+          ],
+          "key": "a2a_external_id",
+          "matched": true,
+          "regex": "external_a2a_task_id"
+        },
+        {
+          "description": "A2A handler is idempotency-gated",
+          "hits": [
+            {
+              "line": 345,
+              "path": "dharma_swarm/a2a/a2a_server.py",
+              "text": "if not self._runtime_state.try_begin_idempotent_side_effect_sync("
+            }
+          ],
+          "key": "begin_idempotent",
+          "matched": true,
+          "regex": "try_begin_idempotent_side_effect_sync"
+        },
+        {
+          "description": "A2A task receipt is recorded",
+          "hits": [
+            {
+              "line": 372,
+              "path": "dharma_swarm/a2a/a2a_server.py",
+              "text": "receipt_type=\"a2a_task\","
+            }
+          ],
+          "key": "a2a_receipt",
+          "matched": true,
+          "regex": "receipt_type=\\\"a2a_task\\\""
+        }
+      ],
+      "label": "A2A task ingress",
+      "legacy_evidence": [
+        {
+          "description": "A2A still keeps a process-local task map",
+          "hits": [
+            {
+              "line": 280,
+              "path": "dharma_swarm/a2a/a2a_server.py",
+              "text": "self._tasks: dict[str, A2ATask] = {}"
+            }
+          ],
+          "key": "memory_task_store",
+          "matched": true,
+          "regex": "self\\._tasks: dict"
+        },
+        {
+          "description": "A2A still writes a JSONL projection",
+          "hits": [
+            {
+              "line": 43,
+              "path": "dharma_swarm/a2a/a2a_server.py",
+              "text": "_DEFAULT_TASK_LOG = _STATE_DIR / \"a2a\" / \"task_log.jsonl\""
+            }
+          ],
+          "key": "jsonl_task_log",
+          "matched": true,
+          "regex": "task_log\\.jsonl"
+        }
+      ],
+      "missing_joined_patterns": [],
+      "path_patterns": [
+        "dharma_swarm/a2a/a2a_server.py"
+      ],
+      "priority": 4,
+      "quarantine_evidence": [],
+      "status": "joined"
+    },
+    {
+      "adapter_ready_evidence": [
+        {
+          "description": "artifact store exists",
+          "hits": [
+            {
+              "line": 28,
+              "path": "dharma_swarm/artifact_store.py",
+              "text": "class RuntimeArtifactStore:"
+            }
+          ],
+          "key": "artifact_store_class",
+          "matched": true,
+          "regex": "\\bclass RuntimeArtifactStore\\b"
+        }
+      ],
+      "category": "artifact",
+      "files": [
+        "dharma_swarm/artifact_store.py"
+      ],
+      "id": "artifact_store",
+      "joined_evidence": [
+        {
+          "description": "identity imported",
+          "hits": [
+            {
+              "line": 16,
+              "path": "dharma_swarm/artifact_store.py",
+              "text": "from dharma_swarm.spine.identity import ExecutionIdentity, MissingExecutionIdentity"
+            }
+          ],
+          "key": "identity_import",
+          "matched": true,
+          "regex": "ExecutionIdentity"
+        },
+        {
+          "description": "required identity option exists",
+          "hits": [
+            {
+              "line": 36,
+              "path": "dharma_swarm/artifact_store.py",
+              "text": "require_identity: bool = False,"
+            }
+          ],
+          "key": "require_identity",
+          "matched": true,
+          "regex": "require_identity"
+        },
+        {
+          "description": "artifact intent receipt is recorded",
+          "hits": [
+            {
+              "line": 119,
+              "path": "dharma_swarm/artifact_store.py",
+              "text": "def _record_artifact_intent_sync("
+            }
+          ],
+          "key": "artifact_intent",
+          "matched": true,
+          "regex": "_record_artifact_intent_sync"
+        },
+        {
+          "description": "artifact completion receipt is recorded",
+          "hits": [
+            {
+              "line": 139,
+              "path": "dharma_swarm/artifact_store.py",
+              "text": "def _record_artifact_complete_sync("
+            }
+          ],
+          "key": "artifact_complete",
+          "matched": true,
+          "regex": "_record_artifact_complete_sync"
+        },
+        {
+          "description": "artifact row is written to RuntimeStateStore",
+          "hits": [
+            {
+              "line": 119,
+              "path": "dharma_swarm/artifact_store.py",
+              "text": "def _record_artifact_intent_sync("
+            }
+          ],
+          "key": "store_artifact",
+          "matched": true,
+          "regex": "record_artifact"
+        }
+      ],
+      "label": "Runtime artifact store",
+      "legacy_evidence": [],
+      "missing_joined_patterns": [],
+      "path_patterns": [
+        "dharma_swarm/artifact_store.py"
+      ],
+      "priority": 4,
+      "quarantine_evidence": [],
+      "status": "joined"
+    },
+    {
+      "adapter_ready_evidence": [
+        {
+          "description": "identity imported",
+          "hits": [
+            {
+              "line": 28,
+              "path": "dharma_swarm/tool_registry.py",
+              "text": "from dharma_swarm.spine.identity import ExecutionIdentity, MissingExecutionIdentity"
+            }
+          ],
+          "key": "identity_import",
+          "matched": true,
+          "regex": "ExecutionIdentity"
+        },
+        {
+          "description": "tool intent receipt is recorded",
+          "hits": [
+            {
+              "line": 199,
+              "path": "dharma_swarm/tool_registry.py",
+              "text": "runtime_state.record_side_effect_intent_sync("
+            }
+          ],
+          "key": "intent_receipt",
+          "matched": true,
+          "regex": "record_side_effect_intent_sync"
+        },
+        {
+          "description": "tool completion receipt is recorded",
+          "hits": [
+            {
+              "line": 220,
+              "path": "dharma_swarm/tool_registry.py",
+              "text": "runtime_state.record_side_effect_complete_sync("
+            }
+          ],
+          "key": "complete_receipt",
+          "matched": true,
+          "regex": "record_side_effect_complete_sync"
+        }
+      ],
+      "category": "tool",
+      "files": [
+        "dharma_swarm/tool_registry.py"
+      ],
+      "id": "tool_registry_dispatch",
+      "joined_evidence": [
+        {
+          "description": "identity imported",
+          "hits": [
+            {
+              "line": 28,
+              "path": "dharma_swarm/tool_registry.py",
+              "text": "from dharma_swarm.spine.identity import ExecutionIdentity, MissingExecutionIdentity"
+            }
+          ],
+          "key": "identity_import",
+          "matched": true,
+          "regex": "ExecutionIdentity"
+        },
+        {
+          "description": "required identity option exists",
+          "hits": [
+            {
+              "line": 73,
+              "path": "dharma_swarm/tool_registry.py",
+              "text": "require_identity: bool = False,"
+            }
+          ],
+          "key": "require_identity",
+          "matched": true,
+          "regex": "require_identity"
+        },
+        {
+          "description": "tool side effects are idempotency-gated",
+          "hits": [],
+          "key": "begin_idempotent",
+          "matched": false,
+          "regex": "try_begin_idempotent_side_effect"
+        },
+        {
+          "description": "tool completion receipt is recorded",
+          "hits": [
+            {
+              "line": 220,
+              "path": "dharma_swarm/tool_registry.py",
+              "text": "runtime_state.record_side_effect_complete_sync("
+            }
+          ],
+          "key": "complete_receipt",
+          "matched": true,
+          "regex": "record_side_effect_complete_sync"
+        }
+      ],
+      "label": "ToolRegistry side-effect dispatch",
+      "legacy_evidence": [],
+      "missing_joined_patterns": [
+        {
+          "description": "tool side effects are idempotency-gated",
+          "key": "begin_idempotent",
+          "regex": "try_begin_idempotent_side_effect"
+        }
+      ],
+      "path_patterns": [
+        "dharma_swarm/tool_registry.py"
+      ],
+      "priority": 5,
+      "quarantine_evidence": [],
+      "status": "adapter-ready"
+    },
+    {
+      "adapter_ready_evidence": [
+        {
+          "description": "ActionDef declares typed actions",
+          "hits": [
+            {
+              "line": 161,
+              "path": "dharma_swarm/ontology.py",
+              "text": "class ActionDef(BaseModel):"
+            }
+          ],
+          "key": "action_def",
+          "matched": true,
+          "regex": "\\bclass ActionDef\\b"
+        },
+        {
+          "description": "typed action execution chokepoint exists",
+          "hits": [
+            {
+              "line": 763,
+              "path": "dharma_swarm/ontology.py",
+              "text": "def execute_action("
+            }
+          ],
+          "key": "execute_action",
+          "matched": true,
+          "regex": "\\bdef execute_action\\b"
+        },
+        {
+          "description": "modifies contract is declared",
+          "hits": [
+            {
+              "line": 172,
+              "path": "dharma_swarm/ontology.py",
+              "text": "modifies: list[str] = Field(default_factory=list)"
+            }
+          ],
+          "key": "modifies_declared",
+          "matched": true,
+          "regex": "modifies:"
+        },
+        {
+          "description": "approval contract is declared",
+          "hits": [
+            {
+              "line": 174,
+              "path": "dharma_swarm/ontology.py",
+              "text": "requires_approval: bool = False"
+            }
+          ],
+          "key": "approval_declared",
+          "matched": true,
+          "regex": "requires_approval"
+        }
+      ],
+      "category": "ontology",
+      "files": [
+        "dharma_swarm/ontology.py"
+      ],
+      "id": "ontology_action_tollbooth",
+      "joined_evidence": [
+        {
+          "description": "ontology actions receive execution identity",
+          "hits": [],
+          "key": "identity_import",
+          "matched": false,
+          "regex": "ExecutionIdentity"
+        },
+        {
+          "description": "ontology actions write to runtime ledger",
+          "hits": [],
+          "key": "runtime_store",
+          "matched": false,
+          "regex": "RuntimeStateStore"
+        },
+        {
+          "description": "ontology action receipts are recorded",
+          "hits": [],
+          "key": "ontology_receipt",
+          "matched": false,
+          "regex": "record_ontology_action_receipt"
+        },
+        {
+          "description": "ActionDef.modifies is read at execution time",
+          "hits": [],
+          "key": "modifies_enforced",
+          "matched": false,
+          "regex": "action_def\\.modifies"
+        },
+        {
+          "description": "requires_approval is read at execution time",
+          "hits": [],
+          "key": "approval_enforced",
+          "matched": false,
+          "regex": "action_def\\.requires_approval"
+        }
+      ],
+      "label": "Ontology typed action tollbooth",
+      "legacy_evidence": [],
+      "missing_joined_patterns": [
+        {
+          "description": "ontology actions receive execution identity",
+          "key": "identity_import",
+          "regex": "ExecutionIdentity"
+        },
+        {
+          "description": "ontology actions write to runtime ledger",
+          "key": "runtime_store",
+          "regex": "RuntimeStateStore"
+        },
+        {
+          "description": "ontology action receipts are recorded",
+          "key": "ontology_receipt",
+          "regex": "record_ontology_action_receipt"
+        },
+        {
+          "description": "ActionDef.modifies is read at execution time",
+          "key": "modifies_enforced",
+          "regex": "action_def\\.modifies"
+        },
+        {
+          "description": "requires_approval is read at execution time",
+          "key": "approval_enforced",
+          "regex": "action_def\\.requires_approval"
+        }
+      ],
+      "path_patterns": [
+        "dharma_swarm/ontology.py"
+      ],
+      "priority": 5,
+      "quarantine_evidence": [],
+      "status": "adapter-ready"
+    },
+    {
+      "adapter_ready_evidence": [
+        {
+          "description": "proposal model exists",
+          "hits": [
+            {
+              "line": 95,
+              "path": "dharma_swarm/evolution.py",
+              "text": "class Proposal(BaseModel):"
+            }
+          ],
+          "key": "proposal_model",
+          "matched": true,
+          "regex": "\\bclass Proposal\\b"
+        },
+        {
+          "description": "gate phase exists",
+          "hits": [
+            {
+              "line": 1200,
+              "path": "dharma_swarm/evolution.py",
+              "text": "await self.gate_check(candidate)"
+            }
+          ],
+          "key": "gate_check",
+          "matched": true,
+          "regex": "\\bgate_check\\b"
+        },
+        {
+          "description": "apply/test phase exists",
+          "hits": [
+            {
+              "line": 273,
+              "path": "dharma_swarm/diff_applier.py",
+              "text": "async def apply_and_test("
+            },
+            {
+              "line": 1218,
+              "path": "dharma_swarm/evolution.py",
+              "text": "candidate, test_results = await self.apply_diff_and_test("
+            }
+          ],
+          "key": "apply_and_test",
+          "matched": true,
+          "regex": "apply_diff_and_test|apply_and_test"
+        },
+        {
+          "description": "rollback path exists",
+          "hits": [
+            {
+              "line": 1,
+              "path": "dharma_swarm/diff_applier.py",
+              "text": "\"\"\"Apply unified diffs to files with rollback and test integration."
+            },
+            {
+              "line": 1009,
+              "path": "dharma_swarm/evolution.py",
+              "text": "return (\"rollback\", \"rollback:apply_or_test\")"
+            },
+            {
+              "line": 435,
+              "path": "dharma_swarm/self_improve.py",
+              "text": "await applier.rollback(apply_result)"
+            }
+          ],
+          "key": "rollback",
+          "matched": true,
+          "regex": "\\brollback\\b"
+        }
+      ],
+      "category": "self-modification",
+      "files": [
+        "dharma_swarm/diff_applier.py",
+        "dharma_swarm/evolution.py",
+        "dharma_swarm/self_improve.py"
+      ],
+      "id": "self_modification_loop",
+      "joined_evidence": [
+        {
+          "description": "self-modification receives execution identity",
+          "hits": [],
+          "key": "identity_import",
+          "matched": false,
+          "regex": "ExecutionIdentity"
+        },
+        {
+          "description": "self-modification writes to runtime ledger",
+          "hits": [],
+          "key": "runtime_store",
+          "matched": false,
+          "regex": "RuntimeStateStore"
+        },
+        {
+          "description": "self-modification receipts are recorded",
+          "hits": [],
+          "key": "self_mod_receipt",
+          "matched": false,
+          "regex": "record_self_mod_receipt"
+        },
+        {
+          "description": "apply path is idempotency-gated",
+          "hits": [],
+          "key": "begin_idempotent",
+          "matched": false,
+          "regex": "try_begin_idempotent_side_effect"
+        }
+      ],
+      "label": "Self-modification propose/gate/apply/verify loop",
+      "legacy_evidence": [],
+      "missing_joined_patterns": [
+        {
+          "description": "self-modification receives execution identity",
+          "key": "identity_import",
+          "regex": "ExecutionIdentity"
+        },
+        {
+          "description": "self-modification writes to runtime ledger",
+          "key": "runtime_store",
+          "regex": "RuntimeStateStore"
+        },
+        {
+          "description": "self-modification receipts are recorded",
+          "key": "self_mod_receipt",
+          "regex": "record_self_mod_receipt"
+        },
+        {
+          "description": "apply path is idempotency-gated",
+          "key": "begin_idempotent",
+          "regex": "try_begin_idempotent_side_effect"
+        }
+      ],
+      "path_patterns": [
+        "dharma_swarm/evolution.py",
+        "dharma_swarm/self_improve.py",
+        "dharma_swarm/diff_applier.py"
+      ],
+      "priority": 6,
+      "quarantine_evidence": [],
+      "status": "adapter-ready"
+    },
+    {
+      "adapter_ready_evidence": [
+        {
+          "description": "workflow identity exists",
+          "hits": [
+            {
+              "line": 99,
+              "path": "dharma_swarm/durable_execution.py",
+              "text": "workflow_id: str,"
+            },
+            {
+              "line": 96,
+              "path": "dharma_swarm/workflow.py",
+              "text": "workflow_id: str"
+            }
+          ],
+          "key": "workflow_id",
+          "matched": true,
+          "regex": "workflow_id"
+        },
+        {
+          "description": "checkpointing exists",
+          "hits": [
+            {
+              "line": 12,
+              "path": "dharma_swarm/checkpoint.py",
+              "text": "3. **CheckpointStore** \u2014 filesystem-backed store for checkpoint data."
+            },
+            {
+              "line": 1,
+              "path": "dharma_swarm/durable_execution.py",
+              "text": "\"\"\"Durable execution with crash-recovery checkpointing."
+            },
+            {
+              "line": 1,
+              "path": "dharma_swarm/workflow.py",
+              "text": "\"\"\"Workflow Compiler \u2014 Declarative DAGs with checkpointing."
+            }
+          ],
+          "key": "checkpoint",
+          "matched": true,
+          "regex": "checkpoint"
+        },
+        {
+          "description": "replay harness exists",
+          "hits": [
+            {
+              "line": 1,
+              "path": "dharma_swarm/canonical_replay.py",
+              "text": "\"\"\"Canonical Replay Harness \u2014 proves all mutations are replayable."
+            },
+            {
+              "line": 9,
+              "path": "dharma_swarm/durable_execution.py",
+              "text": "- Temporal/Durable Functions: deterministic replay from event log"
+            }
+          ],
+          "key": "replay",
+          "matched": true,
+          "regex": "replay"
+        }
+      ],
+      "category": "checkpoint-replay",
+      "files": [
+        "dharma_swarm/canonical_replay.py",
+        "dharma_swarm/checkpoint.py",
+        "dharma_swarm/durable_execution.py",
+        "dharma_swarm/workflow.py"
+      ],
+      "id": "workflow_checkpoint_replay",
+      "joined_evidence": [
+        {
+          "description": "workflow/checkpoint path receives execution identity",
+          "hits": [],
+          "key": "identity_import",
+          "matched": false,
+          "regex": "ExecutionIdentity"
+        },
+        {
+          "description": "workflow/checkpoint path writes to runtime ledger",
+          "hits": [],
+          "key": "runtime_store",
+          "matched": false,
+          "regex": "RuntimeStateStore"
+        },
+        {
+          "description": "workflow/checkpoint path is ledger-reconstructable",
+          "hits": [],
+          "key": "runtime_receipt",
+          "matched": false,
+          "regex": "record_runtime_receipt|get_run_ledger"
+        }
+      ],
+      "label": "Workflow/checkpoint/replay path",
+      "legacy_evidence": [
+        {
+          "description": "filesystem checkpoint state exists",
+          "hits": [
+            {
+              "line": 12,
+              "path": "dharma_swarm/checkpoint.py",
+              "text": "3. **CheckpointStore** \u2014 filesystem-backed store for checkpoint data."
+            },
+            {
+              "line": 226,
+              "path": "dharma_swarm/durable_execution.py",
+              "text": "target = self._persist_dir / \"state.json\""
+            },
+            {
+              "line": 270,
+              "path": "dharma_swarm/workflow.py",
+              "text": "checkpoint_dir: Path | None = None,"
+            }
+          ],
+          "key": "filesystem_checkpoint",
+          "matched": true,
+          "regex": "checkpoint_dir|state\\.json|CheckpointStore"
+        },
+        {
+          "description": "replay uses a separate event log",
+          "hits": [
+            {
+              "line": 71,
+              "path": "dharma_swarm/canonical_replay.py",
+              "text": "from dharma_swarm.event_log import EventLog"
+            }
+          ],
+          "key": "event_log_replay",
+          "matched": true,
+          "regex": "EventLog"
+        }
+      ],
+      "missing_joined_patterns": [
+        {
+          "description": "workflow/checkpoint path receives execution identity",
+          "key": "identity_import",
+          "regex": "ExecutionIdentity"
+        },
+        {
+          "description": "workflow/checkpoint path writes to runtime ledger",
+          "key": "runtime_store",
+          "regex": "RuntimeStateStore"
+        },
+        {
+          "description": "workflow/checkpoint path is ledger-reconstructable",
+          "key": "runtime_receipt",
+          "regex": "record_runtime_receipt|get_run_ledger"
+        }
+      ],
+      "path_patterns": [
+        "dharma_swarm/workflow.py",
+        "dharma_swarm/checkpoint.py",
+        "dharma_swarm/durable_execution.py",
+        "dharma_swarm/canonical_replay.py"
+      ],
+      "priority": 6,
+      "quarantine_evidence": [],
+      "status": "legacy"
+    },
+    {
+      "adapter_ready_evidence": [
+        {
+          "description": "MCP/tool surface exists",
+          "hits": [
+            {
+              "line": 1,
+              "path": "dharma_swarm/dharma_context_mcp.py",
+              "text": "\"\"\"dharma_swarm Context Engine MCP Server."
+            },
+            {
+              "line": 1,
+              "path": "dharma_swarm/mcp_server.py",
+              "text": "\"\"\"MCP Server \u2014 exposes DHARMA SWARM operations as MCP tools."
+            }
+          ],
+          "key": "mcp_surface",
+          "matched": true,
+          "regex": "MCP|mcp|tool"
+        }
+      ],
+      "category": "tool",
+      "files": [
+        "dharma_swarm/dharma_context_mcp.py",
+        "dharma_swarm/mcp_server.py"
+      ],
+      "id": "mcp_tool_access",
+      "joined_evidence": [
+        {
+          "description": "MCP tools receive execution identity",
+          "hits": [],
+          "key": "identity_import",
+          "matched": false,
+          "regex": "ExecutionIdentity"
+        },
+        {
+          "description": "MCP tools write to runtime ledger",
+          "hits": [],
+          "key": "runtime_store",
+          "matched": false,
+          "regex": "RuntimeStateStore"
+        },
+        {
+          "description": "MCP side effects emit receipts",
+          "hits": [],
+          "key": "side_effect_receipt",
+          "matched": false,
+          "regex": "record_side_effect"
+        }
+      ],
+      "label": "MCP/tool access boundary",
+      "legacy_evidence": [],
+      "missing_joined_patterns": [
+        {
+          "description": "MCP tools receive execution identity",
+          "key": "identity_import",
+          "regex": "ExecutionIdentity"
+        },
+        {
+          "description": "MCP tools write to runtime ledger",
+          "key": "runtime_store",
+          "regex": "RuntimeStateStore"
+        },
+        {
+          "description": "MCP side effects emit receipts",
+          "key": "side_effect_receipt",
+          "regex": "record_side_effect"
+        }
+      ],
+      "path_patterns": [
+        "dharma_swarm/mcp_server.py",
+        "dharma_swarm/dharma_context_mcp.py"
+      ],
+      "priority": 7,
+      "quarantine_evidence": [],
+      "status": "adapter-ready"
+    },
+    {
+      "adapter_ready_evidence": [
+        {
+          "description": "NATS terms are present",
+          "hits": [],
+          "key": "nats_name_seen",
+          "matched": false,
+          "regex": "NATS|JetStream|nats"
+        }
+      ],
+      "category": "event",
+      "files": [],
+      "id": "nats_jetstream_transport",
+      "joined_evidence": [
+        {
+          "description": "NATS/JetStream client code exists",
+          "hits": [],
+          "key": "nats_client",
+          "matched": false,
+          "regex": "\\bnats\\b|JetStream"
+        },
+        {
+          "description": "NATS events carry execution identity",
+          "hits": [],
+          "key": "identity_import",
+          "matched": false,
+          "regex": "ExecutionIdentity"
+        },
+        {
+          "description": "NATS receiver is idempotency-gated",
+          "hits": [],
+          "key": "begin_idempotent",
+          "matched": false,
+          "regex": "try_begin_idempotent_side_effect"
+        },
+        {
+          "description": "ack/nack contract is visible",
+          "hits": [],
+          "key": "ack_contract",
+          "matched": false,
+          "regex": "\\back\\b|\\bnack\\b"
+        }
+      ],
+      "label": "NATS/JetStream event transport",
+      "legacy_evidence": [],
+      "missing_joined_patterns": [
+        {
+          "description": "NATS/JetStream client code exists",
+          "key": "nats_client",
+          "regex": "\\bnats\\b|JetStream"
+        },
+        {
+          "description": "NATS events carry execution identity",
+          "key": "identity_import",
+          "regex": "ExecutionIdentity"
+        },
+        {
+          "description": "NATS receiver is idempotency-gated",
+          "key": "begin_idempotent",
+          "regex": "try_begin_idempotent_side_effect"
+        },
+        {
+          "description": "ack/nack contract is visible",
+          "key": "ack_contract",
+          "regex": "\\back\\b|\\bnack\\b"
+        }
+      ],
+      "path_patterns": [
+        "dharma_swarm/nats*.py",
+        "dharma_swarm/**/nats*.py"
+      ],
+      "priority": 8,
+      "quarantine_evidence": [],
+      "status": "missing"
+    },
+    {
+      "adapter_ready_evidence": [
+        {
+          "description": "stage-result surface exists",
+          "hits": [
+            {
+              "line": 57,
+              "path": "dharma_swarm/opportunity_refill.py",
+              "text": "class StageResult(BaseModel):"
+            }
+          ],
+          "key": "stage_results",
+          "matched": true,
+          "regex": "StageResult"
+        }
+      ],
+      "category": "quarantine",
+      "files": [
+        "dharma_swarm/opportunity_refill.py"
+      ],
+      "id": "opportunity_refill_research_backend",
+      "joined_evidence": [
+        {
+          "description": "opportunity refill carries execution identity",
+          "hits": [],
+          "key": "identity_import",
+          "matched": false,
+          "regex": "ExecutionIdentity"
+        },
+        {
+          "description": "opportunity refill writes to runtime ledger",
+          "hits": [
+            {
+              "line": 8,
+              "path": "dharma_swarm/opportunity_refill.py",
+              "text": "1. A durable RuntimeStateStore task claim + delegation run"
+            }
+          ],
+          "key": "runtime_store",
+          "matched": true,
+          "regex": "RuntimeStateStore"
+        }
+      ],
+      "label": "Opportunity refill research backend",
+      "legacy_evidence": [],
+      "missing_joined_patterns": [
+        {
+          "description": "opportunity refill carries execution identity",
+          "key": "identity_import",
+          "regex": "ExecutionIdentity"
+        }
+      ],
+      "path_patterns": [
+        "dharma_swarm/opportunity_refill.py"
+      ],
+      "priority": 9,
+      "quarantine_evidence": [
+        {
+          "description": "surface has explicit quarantine mode",
+          "hits": [
+            {
+              "line": 14,
+              "path": "dharma_swarm/opportunity_refill.py",
+              "text": "If the backend is unavailable, the stage is quarantined with a clear marker."
+            }
+          ],
+          "key": "quarantine_marker",
+          "matched": true,
+          "regex": "QUARANTINE_MARKER|quarantined"
+        },
+        {
+          "description": "backend can be forced into quarantine",
+          "hits": [
+            {
+              "line": 178,
+              "path": "dharma_swarm/opportunity_refill.py",
+              "text": "sr.error = \"Research backend quarantined by operator (DHARMA_RESEARCH_BACKEND=quarantine)\""
+            }
+          ],
+          "key": "backend_quarantine",
+          "matched": true,
+          "regex": "DHARMA_RESEARCH_BACKEND=quarantine"
+        }
+      ],
+      "status": "quarantine"
+    },
+    {
+      "adapter_ready_evidence": [],
+      "category": "legacy",
+      "files": [
+        "dharma_swarm/runtime_state.py",
+        "tests/test_runtime_state_invariants.py"
+      ],
+      "id": "legacy_no_identity_escape_hatch",
+      "joined_evidence": [],
+      "label": "Legacy no-identity escape hatch",
+      "legacy_evidence": [
+        {
+          "description": "legacy bypass must stay explicit",
+          "hits": [
+            {
+              "line": 893,
+              "path": "dharma_swarm/runtime_state.py",
+              "text": "\"legacy_no_identity_allowed\": True,"
+            },
+            {
+              "line": 51,
+              "path": "tests/test_runtime_state_invariants.py",
+              "text": "legacy_no_identity_allowed=True,"
+            }
+          ],
+          "key": "legacy_flag",
+          "matched": true,
+          "regex": "legacy_no_identity_allowed"
+        },
+        {
+          "description": "legacy bypass has invariant coverage",
+          "hits": [
+            {
+              "line": 34,
+              "path": "tests/test_runtime_state_invariants.py",
+              "text": "async def test_sync_legacy_helpers_fail_closed_without_identity_unless_flagged("
+            }
+          ],
+          "key": "legacy_tests",
+          "matched": true,
+          "regex": "fail_closed_without_identity_unless_flagged"
+        }
+      ],
+      "missing_joined_patterns": [],
+      "path_patterns": [
+        "dharma_swarm/runtime_state.py",
+        "tests/test_runtime_state_invariants.py"
+      ],
+      "priority": 10,
+      "quarantine_evidence": [],
+      "status": "legacy"
+    }
+  ],
+  "top_saturation_targets": [
+    {
+      "category": "event",
+      "files": [],
+      "id": "nats_jetstream_transport",
+      "label": "NATS/JetStream event transport",
+      "missing_joined_patterns": [
+        {
+          "description": "NATS/JetStream client code exists",
+          "key": "nats_client",
+          "regex": "\\bnats\\b|JetStream"
+        },
+        {
+          "description": "NATS events carry execution identity",
+          "key": "identity_import",
+          "regex": "ExecutionIdentity"
+        },
+        {
+          "description": "NATS receiver is idempotency-gated",
+          "key": "begin_idempotent",
+          "regex": "try_begin_idempotent_side_effect"
+        },
+        {
+          "description": "ack/nack contract is visible",
+          "key": "ack_contract",
+          "regex": "\\back\\b|\\bnack\\b"
+        }
+      ],
+      "status": "missing"
+    },
+    {
+      "category": "ontology",
+      "files": [
+        "dharma_swarm/ontology.py"
+      ],
+      "id": "ontology_action_tollbooth",
+      "label": "Ontology typed action tollbooth",
+      "missing_joined_patterns": [
+        {
+          "description": "ontology actions receive execution identity",
+          "key": "identity_import",
+          "regex": "ExecutionIdentity"
+        },
+        {
+          "description": "ontology actions write to runtime ledger",
+          "key": "runtime_store",
+          "regex": "RuntimeStateStore"
+        },
+        {
+          "description": "ontology action receipts are recorded",
+          "key": "ontology_receipt",
+          "regex": "record_ontology_action_receipt"
+        },
+        {
+          "description": "ActionDef.modifies is read at execution time",
+          "key": "modifies_enforced",
+          "regex": "action_def\\.modifies"
+        },
+        {
+          "description": "requires_approval is read at execution time",
+          "key": "approval_enforced",
+          "regex": "action_def\\.requires_approval"
+        }
+      ],
+      "status": "adapter-ready"
+    },
+    {
+      "category": "tool",
+      "files": [
+        "dharma_swarm/tool_registry.py"
+      ],
+      "id": "tool_registry_dispatch",
+      "label": "ToolRegistry side-effect dispatch",
+      "missing_joined_patterns": [
+        {
+          "description": "tool side effects are idempotency-gated",
+          "key": "begin_idempotent",
+          "regex": "try_begin_idempotent_side_effect"
+        }
+      ],
+      "status": "adapter-ready"
+    },
+    {
+      "category": "self-modification",
+      "files": [
+        "dharma_swarm/diff_applier.py",
+        "dharma_swarm/evolution.py",
+        "dharma_swarm/self_improve.py"
+      ],
+      "id": "self_modification_loop",
+      "label": "Self-modification propose/gate/apply/verify loop",
+      "missing_joined_patterns": [
+        {
+          "description": "self-modification receives execution identity",
+          "key": "identity_import",
+          "regex": "ExecutionIdentity"
+        },
+        {
+          "description": "self-modification writes to runtime ledger",
+          "key": "runtime_store",
+          "regex": "RuntimeStateStore"
+        },
+        {
+          "description": "self-modification receipts are recorded",
+          "key": "self_mod_receipt",
+          "regex": "record_self_mod_receipt"
+        },
+        {
+          "description": "apply path is idempotency-gated",
+          "key": "begin_idempotent",
+          "regex": "try_begin_idempotent_side_effect"
+        }
+      ],
+      "status": "adapter-ready"
+    },
+    {
+      "category": "tool",
+      "files": [
+        "dharma_swarm/dharma_context_mcp.py",
+        "dharma_swarm/mcp_server.py"
+      ],
+      "id": "mcp_tool_access",
+      "label": "MCP/tool access boundary",
+      "missing_joined_patterns": [
+        {
+          "description": "MCP tools receive execution identity",
+          "key": "identity_import",
+          "regex": "ExecutionIdentity"
+        },
+        {
+          "description": "MCP tools write to runtime ledger",
+          "key": "runtime_store",
+          "regex": "RuntimeStateStore"
+        },
+        {
+          "description": "MCP side effects emit receipts",
+          "key": "side_effect_receipt",
+          "regex": "record_side_effect"
+        }
+      ],
+      "status": "adapter-ready"
+    }
+  ],
+  "tracked_file_count": 2761
+}

--- a/seams/spine-adoption/codex-runlog.md
+++ b/seams/spine-adoption/codex-runlog.md
@@ -1,3 +1,4 @@
 2026-06-01T15:03:46Z | slice-A | PR #430 | Opened Slice A sync legacy ledger bypass PR with identity-before-telic fix and passing v2 baseline.
 2026-06-01T18:40:41Z | slice-B | PR #435 | Opened adapter saturation PR; verification commands are listed in the PR body.
 2026-06-01T18:40:41Z | slice-C | PR #436 | Opened mapping receipt PR; verification commands are listed in the PR body.
+2026-06-01T20:24:12Z | slice-1 | PR #443 | Opened adoption metric gate PR with truthful 75.0% spine adoption and read-only CI checks.

--- a/tests/test_spine_adoption_metric.py
+++ b/tests/test_spine_adoption_metric.py
@@ -1,0 +1,234 @@
+"""Tests for the deterministic spine adoption metric tool.
+
+Codex Slice 1 deliverable: tools/spine_adoption_metric.py must
+deterministically scan tracked source files and classify each
+surface as joined / adapter-ready / missing / quarantine / legacy.
+
+The adoption_pct formula is:
+    (joined_count + adapter_ready_count) / total_surfaces * 100
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tools.spine_adoption_metric import (
+    SURFACE_RULES,
+    VALID_STATUSES,
+    SurfaceRule,
+    classify_surface,
+    generate_report,
+    main,
+    summarize_surfaces,
+    write_report,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _generate() -> dict:
+    return generate_report(REPO_ROOT)
+
+
+# ---------------------------------------------------------------------------
+# Core metric structure tests
+# ---------------------------------------------------------------------------
+
+
+def test_report_has_required_top_level_keys() -> None:
+    report = _generate()
+    for key in (
+        "metric",
+        "audit_sha",
+        "source_status",
+        "source_status_entries",
+        "tracked_file_count",
+        "classification_vocabulary",
+        "classification_rule",
+        "summary",
+        "surfaces",
+        "top_saturation_targets",
+    ):
+        assert key in report, f"missing top-level key: {key}"
+    assert report["metric"] == "spine_adoption_metric"
+    assert report["source_status"] in {"clean", "dirty"}
+    assert isinstance(report["source_status_entries"], list)
+
+
+def test_classification_vocabulary_matches_valid_statuses() -> None:
+    report = _generate()
+    assert tuple(report["classification_vocabulary"]) == VALID_STATUSES
+
+
+def test_summary_adoption_pct_formula() -> None:
+    report = _generate()
+    summary = report["summary"]
+    total = summary["total_surfaces"]
+    joined = summary["joined_count"]
+    adapter_ready = summary["adapter_ready_count"]
+    expected_pct = round((joined + adapter_ready) / total * 100, 1) if total else 0.0
+    assert summary["adoption_pct"] == expected_pct
+    assert summary["joined_or_adapter_ready_count"] == joined + adapter_ready
+
+
+def test_every_surface_rule_is_represented() -> None:
+    report = _generate()
+    surface_ids = {s["id"] for s in report["surfaces"]}
+    rule_ids = {r.surface_id for r in SURFACE_RULES}
+    assert surface_ids == rule_ids
+
+
+def test_every_surface_has_valid_status() -> None:
+    report = _generate()
+    for surface in report["surfaces"]:
+        assert surface["status"] in VALID_STATUSES, (
+            f"surface {surface['id']} has invalid status: {surface['status']}"
+        )
+
+
+def test_status_counts_sum_to_total() -> None:
+    report = _generate()
+    summary = report["summary"]
+    total_from_counts = sum(summary["status_counts"].values())
+    assert total_from_counts == summary["total_surfaces"]
+
+
+# ---------------------------------------------------------------------------
+# Determinism test
+# ---------------------------------------------------------------------------
+
+
+def test_report_is_deterministic(tmp_path: Path) -> None:
+    output = tmp_path / "metric.json"
+    report_a = _generate()
+    write_report(report_a, output, REPO_ROOT)
+    text_a = output.read_text(encoding="utf-8")
+
+    report_b = _generate()
+    write_report(report_b, output, REPO_ROOT)
+    text_b = output.read_text(encoding="utf-8")
+
+    assert text_a == text_b
+    assert json.loads(text_a)["summary"]["adoption_pct"] == report_a["summary"]["adoption_pct"]
+
+
+def test_require_clean_source_fails_before_writing_when_dirty(monkeypatch, tmp_path: Path) -> None:
+    from tools import spine_adoption_metric as metric_module
+
+    output = tmp_path / "should_not_exist.json"
+    monkeypatch.setattr(metric_module, "git_status_porcelain", lambda repo_root: [" M fake.py"])
+
+    assert main(["--repo-root", str(REPO_ROOT), "--output", str(output), "--require-clean-source"]) == 1
+    assert not output.exists()
+
+
+def test_cli_checks_are_read_only_without_output(monkeypatch) -> None:
+    from tools import spine_adoption_metric as metric_module
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("read-only metric checks must not write reports")
+
+    monkeypatch.setattr(metric_module, "write_report", fail_if_called)
+
+    assert metric_module.main(["--repo-root", str(REPO_ROOT), "--fail-below-adoption", "0"]) == 0
+
+
+# ---------------------------------------------------------------------------
+# Falsification: injecting a missing token must flip a surface to non-joined
+# ---------------------------------------------------------------------------
+
+
+def test_missing_pattern_makes_surface_non_joined() -> None:
+    """If a joined-evidence pattern can't match, the surface must NOT be joined."""
+    from tools.spine_adoption_metric import PatternSpec, load_tracked_sources, git_tracked_files
+
+    tracked = git_tracked_files(REPO_ROOT)
+    source_map = load_tracked_sources(REPO_ROOT, tracked)
+
+    # Take a rule that is currently joined and inject an unmatchable pattern
+    joined_rules = [
+        r for r in SURFACE_RULES
+        if classify_surface(r, source_map)["status"] == "joined"
+    ]
+    assert joined_rules, "no joined surfaces to test against"
+    original = joined_rules[0]
+    broken_rule = SurfaceRule(
+        surface_id=original.surface_id,
+        label=original.label,
+        category=original.category,
+        path_patterns=original.path_patterns,
+        joined=original.joined + (
+            PatternSpec(
+                key="definitely_missing_token",
+                regex=r"XYZZY_IMPOSSIBLE_TOKEN_FOR_FALSIFICATION_42",
+                description="impossible token for falsification",
+            ),
+        ),
+        adapter_ready=original.adapter_ready,
+        quarantine=original.quarantine,
+        legacy=original.legacy,
+        priority=original.priority,
+    )
+    result = classify_surface(broken_rule, source_map)
+    assert result["status"] != "joined", (
+        f"surface {original.surface_id} still classified as joined after injecting missing pattern"
+    )
+    missing_keys = [p["key"] for p in result["missing_joined_patterns"]]
+    assert "definitely_missing_token" in missing_keys
+
+
+# ---------------------------------------------------------------------------
+# Known surface status assertions (grounded in merged PRs #435 + #436)
+# ---------------------------------------------------------------------------
+
+
+def test_known_joined_surfaces() -> None:
+    """Surfaces proven joined by PRs #435 and #436."""
+    report = _generate()
+    surface_map = {s["id"]: s["status"] for s in report["surfaces"]}
+    expected_joined = [
+        "identity_contract",
+        "runtime_state_ledger",
+        "runtime_lifecycle_adapter",
+        "task_board_ingress",
+        "orchestrator_dispatch",
+        "message_bus_transport",
+        "a2a_server_ingress",
+        "artifact_store",
+    ]
+    for sid in expected_joined:
+        assert surface_map.get(sid) == "joined", (
+            f"expected {sid} to be joined but got {surface_map.get(sid)}"
+        )
+
+
+def test_nats_is_scoped_out() -> None:
+    """NATS is explicitly scoped out per active track non-goals.
+
+    It has no source files so the metric correctly marks it 'missing'.
+    This is acceptable — the adoption formula (joined + adapter_ready) / total
+    accounts for it.  If NATS source files appear later, quarantine evidence
+    patterns should be added to the SurfaceRule.
+    """
+    report = _generate()
+    nats = next((s for s in report["surfaces"] if s["id"] == "nats_jetstream_transport"), None)
+    assert nats is not None
+    assert nats["status"] in ("missing", "quarantine")
+
+
+# ---------------------------------------------------------------------------
+# Adoption threshold (current state — updated as slices land)
+# ---------------------------------------------------------------------------
+
+
+def test_current_adoption_is_above_baseline() -> None:
+    """adoption_pct must exceed the pre-saturation baseline of 56.25%."""
+    report = _generate()
+    assert report["summary"]["adoption_pct"] > 56.0

--- a/tools/spine_adoption_metric.py
+++ b/tools/spine_adoption_metric.py
@@ -1,0 +1,588 @@
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+
+VALID_STATUSES = ("joined", "adapter-ready", "missing", "quarantine", "legacy")
+DEFAULT_OUTPUT = Path("reports/governance/spine_adoption_metric.json")
+DOC_ANCHORS = (
+    "docs/reports/CONVERGED_SEAM_AUDIT_RUNTIME_TRUTH_SPINE.md",
+    "reports/governance/execution_identity_lineage_blast_radius_audit.md",
+    "dharma_swarm/a2a/README.md",
+)
+
+
+@dataclass(frozen=True)
+class PatternSpec:
+    key: str
+    regex: str
+    description: str
+
+
+@dataclass(frozen=True)
+class SurfaceRule:
+    surface_id: str
+    label: str
+    category: str
+    path_patterns: tuple[str, ...]
+    joined: tuple[PatternSpec, ...] = ()
+    adapter_ready: tuple[PatternSpec, ...] = ()
+    quarantine: tuple[PatternSpec, ...] = ()
+    legacy: tuple[PatternSpec, ...] = ()
+    priority: int = 50
+
+
+def p(key: str, regex: str, description: str) -> PatternSpec:
+    return PatternSpec(key=key, regex=regex, description=description)
+
+
+SURFACE_RULES: tuple[SurfaceRule, ...] = (
+    SurfaceRule(
+        surface_id="identity_contract",
+        label="Canonical ExecutionIdentity contract",
+        category="identity",
+        path_patterns=("dharma_swarm/spine/identity.py",),
+        joined=(
+            p("execution_identity_class", r"\bclass ExecutionIdentity\b", "ExecutionIdentity type exists"),
+            p("metadata_hydration", r"\bdef from_metadata\b", "identity can be recovered from metadata"),
+            p("dispatch_requirement", r"\bdef require_for_dispatch\b", "dispatch can require mandatory identity fields"),
+        ),
+        adapter_ready=(p("identity_name_seen", r"ExecutionIdentity", "identity symbol is present"),),
+        priority=1,
+    ),
+    SurfaceRule(
+        surface_id="runtime_state_ledger",
+        label="RuntimeStateStore durable ledger",
+        category="ledger",
+        path_patterns=("dharma_swarm/runtime_state.py",),
+        joined=(
+            p("store_class", r"\bclass RuntimeStateStore\b", "RuntimeStateStore type exists"),
+            p("identity_table", r"execution_identities", "execution identity table is declared"),
+            p("receipt_table", r"runtime_receipts", "runtime receipt table is declared"),
+            p("idempotency_table", r"idempotency_records", "idempotency table is declared"),
+            p("run_ledger_query", r"\bdef get_run_ledger\b", "run ledger query exists"),
+        ),
+        adapter_ready=(p("runtime_state_name_seen", r"RuntimeStateStore", "runtime store symbol is present"),),
+        legacy=(p("legacy_bypass_flag", r"legacy_no_identity_allowed", "legacy identity bypass flag is present"),),
+        priority=1,
+    ),
+    SurfaceRule(
+        surface_id="runtime_lifecycle_adapter",
+        label="Runtime lifecycle adapter",
+        category="dispatch",
+        path_patterns=("dharma_swarm/runtime_lifecycle.py",),
+        joined=(
+            p("ensure_identity", r"\bdef ensure_execution_identity\b", "lifecycle can create/require identity"),
+            p("task_claim_receipt", r"\basync def record_task_claim\b", "task claim lifecycle path exists"),
+            p("delegation_receipt", r"\basync def record_delegation_run\b", "delegation run lifecycle path exists"),
+            p("artifact_receipt", r"\basync def record_artifact\b", "artifact lifecycle path exists"),
+            p("runtime_receipt", r"RuntimeReceipt", "runtime receipts are emitted"),
+        ),
+        adapter_ready=(p("identity_import", r"ExecutionIdentity", "identity imported"),),
+        priority=2,
+    ),
+    SurfaceRule(
+        surface_id="task_board_ingress",
+        label="TaskBoard local ingress",
+        category="ingress",
+        path_patterns=("dharma_swarm/task_board.py",),
+        joined=(
+            p("identity_import", r"ExecutionIdentity", "identity imported"),
+            p("require_identity", r"require_identity", "required identity option exists"),
+            p("runtime_store", r"RuntimeStateStore", "runtime store accepted"),
+            p("identity_receipt", r"record_receipt_for_identity", "task receipts are written to the ledger"),
+        ),
+        adapter_ready=(p("task_create", r"\basync def create\b", "task create path exists"),),
+        priority=2,
+    ),
+    SurfaceRule(
+        surface_id="orchestrator_dispatch",
+        label="Orchestrator dispatch path",
+        category="dispatch",
+        path_patterns=("dharma_swarm/orchestrator.py",),
+        joined=(
+            p("ensure_identity", r"ensure_execution_identity", "dispatch attaches identity"),
+            p("claim_receipt", r"record_task_claim", "dispatch records task claims"),
+            p("delegation_receipt", r"record_delegation_run", "dispatch records delegation runs"),
+        ),
+        adapter_ready=(p("runtime_lifecycle", r"_runtime_lifecycle", "orchestrator has lifecycle adapter seam"),),
+        priority=3,
+    ),
+    SurfaceRule(
+        surface_id="message_bus_transport",
+        label="MessageBus internal event transport",
+        category="event",
+        path_patterns=("dharma_swarm/message_bus.py",),
+        joined=(
+            p("identity_import", r"ExecutionIdentity", "identity imported"),
+            p("require_identity", r"require_identity", "required identity option exists"),
+            p("begin_idempotent", r"try_begin_idempotent_side_effect", "idempotency is checked before send/emit side effects"),
+            p("complete_idempotent", r"complete_idempotent_side_effect", "idempotency completion is recorded"),
+            p("message_consumed_receipt", r"message_consumed", "message consumption receipt exists"),
+        ),
+        adapter_ready=(p("events_table", r"\bCREATE TABLE IF NOT EXISTS events\b", "event table exists"),),
+        priority=3,
+    ),
+    SurfaceRule(
+        surface_id="a2a_server_ingress",
+        label="A2A task ingress",
+        category="external-agent",
+        path_patterns=("dharma_swarm/a2a/a2a_server.py",),
+        joined=(
+            p("identity_import", r"ExecutionIdentity", "identity imported"),
+            p("runtime_store", r"RuntimeStateStore", "runtime store accepted"),
+            p("a2a_external_id", r"external_a2a_task_id", "external A2A task ID maps into identity"),
+            p("begin_idempotent", r"try_begin_idempotent_side_effect_sync", "A2A handler is idempotency-gated"),
+            p("a2a_receipt", r"receipt_type=\"a2a_task\"", "A2A task receipt is recorded"),
+        ),
+        adapter_ready=(p("a2a_task_model", r"\bclass A2ATask\b", "A2A task model exists"),),
+        legacy=(
+            p("memory_task_store", r"self\._tasks: dict", "A2A still keeps a process-local task map"),
+            p("jsonl_task_log", r"task_log\.jsonl", "A2A still writes a JSONL projection"),
+        ),
+        priority=4,
+    ),
+    SurfaceRule(
+        surface_id="artifact_store",
+        label="Runtime artifact store",
+        category="artifact",
+        path_patterns=("dharma_swarm/artifact_store.py",),
+        joined=(
+            p("identity_import", r"ExecutionIdentity", "identity imported"),
+            p("require_identity", r"require_identity", "required identity option exists"),
+            p("artifact_intent", r"_record_artifact_intent_sync", "artifact intent receipt is recorded"),
+            p("artifact_complete", r"_record_artifact_complete_sync", "artifact completion receipt is recorded"),
+            p("store_artifact", r"record_artifact", "artifact row is written to RuntimeStateStore"),
+        ),
+        adapter_ready=(p("artifact_store_class", r"\bclass RuntimeArtifactStore\b", "artifact store exists"),),
+        priority=4,
+    ),
+    SurfaceRule(
+        surface_id="tool_registry_dispatch",
+        label="ToolRegistry side-effect dispatch",
+        category="tool",
+        path_patterns=("dharma_swarm/tool_registry.py",),
+        joined=(
+            p("identity_import", r"ExecutionIdentity", "identity imported"),
+            p("require_identity", r"require_identity", "required identity option exists"),
+            p("begin_idempotent", r"try_begin_idempotent_side_effect", "tool side effects are idempotency-gated"),
+            p("complete_receipt", r"record_side_effect_complete_sync", "tool completion receipt is recorded"),
+        ),
+        adapter_ready=(
+            p("identity_import", r"ExecutionIdentity", "identity imported"),
+            p("intent_receipt", r"record_side_effect_intent_sync", "tool intent receipt is recorded"),
+            p("complete_receipt", r"record_side_effect_complete_sync", "tool completion receipt is recorded"),
+        ),
+        priority=5,
+    ),
+    SurfaceRule(
+        surface_id="ontology_action_tollbooth",
+        label="Ontology typed action tollbooth",
+        category="ontology",
+        path_patterns=("dharma_swarm/ontology.py",),
+        joined=(
+            p("identity_import", r"ExecutionIdentity", "ontology actions receive execution identity"),
+            p("runtime_store", r"RuntimeStateStore", "ontology actions write to runtime ledger"),
+            p("ontology_receipt", r"record_ontology_action_receipt", "ontology action receipts are recorded"),
+            p("modifies_enforced", r"action_def\.modifies", "ActionDef.modifies is read at execution time"),
+            p("approval_enforced", r"action_def\.requires_approval", "requires_approval is read at execution time"),
+        ),
+        adapter_ready=(
+            p("action_def", r"\bclass ActionDef\b", "ActionDef declares typed actions"),
+            p("execute_action", r"\bdef execute_action\b", "typed action execution chokepoint exists"),
+            p("modifies_declared", r"modifies:", "modifies contract is declared"),
+            p("approval_declared", r"requires_approval", "approval contract is declared"),
+        ),
+        priority=5,
+    ),
+    SurfaceRule(
+        surface_id="self_modification_loop",
+        label="Self-modification propose/gate/apply/verify loop",
+        category="self-modification",
+        path_patterns=(
+            "dharma_swarm/evolution.py",
+            "dharma_swarm/self_improve.py",
+            "dharma_swarm/diff_applier.py",
+        ),
+        joined=(
+            p("identity_import", r"ExecutionIdentity", "self-modification receives execution identity"),
+            p("runtime_store", r"RuntimeStateStore", "self-modification writes to runtime ledger"),
+            p("self_mod_receipt", r"record_self_mod_receipt", "self-modification receipts are recorded"),
+            p("begin_idempotent", r"try_begin_idempotent_side_effect", "apply path is idempotency-gated"),
+        ),
+        adapter_ready=(
+            p("proposal_model", r"\bclass Proposal\b", "proposal model exists"),
+            p("gate_check", r"\bgate_check\b", "gate phase exists"),
+            p("apply_and_test", r"apply_diff_and_test|apply_and_test", "apply/test phase exists"),
+            p("rollback", r"\brollback\b", "rollback path exists"),
+        ),
+        priority=6,
+    ),
+    SurfaceRule(
+        surface_id="workflow_checkpoint_replay",
+        label="Workflow/checkpoint/replay path",
+        category="checkpoint-replay",
+        path_patterns=(
+            "dharma_swarm/workflow.py",
+            "dharma_swarm/checkpoint.py",
+            "dharma_swarm/durable_execution.py",
+            "dharma_swarm/canonical_replay.py",
+        ),
+        joined=(
+            p("identity_import", r"ExecutionIdentity", "workflow/checkpoint path receives execution identity"),
+            p("runtime_store", r"RuntimeStateStore", "workflow/checkpoint path writes to runtime ledger"),
+            p("runtime_receipt", r"record_runtime_receipt|get_run_ledger", "workflow/checkpoint path is ledger-reconstructable"),
+        ),
+        adapter_ready=(
+            p("workflow_id", r"workflow_id", "workflow identity exists"),
+            p("checkpoint", r"checkpoint", "checkpointing exists"),
+            p("replay", r"replay", "replay harness exists"),
+        ),
+        legacy=(
+            p("filesystem_checkpoint", r"checkpoint_dir|state\.json|CheckpointStore", "filesystem checkpoint state exists"),
+            p("event_log_replay", r"EventLog", "replay uses a separate event log"),
+        ),
+        priority=6,
+    ),
+    SurfaceRule(
+        surface_id="mcp_tool_access",
+        label="MCP/tool access boundary",
+        category="tool",
+        path_patterns=("dharma_swarm/mcp_server.py", "dharma_swarm/dharma_context_mcp.py"),
+        joined=(
+            p("identity_import", r"ExecutionIdentity", "MCP tools receive execution identity"),
+            p("runtime_store", r"RuntimeStateStore", "MCP tools write to runtime ledger"),
+            p("side_effect_receipt", r"record_side_effect", "MCP side effects emit receipts"),
+        ),
+        adapter_ready=(p("mcp_surface", r"MCP|mcp|tool", "MCP/tool surface exists"),),
+        priority=7,
+    ),
+    SurfaceRule(
+        surface_id="nats_jetstream_transport",
+        label="NATS/JetStream event transport",
+        category="event",
+        path_patterns=("dharma_swarm/nats*.py", "dharma_swarm/**/nats*.py"),
+        joined=(
+            p("nats_client", r"\bnats\b|JetStream", "NATS/JetStream client code exists"),
+            p("identity_import", r"ExecutionIdentity", "NATS events carry execution identity"),
+            p("begin_idempotent", r"try_begin_idempotent_side_effect", "NATS receiver is idempotency-gated"),
+            p("ack_contract", r"\back\b|\bnack\b", "ack/nack contract is visible"),
+        ),
+        adapter_ready=(p("nats_name_seen", r"NATS|JetStream|nats", "NATS terms are present"),),
+        priority=8,
+    ),
+    SurfaceRule(
+        surface_id="opportunity_refill_research_backend",
+        label="Opportunity refill research backend",
+        category="quarantine",
+        path_patterns=("dharma_swarm/opportunity_refill.py",),
+        joined=(
+            p("identity_import", r"ExecutionIdentity", "opportunity refill carries execution identity"),
+            p("runtime_store", r"RuntimeStateStore", "opportunity refill writes to runtime ledger"),
+        ),
+        adapter_ready=(p("stage_results", r"StageResult", "stage-result surface exists"),),
+        quarantine=(
+            p("quarantine_marker", r"QUARANTINE_MARKER|quarantined", "surface has explicit quarantine mode"),
+            p("backend_quarantine", r"DHARMA_RESEARCH_BACKEND=quarantine", "backend can be forced into quarantine"),
+        ),
+        priority=9,
+    ),
+    SurfaceRule(
+        surface_id="legacy_no_identity_escape_hatch",
+        label="Legacy no-identity escape hatch",
+        category="legacy",
+        path_patterns=("dharma_swarm/runtime_state.py", "tests/test_runtime_state_invariants.py"),
+        joined=(),
+        adapter_ready=(),
+        legacy=(
+            p("legacy_flag", r"legacy_no_identity_allowed", "legacy bypass must stay explicit"),
+            p("legacy_tests", r"fail_closed_without_identity_unless_flagged", "legacy bypass has invariant coverage"),
+        ),
+        priority=10,
+    ),
+)
+
+
+def repo_root_from(path: Path | None = None) -> Path:
+    root = path or Path.cwd()
+    return root.resolve()
+
+
+def git_tracked_files(repo_root: Path) -> list[str]:
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "ls-files"],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return sorted(line.strip() for line in result.stdout.splitlines() if line.strip())
+
+
+def git_head(repo_root: Path) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "rev-parse", "HEAD"],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return result.stdout.strip()
+
+
+def git_status_porcelain(repo_root: Path) -> list[str]:
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "status", "--porcelain", "--untracked-files=all"],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return [line for line in result.stdout.splitlines() if line.strip()]
+
+
+def load_tracked_sources(repo_root: Path, tracked_files: Iterable[str]) -> dict[str, list[str]]:
+    sources: dict[str, list[str]] = {}
+    for rel_path in tracked_files:
+        path = repo_root / rel_path
+        if path.suffix not in {".py", ".json", ".yaml", ".yml", ".toml", ".md"}:
+            continue
+        try:
+            sources[rel_path] = path.read_text(encoding="utf-8").splitlines()
+        except UnicodeDecodeError:
+            continue
+    return sources
+
+
+def _matches_path(rel_path: str, patterns: tuple[str, ...]) -> bool:
+    return any(fnmatch.fnmatch(rel_path, pattern) for pattern in patterns)
+
+
+def _scan_pattern(pattern: PatternSpec, source_map: dict[str, list[str]], paths: list[str]) -> dict[str, Any]:
+    compiled = re.compile(pattern.regex)
+    hits: list[dict[str, Any]] = []
+    for rel_path in paths:
+        for line_number, line in enumerate(source_map.get(rel_path, []), start=1):
+            if compiled.search(line):
+                hits.append(
+                    {
+                        "path": rel_path,
+                        "line": line_number,
+                        "text": line.strip()[:220],
+                    }
+                )
+                break
+    return {
+        "key": pattern.key,
+        "description": pattern.description,
+        "regex": pattern.regex,
+        "matched": bool(hits),
+        "hits": hits,
+    }
+
+
+def _scan_patterns(
+    patterns: tuple[PatternSpec, ...],
+    source_map: dict[str, list[str]],
+    paths: list[str],
+) -> list[dict[str, Any]]:
+    return [_scan_pattern(pattern, source_map, paths) for pattern in patterns]
+
+
+def _all_matched(results: list[dict[str, Any]]) -> bool:
+    return bool(results) and all(bool(result["matched"]) for result in results)
+
+
+def _any_matched(results: list[dict[str, Any]]) -> bool:
+    return any(bool(result["matched"]) for result in results)
+
+
+def classify_surface(rule: SurfaceRule, source_map: dict[str, list[str]]) -> dict[str, Any]:
+    paths = sorted(rel_path for rel_path in source_map if _matches_path(rel_path, rule.path_patterns))
+    joined = _scan_patterns(rule.joined, source_map, paths)
+    adapter_ready = _scan_patterns(rule.adapter_ready, source_map, paths)
+    quarantine = _scan_patterns(rule.quarantine, source_map, paths)
+    legacy = _scan_patterns(rule.legacy, source_map, paths)
+
+    if not paths:
+        status = "missing"
+    elif _all_matched(joined):
+        status = "joined"
+    elif _any_matched(quarantine):
+        status = "quarantine"
+    elif _any_matched(legacy):
+        status = "legacy"
+    elif _all_matched(adapter_ready):
+        status = "adapter-ready"
+    else:
+        status = "missing"
+
+    missing_joined = [
+        {
+            "key": result["key"],
+            "description": result["description"],
+            "regex": result["regex"],
+        }
+        for result in joined
+        if not result["matched"]
+    ]
+    return {
+        "id": rule.surface_id,
+        "label": rule.label,
+        "category": rule.category,
+        "status": status,
+        "priority": rule.priority,
+        "path_patterns": list(rule.path_patterns),
+        "files": paths,
+        "joined_evidence": joined,
+        "adapter_ready_evidence": adapter_ready,
+        "quarantine_evidence": quarantine,
+        "legacy_evidence": legacy,
+        "missing_joined_patterns": missing_joined,
+    }
+
+
+def summarize_surfaces(surfaces: list[dict[str, Any]]) -> dict[str, Any]:
+    counts = {status: 0 for status in VALID_STATUSES}
+    for surface in surfaces:
+        counts[surface["status"]] += 1
+    total = len(surfaces)
+    joined = counts["joined"]
+    adapter_ready = counts["adapter-ready"]
+    joined_or_adapter_ready = joined + adapter_ready
+    return {
+        "total_surfaces": total,
+        "status_counts": counts,
+        "joined_count": joined,
+        "adapter_ready_count": adapter_ready,
+        "joined_or_adapter_ready_count": joined_or_adapter_ready,
+        "joined_percent": round((joined / total) * 100, 1) if total else 0.0,
+        "joined_or_adapter_ready_percent": round((joined_or_adapter_ready / total) * 100, 1) if total else 0.0,
+        "adoption_pct": round((joined_or_adapter_ready / total) * 100, 1) if total else 0.0,
+        "missing_count": counts["missing"],
+        "quarantine_count": counts["quarantine"],
+        "legacy_count": counts["legacy"],
+        "non_joined_surface_ids": [surface["id"] for surface in surfaces if surface["status"] != "joined"],
+    }
+
+
+def top_saturation_targets(surfaces: list[dict[str, Any]], *, limit: int = 5) -> list[dict[str, Any]]:
+    status_rank = {
+        "missing": 0,
+        "adapter-ready": 1,
+        "legacy": 2,
+        "quarantine": 3,
+        "joined": 9,
+    }
+    targets = sorted(
+        (surface for surface in surfaces if surface["status"] != "joined"),
+        key=lambda surface: (status_rank[surface["status"]], surface["priority"], surface["id"]),
+    )
+    return [
+        {
+            "id": surface["id"],
+            "label": surface["label"],
+            "category": surface["category"],
+            "status": surface["status"],
+            "missing_joined_patterns": surface["missing_joined_patterns"],
+            "files": surface["files"],
+        }
+        for surface in targets[:limit]
+    ]
+
+
+def generate_report(repo_root: Path | None = None) -> dict[str, Any]:
+    root = repo_root_from(repo_root)
+    tracked_files = git_tracked_files(root)
+    status_entries = git_status_porcelain(root)
+    source_map = load_tracked_sources(root, tracked_files)
+    surfaces = [classify_surface(rule, source_map) for rule in SURFACE_RULES]
+    summary = summarize_surfaces(surfaces)
+    missing_doc_anchors = [path for path in DOC_ANCHORS if path not in tracked_files]
+    return {
+        "metric": "spine_adoption_metric",
+        "audit_sha": git_head(root),
+        "source_status": "clean" if not status_entries else "dirty",
+        "source_status_entries": status_entries,
+        "tracked_file_count": len(tracked_files),
+        "classification_vocabulary": list(VALID_STATUSES),
+        "classification_rule": (
+            "joined requires all joined evidence patterns; adapter-ready requires all adapter evidence patterns "
+            "when joined is incomplete; quarantine and legacy require explicit source markers; missing means "
+            "no tracked surface or insufficient evidence."
+        ),
+        "doc_anchor_status": "ok" if not missing_doc_anchors else "missing",
+        "missing_doc_anchors": missing_doc_anchors,
+        "summary": summary,
+        "top_saturation_targets": top_saturation_targets(surfaces),
+        "surfaces": surfaces,
+    }
+
+
+def write_report(report: dict[str, Any], output: Path, repo_root: Path) -> None:
+    path = output if output.is_absolute() else repo_root / output
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Measure Runtime Truth Spine adoption from tracked source files.")
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help=f"Write the report JSON to this path. Omit for read-only checks. Default report path: {DEFAULT_OUTPUT}",
+    )
+    parser.add_argument("--print", action="store_true", dest="print_json", help="Print the report JSON to stdout.")
+    parser.add_argument("--require-clean-source", action="store_true", help="Exit before writing when git status is dirty.")
+    parser.add_argument(
+        "--fail-below-adoption",
+        type=float,
+        default=None,
+        help="Exit non-zero when joined-or-adapter-ready adoption is below this percentage.",
+    )
+    parser.add_argument("--fail-on-doc-drift", action="store_true", help="Exit non-zero when tracked doc anchors are missing.")
+    parser.add_argument(
+        "--fail-on",
+        choices=VALID_STATUSES,
+        action="append",
+        default=[],
+        help="Exit non-zero if any surface has this status. May be provided more than once.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    repo_root = repo_root_from(args.repo_root)
+    if args.require_clean_source:
+        status_entries = git_status_porcelain(repo_root)
+        if status_entries:
+            print("spine_adoption_metric: source tree is not clean", file=sys.stderr)
+            for entry in status_entries:
+                print(entry, file=sys.stderr)
+            return 1
+    report = generate_report(repo_root)
+    if args.output is not None:
+        write_report(report, args.output, repo_root)
+    if args.print_json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    blocked = sorted(set(args.fail_on) & set(report["summary"]["status_counts"]))
+    for status in blocked:
+        if report["summary"]["status_counts"][status] > 0:
+            return 1
+    if args.fail_below_adoption is not None and report["summary"]["adoption_pct"] < args.fail_below_adoption:
+        return 1
+    if args.fail_on_doc_drift and report["doc_anchor_status"] != "ok":
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Adds deterministic Runtime Truth Spine adoption metric over 16 tracked surfaces.
- Writes generated report at reports/governance/spine_adoption_metric.json and adds dharma_swarm/a2a/README.md as the A2A doc anchor.
- Keeps metric checks read-only by default; report writes require explicit --output.
- Refreshes generated DocOps counts only; no operator-owned spec/doctrine files changed.

## Coherence Delta
- Organ touched: Runtime Truth Spine adoption measurement / governance reporting surface.
- Declared-vs-actual gap closed: the plan declared adoption_pct as an external metric; this PR makes it deterministic, source-scanned, and falsifiable instead of self-graded.
- Proof that re-reads the map: tools/spine_adoption_metric.py scans tracked files and reports 16 surfaces with joined / adapter-ready / missing / quarantine / legacy status; tests/test_spine_adoption_metric.py falsifies missing evidence and CLI write behavior.
- New drift introduced: generated DocOps counts and one A2A doc anchor; no operator-owned specs changed. The metric truthfully reports remaining drift at 75.0%, including NATS missing and tollbooth/self-mod/MCP surfaces not fully joined.

## Metric
- adoption_pct: 75.0
- joined: 8
- adapter-ready: 4
- legacy: 2
- quarantine: 1
- missing: 1
- top targets: nats_jetstream_transport, ontology_action_tollbooth, tool_registry_dispatch, self_modification_loop, mcp_tool_access

## Verification
- pytest -q tests/test_runtime_state_invariants.py tests/test_runtime_truth_spine_adoption.py tests/test_spine_mapping_receipts.py tests/test_spine_adoption_metric.py tests/test_runtime_truth_spine_v2_evidence.py tests/test_active_track_governance.py -> 38 passed, 1 warning
- python tools/spine_adoption_metric.py --require-clean-source --fail-below-adoption 50 -> exit 0
- python tools/spine_adoption_metric.py --require-clean-source --fail-below-adoption 95 -> exit 1 expected; adoption is truthfully 75.0, not fake-green
- python scripts/docops/check_docops_integrity.py --write-auto-sections -> passed
- git diff --check -> exit 0

## Notes
- This is Slice 1 only: metric/gate/report. It does not implement C2, workflow unification, NATS, or broad tollbooth rewrites.
- Remaining queued slices: RuntimeStateStore recovery authority, then tollbooth side-effect gateway.