### PR TITLE
spine(slice-2): harden runtime idempotency recovery

### DIFF
--- a/dharma_swarm/message_bus.py
+++ b/dharma_swarm/message_bus.py
@@ -98,6 +98,12 @@ def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+def _stable_operation_hash(payload: dict[str, Any]) -> str:
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, default=str).encode("utf-8")
+    ).hexdigest()
+
+
 def _row_to_message(row: aiosqlite.Row) -> Message:
     """Convert a database row into a Message model."""
     return Message(
@@ -241,7 +247,20 @@ class MessageBus:
                 should_execute = await self._runtime_state.try_begin_idempotent_side_effect(
                     identity,
                     side_effect_key,
-                    metadata={"message_id": message.id, "to_agent": message.to_agent},
+                    metadata={
+                        "message_id": message.id,
+                        "to_agent": message.to_agent,
+                        "operation_hash": _stable_operation_hash(
+                            {
+                                "from_agent": message.from_agent,
+                                "to_agent": message.to_agent,
+                                "subject": message.subject,
+                                "body": message.body,
+                                "priority": message.priority.value,
+                                "reply_to": message.reply_to,
+                            }
+                        ),
+                    },
                 )
                 if not should_execute:
                     record = await self._runtime_state.get_idempotency_record(
@@ -713,18 +732,14 @@ class MessageBus:
                 side_effect_key,
                 metadata={
                     "event_type": event_type,
-                    "operation_hash": hashlib.sha256(
-                        json.dumps(
-                            {
-                                "event_type": event_type,
-                                "task_id": task_id,
-                                "agent_id": agent_id,
-                                "payload": event_payload,
-                            },
-                            sort_keys=True,
-                            default=str,
-                        ).encode("utf-8")
-                    ).hexdigest(),
+                    "operation_hash": _stable_operation_hash(
+                        {
+                            "event_type": event_type,
+                            "task_id": task_id,
+                            "agent_id": agent_id,
+                            "payload": event_payload,
+                        }
+                    ),
                 },
             )
             if not should_execute:

--- a/dharma_swarm/runtime_state.py
+++ b/dharma_swarm/runtime_state.py
@@ -864,6 +864,19 @@ def _row_to_idempotency_record(row: sqlite3.Row | aiosqlite.Row) -> IdempotencyR
     )
 
 
+def _operation_hash(metadata: dict[str, Any] | None) -> str:
+    return str((metadata or {}).get("operation_hash") or "")
+
+
+def _merge_idempotency_metadata(
+    existing: IdempotencyRecord,
+    metadata: dict[str, Any] | None,
+) -> dict[str, Any]:
+    merged = dict(existing.metadata)
+    merged.update(metadata or {})
+    return merged
+
+
 def _identity_from_metadata(metadata: dict[str, Any] | None) -> ExecutionIdentity | None:
     return ExecutionIdentity.from_metadata(metadata, require=False)
 
@@ -2994,12 +3007,176 @@ class RuntimeStateStore:
             rows = await (await db.execute(query, params)).fetchall()
         return [_row_to_runtime_receipt(row) for row in rows]
 
+    async def _mark_idempotency_record_stale(
+        self,
+        existing: IdempotencyRecord,
+        *,
+        metadata: dict[str, Any] | None = None,
+    ) -> IdempotencyRecord:
+        now = _utc_now_iso()
+        merged_metadata = _merge_idempotency_metadata(
+            existing,
+            {
+                **dict(metadata or {}),
+                "stale_quarantined_at": now,
+                "previous_status": existing.status,
+            },
+        )
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute(
+                "UPDATE idempotency_records SET status = 'stale',"
+                " metadata_json = ?, updated_at = ?"
+                " WHERE idempotency_key = ? AND side_effect_key = ?",
+                (
+                    _json_dump(merged_metadata),
+                    now,
+                    existing.idempotency_key,
+                    existing.side_effect_key,
+                ),
+            )
+            await db.commit()
+        record = await self.get_idempotency_record(existing.idempotency_key, existing.side_effect_key)
+        if record is None:
+            raise KeyError(f"idempotency record {existing.idempotency_key}:{existing.side_effect_key} not found")
+        return record
+
+    def _mark_idempotency_record_stale_sync(
+        self,
+        existing: IdempotencyRecord,
+        *,
+        metadata: dict[str, Any] | None = None,
+    ) -> IdempotencyRecord:
+        now = _utc_now_iso()
+        merged_metadata = _merge_idempotency_metadata(
+            existing,
+            {
+                **dict(metadata or {}),
+                "stale_quarantined_at": now,
+                "previous_status": existing.status,
+            },
+        )
+        with sqlite3.connect(self.db_path) as db:
+            _apply_connection_pragmas_sync(db)
+            db.execute(
+                "UPDATE idempotency_records SET status = 'stale',"
+                " metadata_json = ?, updated_at = ?"
+                " WHERE idempotency_key = ? AND side_effect_key = ?",
+                (
+                    _json_dump(merged_metadata),
+                    now,
+                    existing.idempotency_key,
+                    existing.side_effect_key,
+                ),
+            )
+            db.commit()
+        record = self.get_idempotency_record_sync(existing.idempotency_key, existing.side_effect_key)
+        if record is None:
+            raise KeyError(f"idempotency record {existing.idempotency_key}:{existing.side_effect_key} not found")
+        return record
+
+    async def _handle_existing_idempotency_record(
+        self,
+        identity: ExecutionIdentity,
+        existing: IdempotencyRecord,
+        *,
+        metadata: dict[str, Any] | None,
+        stale_after_seconds: float | None,
+    ) -> None:
+        existing_hash = _operation_hash(existing.metadata)
+        incoming_hash = _operation_hash(metadata)
+        if existing_hash and incoming_hash and existing_hash != incoming_hash:
+            await self.record_idempotency_consumed(
+                identity,
+                existing.side_effect_key,
+                status="conflict",
+                payload={
+                    **dict(metadata or {}),
+                    "existing_operation_hash": existing_hash,
+                    "operation_hash": incoming_hash,
+                },
+            )
+            raise ValueError(
+                "idempotency operation_hash conflict for "
+                f"{existing.idempotency_key}:{existing.side_effect_key}"
+            )
+        if (
+            existing.status == "started"
+            and stale_after_seconds is not None
+            and (_utc_now() - existing.updated_at).total_seconds() >= stale_after_seconds
+        ):
+            await self._mark_idempotency_record_stale(existing, metadata=metadata)
+            await self.record_idempotency_consumed(
+                identity,
+                existing.side_effect_key,
+                status="stale",
+                payload={
+                    **dict(metadata or {}),
+                    "stale_after_seconds": stale_after_seconds,
+                },
+            )
+            return
+        await self.record_idempotency_consumed(
+            identity,
+            existing.side_effect_key,
+            status="duplicate",
+            payload=metadata,
+        )
+
+    def _handle_existing_idempotency_record_sync(
+        self,
+        identity: ExecutionIdentity,
+        existing: IdempotencyRecord,
+        *,
+        metadata: dict[str, Any] | None,
+        stale_after_seconds: float | None,
+    ) -> None:
+        existing_hash = _operation_hash(existing.metadata)
+        incoming_hash = _operation_hash(metadata)
+        if existing_hash and incoming_hash and existing_hash != incoming_hash:
+            self.record_idempotency_consumed_sync(
+                identity,
+                existing.side_effect_key,
+                status="conflict",
+                payload={
+                    **dict(metadata or {}),
+                    "existing_operation_hash": existing_hash,
+                    "operation_hash": incoming_hash,
+                },
+            )
+            raise ValueError(
+                "idempotency operation_hash conflict for "
+                f"{existing.idempotency_key}:{existing.side_effect_key}"
+            )
+        if (
+            existing.status == "started"
+            and stale_after_seconds is not None
+            and (_utc_now() - existing.updated_at).total_seconds() >= stale_after_seconds
+        ):
+            self._mark_idempotency_record_stale_sync(existing, metadata=metadata)
+            self.record_idempotency_consumed_sync(
+                identity,
+                existing.side_effect_key,
+                status="stale",
+                payload={
+                    **dict(metadata or {}),
+                    "stale_after_seconds": stale_after_seconds,
+                },
+            )
+            return
+        self.record_idempotency_consumed_sync(
+            identity,
+            existing.side_effect_key,
+            status="duplicate",
+            payload=metadata,
+        )
+
     async def try_begin_idempotent_side_effect(
         self,
         identity: ExecutionIdentity,
         side_effect_key: str,
         *,
         metadata: dict[str, Any] | None = None,
+        stale_after_seconds: float | None = None,
     ) -> bool:
         identity.require_for_dispatch()
         if not side_effect_key:
@@ -3026,10 +3203,21 @@ class RuntimeStateStore:
             )
             await db.commit()
             inserted = int(cur.rowcount or 0) == 1
+        if not inserted:
+            existing = await self.get_idempotency_record(identity.idempotency_key, side_effect_key)
+            if existing is None:
+                raise KeyError(f"idempotency record {identity.idempotency_key}:{side_effect_key} not found")
+            await self._handle_existing_idempotency_record(
+                identity,
+                existing,
+                metadata=metadata,
+                stale_after_seconds=stale_after_seconds,
+            )
+            return False
         await self.record_idempotency_consumed(
             identity,
             side_effect_key,
-            status="accepted" if inserted else "duplicate",
+            status="accepted",
             payload=metadata,
         )
         if inserted:
@@ -3046,6 +3234,7 @@ class RuntimeStateStore:
         side_effect_key: str,
         *,
         metadata: dict[str, Any] | None = None,
+        stale_after_seconds: float | None = None,
     ) -> bool:
         identity.require_for_dispatch()
         if not side_effect_key:
@@ -3073,10 +3262,21 @@ class RuntimeStateStore:
             )
             db.commit()
             inserted = int(cur.rowcount or 0) == 1
+        if not inserted:
+            existing = self.get_idempotency_record_sync(identity.idempotency_key, side_effect_key)
+            if existing is None:
+                raise KeyError(f"idempotency record {identity.idempotency_key}:{side_effect_key} not found")
+            self._handle_existing_idempotency_record_sync(
+                identity,
+                existing,
+                metadata=metadata,
+                stale_after_seconds=stale_after_seconds,
+            )
+            return False
         self.record_idempotency_consumed_sync(
             identity,
             side_effect_key,
-            status="accepted" if inserted else "duplicate",
+            status="accepted",
             payload=metadata,
         )
         if inserted:
@@ -3099,6 +3299,10 @@ class RuntimeStateStore:
         identity.require_for_dispatch()
         await self.init_db()
         now = _utc_now_iso()
+        existing = await self.get_idempotency_record(identity.idempotency_key, side_effect_key)
+        if existing is None:
+            raise KeyError(f"idempotency record {identity.idempotency_key}:{side_effect_key} not found")
+        merged_metadata = _merge_idempotency_metadata(existing, metadata)
         async with aiosqlite.connect(self.db_path) as db:
             await db.execute(
                 "UPDATE idempotency_records SET status = ?, result_receipt_id = ?,"
@@ -3107,7 +3311,7 @@ class RuntimeStateStore:
                 (
                     status,
                     result_receipt_id,
-                    _json_dump(metadata or {}),
+                    _json_dump(merged_metadata),
                     now,
                     identity.idempotency_key,
                     side_effect_key,
@@ -3115,14 +3319,12 @@ class RuntimeStateStore:
             )
             await db.commit()
         record = await self.get_idempotency_record(identity.idempotency_key, side_effect_key)
-        if record is None:
-            raise KeyError(f"idempotency record {identity.idempotency_key}:{side_effect_key} not found")
         await self.record_side_effect_complete(
             identity,
             side_effect_key,
             status=status,
             result_receipt_id=result_receipt_id,
-            payload=metadata,
+            payload=merged_metadata,
         )
         return record
 
@@ -3138,6 +3340,10 @@ class RuntimeStateStore:
         identity.require_for_dispatch()
         self.init_db_sync()
         now = _utc_now_iso()
+        existing = self.get_idempotency_record_sync(identity.idempotency_key, side_effect_key)
+        if existing is None:
+            raise KeyError(f"idempotency record {identity.idempotency_key}:{side_effect_key} not found")
+        merged_metadata = _merge_idempotency_metadata(existing, metadata)
         with sqlite3.connect(self.db_path) as db:
             _apply_connection_pragmas_sync(db)
             db.execute(
@@ -3147,7 +3353,7 @@ class RuntimeStateStore:
                 (
                     status,
                     result_receipt_id,
-                    _json_dump(metadata or {}),
+                    _json_dump(merged_metadata),
                     now,
                     identity.idempotency_key,
                     side_effect_key,
@@ -3155,14 +3361,12 @@ class RuntimeStateStore:
             )
             db.commit()
         record = self.get_idempotency_record_sync(identity.idempotency_key, side_effect_key)
-        if record is None:
-            raise KeyError(f"idempotency record {identity.idempotency_key}:{side_effect_key} not found")
         self.record_side_effect_complete_sync(
             identity,
             side_effect_key,
             status=status,
             result_receipt_id=result_receipt_id,
-            payload=metadata,
+            payload=merged_metadata,
         )
         return record
 
@@ -3235,21 +3439,20 @@ class RuntimeStateStore:
         mappings = await self.list_mapping_receipts(run_id=run_id, limit=200)
         children = await self.list_child_runs(run_id)
         idempotency_records: list[IdempotencyRecord] = []
-        if identity is not None:
-            await self.init_db()
-            async with aiosqlite.connect(self.db_path) as db:
-                db.row_factory = aiosqlite.Row
-                rows = await (
-                    await db.execute(
-                        "SELECT idempotency_key, side_effect_key, run_id, task_id,"
-                        " trace_id, correlation_id, status, result_receipt_id,"
-                        " metadata_json, created_at, updated_at"
-                        " FROM idempotency_records WHERE idempotency_key = ?"
-                        " ORDER BY created_at ASC",
-                        (identity.idempotency_key,),
-                    )
-                ).fetchall()
-            idempotency_records = [_row_to_idempotency_record(row) for row in rows]
+        await self.init_db()
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            rows = await (
+                await db.execute(
+                    "SELECT idempotency_key, side_effect_key, run_id, task_id,"
+                    " trace_id, correlation_id, status, result_receipt_id,"
+                    " metadata_json, created_at, updated_at"
+                    " FROM idempotency_records WHERE run_id = ?"
+                    " ORDER BY created_at ASC",
+                    (run_id,),
+                )
+            ).fetchall()
+        idempotency_records = [_row_to_idempotency_record(row) for row in rows]
         return {
             "identity": identity,
             "run": run,

--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -8,9 +8,9 @@ Do not hand-edit the generated block.
 |---|---:|
 | Dharma Python modules | 661 |
 | Top-level Dharma Python modules | 389 |
-| Dharma Python LOC | 280,829 |
-| Test files | 620 |
-| Test function occurrences | 10,748 |
+| Dharma Python LOC | 281,047 |
+| Test files | 621 |
+| Test function occurrences | 10,752 |
 | Markdown files | 763 |
 | Markdown total lines | 191,506 |
 | Bridge files | 24 |

--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -12,7 +12,7 @@ Do not hand-edit the generated block.
 | Test files | 621 |
 | Test function occurrences | 10,752 |
 | Markdown files | 763 |
-| Markdown total lines | 191,506 |
+| Markdown total lines | 191,507 |
 | Bridge files | 24 |
 | Adapter files | 21 |
 | Orchestrator files | 4 |

--- a/docs/governance/SOVEREIGN_MANIFEST.md
+++ b/docs/governance/SOVEREIGN_MANIFEST.md
@@ -127,9 +127,9 @@ These are the ground-truth metrics. All other documents citing different numbers
 |--------|-------|-------------|
 | Total Python modules | **661** | find dharma_swarm -name "*.py" -type f |
 | Top-level (flat) modules | **389 (59.0%)** | find dharma_swarm -maxdepth 1 -name "*.py" -type f |
-| Total Python LOC | **280,829** | wc -l across dharma_swarm Python modules |
-| Test files | **620** | find tests -name "*.py" -type f |
-| Test functions | **10,748 `def test_` occurrences under tests/** | rg "def test_" tests |
+| Total Python LOC | **281,047** | wc -l across dharma_swarm Python modules |
+| Test files | **621** | find tests -name "*.py" -type f |
+| Test functions | **10,752 `def test_` occurrences under tests/** | rg "def test_" tests |
 | Tests collected (pytest) | **Needs write-permitted refresh** | not run during this DocOps count pass |
 | Collection errors | **Historical: 16 on 2026-04-04** | refresh before relying on this count |
 | Markdown files | **763** | find . -name "*.md" -type f |

--- a/docs/governance/SOVEREIGN_MANIFEST.md
+++ b/docs/governance/SOVEREIGN_MANIFEST.md
@@ -133,7 +133,7 @@ These are the ground-truth metrics. All other documents citing different numbers
 | Tests collected (pytest) | **Needs write-permitted refresh** | not run during this DocOps count pass |
 | Collection errors | **Historical: 16 on 2026-04-04** | refresh before relying on this count |
 | Markdown files | **763** | find . -name "*.md" -type f |
-| Markdown total lines | **191,506** | wc -l across all .md |
+| Markdown total lines | **191,507** | wc -l across all .md |
 | Bridge files | **24** | find dharma_swarm -name "*bridge*.py" |
 | Adapter files | **21 across 8 locations** | find dharma_swarm -type f \| rg -i "adapter" |
 | Orchestrator files | **4** (6,034 LOC total) | find dharma_swarm -name "*orchestrat*" |

--- a/seams/spine-adoption/codex-runlog.md
+++ b/seams/spine-adoption/codex-runlog.md
@@ -1,3 +1,4 @@
 2026-06-01T15:03:46Z | slice-A | PR #430 | Opened Slice A sync legacy ledger bypass PR with identity-before-telic fix and passing v2 baseline.
 2026-06-01T18:40:41Z | slice-B | PR #435 | Opened adapter saturation PR; verification commands are listed in the PR body.
 2026-06-01T18:40:41Z | slice-C | PR #436 | Opened mapping receipt PR; verification commands are listed in the PR body.
+2026-06-01T21:05:26Z | slice-2 | PR #444 | Opened runtime recovery PR with operation-hash conflict checks and stale-started quarantine.

--- a/tests/test_runtime_state_recovery.py
+++ b/tests/test_runtime_state_recovery.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from dharma_swarm.message_bus import MessageBus
+from dharma_swarm.models import Message
+from dharma_swarm.runtime_state import RuntimeStateStore
+from dharma_swarm.spine.adapters import identity_metadata
+from dharma_swarm.spine.identity import ExecutionIdentity
+
+
+def _identity(**overrides: str) -> ExecutionIdentity:
+    payload = {
+        "task_id": "task-recovery",
+        "agent_id": "agent-recovery",
+        "session_id": "session-recovery",
+        "trace_id": "trace-recovery",
+        "correlation_id": "corr-recovery",
+        "run_id": "run-recovery",
+        "claim_id": "claim-recovery",
+        "idempotency_key": "idem-recovery",
+    }
+    payload.update(overrides)
+    return ExecutionIdentity.new(**payload)
+
+
+def _message_count(db_path: Path) -> int:
+    with sqlite3.connect(db_path) as db:
+        return int(db.execute("SELECT COUNT(*) FROM messages").fetchone()[0])
+
+
+@pytest.mark.asyncio
+async def test_idempotency_duplicate_same_operation_does_not_repeat_after_completion(tmp_path: Path) -> None:
+    store = RuntimeStateStore(tmp_path / "runtime.db")
+    identity = _identity()
+    side_effect_key = "unit.side_effect:alpha"
+    metadata = {"operation_hash": "hash-alpha", "input": "alpha"}
+
+    assert await store.try_begin_idempotent_side_effect(identity, side_effect_key, metadata=metadata)
+    await store.complete_idempotent_side_effect(
+        identity,
+        side_effect_key,
+        result_receipt_id="result-alpha",
+        metadata={"result": "ok"},
+    )
+
+    assert not await store.try_begin_idempotent_side_effect(identity, side_effect_key, metadata=metadata)
+
+    ledger = await store.get_run_ledger(identity.run_id)
+    intents = [r for r in ledger["receipts"] if r.receipt_type == "side_effect_intent"]
+    duplicates = [r for r in ledger["receipts"] if r.receipt_type == "idempotency_consumed" and r.status == "duplicate"]
+    records = ledger["idempotency_records"]
+
+    assert len(intents) == 1
+    assert len(duplicates) == 1
+    assert records[0].status == "completed"
+    assert records[0].result_receipt_id == "result-alpha"
+    assert records[0].metadata["operation_hash"] == "hash-alpha"
+
+
+@pytest.mark.asyncio
+async def test_idempotency_conflicting_operation_hash_fails_before_second_intent(tmp_path: Path) -> None:
+    store = RuntimeStateStore(tmp_path / "runtime.db")
+    identity = _identity(idempotency_key="idem-conflict")
+    side_effect_key = "unit.side_effect:conflict"
+
+    assert await store.try_begin_idempotent_side_effect(
+        identity,
+        side_effect_key,
+        metadata={"operation_hash": "hash-a"},
+    )
+
+    with pytest.raises(ValueError, match="operation_hash conflict"):
+        await store.try_begin_idempotent_side_effect(
+            identity,
+            side_effect_key,
+            metadata={"operation_hash": "hash-b"},
+        )
+
+    ledger = await store.get_run_ledger(identity.run_id)
+    intents = [r for r in ledger["receipts"] if r.receipt_type == "side_effect_intent"]
+    conflicts = [r for r in ledger["receipts"] if r.receipt_type == "idempotency_consumed" and r.status == "conflict"]
+
+    assert len(intents) == 1
+    assert len(conflicts) == 1
+
+
+@pytest.mark.asyncio
+async def test_idempotency_stale_started_record_is_quarantined_without_repeat(tmp_path: Path) -> None:
+    store = RuntimeStateStore(tmp_path / "runtime.db")
+    identity = _identity(idempotency_key="idem-stale")
+    side_effect_key = "unit.side_effect:stale"
+    metadata = {"operation_hash": "hash-stale"}
+
+    assert await store.try_begin_idempotent_side_effect(identity, side_effect_key, metadata=metadata)
+
+    stale_time = (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat()
+    with sqlite3.connect(tmp_path / "runtime.db") as db:
+        db.execute(
+            "UPDATE idempotency_records SET updated_at = ? WHERE idempotency_key = ? AND side_effect_key = ?",
+            (stale_time, identity.idempotency_key, side_effect_key),
+        )
+        db.commit()
+
+    assert not await store.try_begin_idempotent_side_effect(
+        identity,
+        side_effect_key,
+        metadata=metadata,
+        stale_after_seconds=60,
+    )
+
+    record = await store.get_idempotency_record(identity.idempotency_key, side_effect_key)
+    ledger = await store.get_run_ledger(identity.run_id)
+    intents = [r for r in ledger["receipts"] if r.receipt_type == "side_effect_intent"]
+    stale_receipts = [
+        r for r in ledger["receipts"] if r.receipt_type == "idempotency_consumed" and r.status == "stale"
+    ]
+
+    assert record is not None
+    assert record.status == "stale"
+    assert len(intents) == 1
+    assert len(stale_receipts) == 1
+    assert not await store.was_side_effect_performed(identity.idempotency_key, side_effect_key)
+
+
+@pytest.mark.asyncio
+async def test_message_bus_conflicting_idempotency_key_does_not_insert_second_message(tmp_path: Path) -> None:
+    runtime = RuntimeStateStore(tmp_path / "runtime.db")
+    bus_path = tmp_path / "messages.db"
+    bus = MessageBus(bus_path, runtime_state=runtime, require_identity=True)
+    await bus.init_db()
+
+    identity = _identity(
+        run_id="run-message-conflict",
+        task_id="task-message-conflict",
+        idempotency_key="idem-message-conflict",
+    )
+    metadata = identity_metadata(identity, surface="message_bus")
+
+    first_id = await bus.send(Message(from_agent="alice", to_agent="bob", body="first", metadata=metadata))
+    with pytest.raises(ValueError, match="operation_hash conflict"):
+        await bus.send(Message(from_agent="alice", to_agent="bob", body="different", metadata=metadata))
+
+    assert _message_count(bus_path) == 1
+    assert [message.id for message in await bus.receive("bob")] == [first_id]

--- a/tests/test_runtime_truth_spine_adoption.py
+++ b/tests/test_runtime_truth_spine_adoption.py
@@ -104,7 +104,7 @@ async def test_message_bus_required_identity_dedupes_before_send_side_effect(tmp
     )
     metadata = identity_metadata(identity, surface="message_bus")
     first = Message(from_agent="alice", to_agent="bob", body="first", metadata=metadata)
-    second = Message(from_agent="alice", to_agent="bob", body="second", metadata=metadata)
+    second = Message(from_agent="alice", to_agent="bob", body="first", metadata=metadata)
 
     first_id = await bus.send(first)
     second_id = await bus.send(second)


### PR DESCRIPTION
## Summary
- Hardens RuntimeStateStore idempotency records with operation-hash conflict detection.
- Preserves operation_hash metadata through side-effect completion so completed records can still reject conflicting retries.
- Adds stale-started quarantine for selected idempotency records via stale_after_seconds without repeating the side effect.
- Wires MessageBus send/emit_event to stable operation hashes before SQLite inserts.

## Coherence Delta
- Organ touched: RuntimeStateStore recovery authority and MessageBus idempotent side-effect path.
- Declared-vs-actual gap closed: the spine declared durable idempotency/recovery truth; this PR makes duplicate same-op, duplicate different-op, stale started, and completed side-effect queries deterministic and test-backed.
- Proof that re-reads the map: get_run_ledger(run_id) now returns idempotency records by run_id even when an execution identity row is absent; tests/test_runtime_state_recovery.py proves same-op duplicate, conflicting operation hash, stale quarantine, and MessageBus no-second-insert behavior.
- New drift introduced: no new external system, no NATS/Temporal/Palantir calls, no workflow rewrite. Remaining drift is DLQ/poison-message policy beyond this selected MessageBus path.

## Impact Acknowledgment
- [impact-checked]: hot-path RuntimeStateStore changes were reviewed against staged diff and verified with targeted runtime/message tests.

## Verification
- pytest -q tests/test_runtime_state_recovery.py tests/test_runtime_truth_spine_adoption.py tests/test_runtime_truth_spine_v2_evidence.py -> 15 passed, 1 warning
- pytest -q tests/test_runtime_state_invariants.py tests/test_runtime_truth_spine_adoption.py tests/test_spine_mapping_receipts.py tests/test_runtime_state_recovery.py tests/test_runtime_truth_spine_v2_evidence.py -> 23 passed, 1 warning
- python scripts/docops/check_docops_integrity.py --write-auto-sections -> passed
- git diff --check -> exit 0
- pre-commit hooks passed with DHARMA_UPLIFT_ACK=impact-checked for runtime_state.py hot-path edit

## Notes
- This is Slice 2 only: recovery/idempotency hardening. It does not implement C2, NATS, workflow unification, or broad tollbooth rewrites.
- GitNexus MCP was unavailable for this temp worktree; impact check used staged diff plus targeted runtime/message tests.