### PR TITLE
spine(slice-3): add side-effect tollbooth receipts

### DIFF
--- a/dharma_swarm/diff_applier.py
+++ b/dharma_swarm/diff_applier.py
@@ -16,6 +16,10 @@ from pathlib import Path
 
 from pydantic import BaseModel
 
+from dharma_swarm.runtime_state import RuntimeStateStore
+from dharma_swarm.spine.identity import ExecutionIdentity, MissingExecutionIdentity
+from dharma_swarm.spine.tollbooth import require_execution_tollbooth
+
 logger = logging.getLogger(__name__)
 
 
@@ -176,13 +180,27 @@ class DiffApplier:
             Defaults to the current working directory.
     """
 
-    def __init__(self, workspace: Path | None = None) -> None:
+    def __init__(
+        self,
+        workspace: Path | None = None,
+        *,
+        runtime_state: RuntimeStateStore | None = None,
+        require_identity: bool = False,
+    ) -> None:
         self.workspace = (workspace or Path.cwd()).resolve()
+        self._runtime_state = runtime_state
+        self._require_identity = require_identity
 
     # -- public API ---------------------------------------------------------
 
     async def apply(
-        self, diff_text: str, dry_run: bool = False
+        self,
+        diff_text: str,
+        dry_run: bool = False,
+        *,
+        execution_identity: ExecutionIdentity | None = None,
+        require_identity: bool | None = None,
+        proposal_id: str = "",
     ) -> ApplyResult:
         """Parse and apply a unified diff.
 
@@ -212,6 +230,36 @@ class DiffApplier:
         if not patches:
             return ApplyResult(success=True)
 
+        effective_require = self._require_identity if require_identity is None else require_identity
+        identity: ExecutionIdentity | None = None
+        if not dry_run:
+            try:
+                identity = require_execution_tollbooth(
+                    execution_identity=execution_identity,
+                    runtime_state=self._runtime_state,
+                    surface="diff_applier",
+                    action="apply",
+                    require_identity=effective_require,
+                )
+            except MissingExecutionIdentity as exc:
+                return ApplyResult(success=False, error=str(exc))
+            if identity is not None and self._runtime_state is not None:
+                self._runtime_state.record_execution_identity_sync(
+                    identity,
+                    source="diff_applier.apply",
+                    metadata={"surface": "self_modification"},
+                )
+                self._runtime_state.record_self_mod_receipt_sync(
+                    identity,
+                    stage="apply",
+                    status="requested",
+                    proposal_id=proposal_id or identity.proposal_id,
+                    payload={
+                        "files": [patch.target_path for patch in patches],
+                        "dry_run": dry_run,
+                    },
+                )
+
         files_changed: list[str] = []
         backup_paths: dict[str, str] = {}
 
@@ -220,6 +268,14 @@ class DiffApplier:
 
             # Validate: if not a new file, the target must exist
             if not patch.is_new_file and not target.exists():
+                if identity is not None and self._runtime_state is not None:
+                    self._runtime_state.record_self_mod_receipt_sync(
+                        identity,
+                        stage="apply",
+                        status="failed",
+                        proposal_id=proposal_id or identity.proposal_id,
+                        payload={"file": patch.target_path, "error": "target_missing"},
+                    )
                 return ApplyResult(
                     success=False,
                     error=f"Target file does not exist: {patch.target_path}",
@@ -241,6 +297,14 @@ class DiffApplier:
             try:
                 self._apply_patch(target, patch)
             except Exception as exc:
+                if identity is not None and self._runtime_state is not None:
+                    self._runtime_state.record_self_mod_receipt_sync(
+                        identity,
+                        stage="apply",
+                        status="failed",
+                        proposal_id=proposal_id or identity.proposal_id,
+                        payload={"file": patch.target_path, "error": type(exc).__name__},
+                    )
                 return ApplyResult(
                     success=False,
                     error=f"Failed applying patch to {patch.target_path}: {exc}",
@@ -250,6 +314,14 @@ class DiffApplier:
 
             files_changed.append(patch.target_path)
 
+        if identity is not None and self._runtime_state is not None:
+            self._runtime_state.record_self_mod_receipt_sync(
+                identity,
+                stage="apply",
+                status="applied",
+                proposal_id=proposal_id or identity.proposal_id,
+                payload={"files": files_changed},
+            )
         return ApplyResult(
             success=True,
             files_changed=files_changed,

--- a/dharma_swarm/ontology.py
+++ b/dharma_swarm/ontology.py
@@ -39,6 +39,9 @@ from typing import Any, Callable
 
 from pydantic import BaseModel, Field
 
+from dharma_swarm.spine.identity import ExecutionIdentity, MissingExecutionIdentity
+from dharma_swarm.spine.tollbooth import require_execution_tollbooth
+
 logger = logging.getLogger(__name__)
 
 _API_NAME_PATTERN = re.compile(r"^dharma\.([a-z][a-z0-9_]*)\.([A-Z][A-Za-z0-9]*)$")
@@ -768,6 +771,9 @@ class OntologyRegistry:
         params: dict[str, Any],
         executed_by: str = "system",
         gate_check: Callable[[str, dict[str, Any]], dict[str, str]] | None = None,
+        execution_identity: ExecutionIdentity | None = None,
+        runtime_state: Any | None = None,
+        require_identity: bool = False,
     ) -> ActionExecution:
         """Execute a typed action with telos gate checking.
 
@@ -794,6 +800,34 @@ class OntologyRegistry:
             execution.error = f"no action '{action_name}' for type '{object_type}'"
             self._action_log.append(execution)
             return execution
+
+        try:
+            identity = require_execution_tollbooth(
+                execution_identity=execution_identity,
+                runtime_state=runtime_state,
+                surface="ontology",
+                action=action_name,
+                require_identity=require_identity,
+            )
+        except MissingExecutionIdentity as exc:
+            execution.result = "blocked"
+            execution.error = str(exc)
+            self._action_log.append(execution)
+            return execution
+        if identity is not None and runtime_state is not None:
+            runtime_state.record_ontology_action_receipt_sync(
+                identity,
+                action_name=action_name,
+                object_type=object_type,
+                object_id=object_id,
+                applied=False,
+                status="requested",
+                payload={
+                    "modifies": list(action_def.modifies),
+                    "creates": list(action_def.creates),
+                    "requires_approval": action_def.requires_approval,
+                },
+            )
 
         # Telos gate check
         if action_def.telos_gates:
@@ -870,6 +904,20 @@ class OntologyRegistry:
             return execution
 
         execution.result = "success"
+        if identity is not None and runtime_state is not None:
+            runtime_state.record_ontology_action_receipt_sync(
+                identity,
+                action_name=action_name,
+                object_type=object_type,
+                object_id=object_id,
+                applied=True,
+                status="applied",
+                payload={
+                    "modifies": list(action_def.modifies),
+                    "creates": list(action_def.creates),
+                    "requires_approval": action_def.requires_approval,
+                },
+            )
         self._action_log.append(execution)
         return execution
 

--- a/dharma_swarm/spine/tollbooth.py
+++ b/dharma_swarm/spine/tollbooth.py
@@ -1,0 +1,36 @@
+"""Deterministic side-effect tollbooth helpers for runtime-spine adoption.
+
+The tollbooth is intentionally small: it validates that a side-effecting
+surface has a canonical ExecutionIdentity and, in required mode, a
+RuntimeStateStore capable of recording durable receipts.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from dharma_swarm.spine.identity import ExecutionIdentity, MissingExecutionIdentity
+
+
+def require_execution_tollbooth(
+    *,
+    execution_identity: ExecutionIdentity | None,
+    runtime_state: Any | None,
+    surface: str,
+    action: str,
+    require_identity: bool = False,
+) -> ExecutionIdentity | None:
+    """Return a dispatch-ready identity or fail closed in required mode."""
+    if execution_identity is None:
+        if require_identity:
+            raise MissingExecutionIdentity(
+                f"{surface}.{action} requires ExecutionIdentity before side effects"
+            )
+        return None
+
+    identity = execution_identity.require_for_dispatch()
+    if runtime_state is None and require_identity:
+        raise MissingExecutionIdentity(
+            f"{surface}.{action} requires RuntimeStateStore before side effects"
+        )
+    return identity

--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -12,7 +12,7 @@ Do not hand-edit the generated block.
 | Test files | 620 |
 | Test function occurrences | 10,752 |
 | Markdown files | 763 |
-| Markdown total lines | 191,506 |
+| Markdown total lines | 191,507 |
 | Bridge files | 24 |
 | Adapter files | 21 |
 | Orchestrator files | 4 |

--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -6,11 +6,11 @@ Do not hand-edit the generated block.
 <!-- DOCOPS:START metric=repo_inventory -->
 | Metric | Value |
 |---|---:|
-| Dharma Python modules | 661 |
+| Dharma Python modules | 662 |
 | Top-level Dharma Python modules | 389 |
-| Dharma Python LOC | 280,829 |
+| Dharma Python LOC | 280,985 |
 | Test files | 620 |
-| Test function occurrences | 10,748 |
+| Test function occurrences | 10,752 |
 | Markdown files | 763 |
 | Markdown total lines | 191,506 |
 | Bridge files | 24 |

--- a/docs/governance/SOVEREIGN_MANIFEST.md
+++ b/docs/governance/SOVEREIGN_MANIFEST.md
@@ -125,11 +125,11 @@ These are the ground-truth metrics. All other documents citing different numbers
 
 | Metric | Value | Verification |
 |--------|-------|-------------|
-| Total Python modules | **661** | find dharma_swarm -name "*.py" -type f |
+| Total Python modules | **662** | find dharma_swarm -name "*.py" -type f |
 | Top-level (flat) modules | **389 (59.0%)** | find dharma_swarm -maxdepth 1 -name "*.py" -type f |
-| Total Python LOC | **280,829** | wc -l across dharma_swarm Python modules |
+| Total Python LOC | **280,985** | wc -l across dharma_swarm Python modules |
 | Test files | **620** | find tests -name "*.py" -type f |
-| Test functions | **10,748 `def test_` occurrences under tests/** | rg "def test_" tests |
+| Test functions | **10,752 `def test_` occurrences under tests/** | rg "def test_" tests |
 | Tests collected (pytest) | **Needs write-permitted refresh** | not run during this DocOps count pass |
 | Collection errors | **Historical: 16 on 2026-04-04** | refresh before relying on this count |
 | Markdown files | **763** | find . -name "*.md" -type f |

--- a/docs/governance/SOVEREIGN_MANIFEST.md
+++ b/docs/governance/SOVEREIGN_MANIFEST.md
@@ -133,7 +133,7 @@ These are the ground-truth metrics. All other documents citing different numbers
 | Tests collected (pytest) | **Needs write-permitted refresh** | not run during this DocOps count pass |
 | Collection errors | **Historical: 16 on 2026-04-04** | refresh before relying on this count |
 | Markdown files | **763** | find . -name "*.md" -type f |
-| Markdown total lines | **191,506** | wc -l across all .md |
+| Markdown total lines | **191,507** | wc -l across all .md |
 | Bridge files | **24** | find dharma_swarm -name "*bridge*.py" |
 | Adapter files | **21 across 8 locations** | find dharma_swarm -type f \| rg -i "adapter" |
 | Orchestrator files | **4** (6,034 LOC total) | find dharma_swarm -name "*orchestrat*" |

--- a/seams/spine-adoption/codex-runlog.md
+++ b/seams/spine-adoption/codex-runlog.md
@@ -1,3 +1,4 @@
 2026-06-01T15:03:46Z | slice-A | PR #430 | Opened Slice A sync legacy ledger bypass PR with identity-before-telic fix and passing v2 baseline.
 2026-06-01T18:40:41Z | slice-B | PR #435 | Opened adapter saturation PR; verification commands are listed in the PR body.
 2026-06-01T18:40:41Z | slice-C | PR #436 | Opened mapping receipt PR; verification commands are listed in the PR body.
+2026-06-02T01:55:25Z | slice-3 | PR #445 | Opened side-effect tollbooth PR for ontology actions and diff-apply self-mod receipts.

--- a/tests/test_diff_applier.py
+++ b/tests/test_diff_applier.py
@@ -11,6 +11,8 @@ from dharma_swarm.diff_applier import (
     DiffApplier,
     parse_unified_diff,
 )
+from dharma_swarm.runtime_state import RuntimeStateStore
+from dharma_swarm.spine.identity import ExecutionIdentity
 
 
 # ---------------------------------------------------------------------------
@@ -36,6 +38,22 @@ def _make_simple_diff(old_name: str = "a/hello.py", new_name: str = "b/hello.py"
     )
 
 
+def _identity(**overrides: str) -> ExecutionIdentity:
+    payload = {
+        "task_id": "task-diff-tollbooth",
+        "agent_id": "agent-diff-tollbooth",
+        "session_id": "session-diff-tollbooth",
+        "trace_id": "trace-diff-tollbooth",
+        "correlation_id": "corr-diff-tollbooth",
+        "run_id": "run-diff-tollbooth",
+        "claim_id": "claim-diff-tollbooth",
+        "idempotency_key": "idem-diff-tollbooth",
+        "proposal_id": "proposal-diff-tollbooth",
+    }
+    payload.update(overrides)
+    return ExecutionIdentity.new(**payload)
+
+
 # ---------------------------------------------------------------------------
 # 1. Apply simple single-file diff
 # ---------------------------------------------------------------------------
@@ -55,6 +73,47 @@ async def test_apply_simple_diff(tmp_path: Path):
     content = target.read_text()
     assert "new_value = 2" in content
     assert "old_value = 1" not in content
+
+
+@pytest.mark.asyncio
+async def test_apply_requires_identity_before_writing_when_required(tmp_path: Path):
+    """Required tollbooth mode must fail closed before mutating files."""
+    target = tmp_path / "hello.py"
+    original = "# header\nold_value = 1\n# footer\n"
+    target.write_text(original)
+
+    applier = DiffApplier(
+        workspace=tmp_path,
+        runtime_state=RuntimeStateStore(tmp_path / "runtime.db"),
+        require_identity=True,
+    )
+    result = await applier.apply(_make_simple_diff())
+
+    assert result.success is False
+    assert "requires ExecutionIdentity" in result.error
+    assert target.read_text() == original
+
+
+@pytest.mark.asyncio
+async def test_apply_records_self_mod_receipts_when_identity_present(tmp_path: Path):
+    """Diff application should emit self-mod apply receipts when wired to the spine."""
+    target = tmp_path / "hello.py"
+    target.write_text("# header\nold_value = 1\n# footer\n")
+    runtime = RuntimeStateStore(tmp_path / "runtime.db")
+    identity = _identity()
+
+    applier = DiffApplier(workspace=tmp_path, runtime_state=runtime, require_identity=True)
+    result = await applier.apply(_make_simple_diff(), execution_identity=identity)
+
+    assert result.success is True
+    ledger = await runtime.get_run_ledger(identity.run_id)
+    receipts = [
+        receipt
+        for receipt in ledger["receipts"]
+        if receipt.receipt_type == "self_mod_apply"
+    ]
+    assert [receipt.status for receipt in receipts] == ["requested", "applied"]
+    assert receipts[-1].payload["files"] == ["hello.py"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ontology_registry.py
+++ b/tests/test_ontology_registry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import tempfile
 from pathlib import Path
 
@@ -29,6 +30,8 @@ from dharma_swarm.ontology import (
     entity_context,
     entity_graph,
 )
+from dharma_swarm.runtime_state import RuntimeStateStore
+from dharma_swarm.spine.identity import ExecutionIdentity
 
 
 # ── Fixtures ────────────────────────────────────────────────────────
@@ -37,6 +40,21 @@ from dharma_swarm.ontology import (
 @pytest.fixture
 def registry() -> OntologyRegistry:
     return OntologyRegistry.create_dharma_registry()
+
+
+def _identity(**overrides: str) -> ExecutionIdentity:
+    payload = {
+        "task_id": "task-ontology-tollbooth",
+        "agent_id": "agent-ontology-tollbooth",
+        "session_id": "session-ontology-tollbooth",
+        "trace_id": "trace-ontology-tollbooth",
+        "correlation_id": "corr-ontology-tollbooth",
+        "run_id": "run-ontology-tollbooth",
+        "claim_id": "claim-ontology-tollbooth",
+        "idempotency_key": "idem-ontology-tollbooth",
+    }
+    payload.update(overrides)
+    return ExecutionIdentity.new(**payload)
 
 
 @pytest.fixture
@@ -344,6 +362,55 @@ class TestActions:
         })
         result = registry.execute_action("Experiment", "Run", obj.id, {"gpu": "A100"})
         assert result.result == "success"
+
+    def test_execute_action_requires_identity_when_tollbooth_required(
+        self,
+        registry: OntologyRegistry,
+        tmp_path: Path,
+    ) -> None:
+        obj, _ = registry.create_object("Experiment", {
+            "name": "test", "status": "designed",
+        })
+        runtime = RuntimeStateStore(tmp_path / "runtime.db")
+
+        result = registry.execute_action(
+            "Experiment",
+            "Run",
+            obj.id,
+            {"gpu": "A100"},
+            runtime_state=runtime,
+            require_identity=True,
+        )
+
+        assert result.result == "blocked"
+        assert "requires ExecutionIdentity" in result.error
+
+    def test_execute_action_records_ontology_receipts_when_identity_present(
+        self,
+        registry: OntologyRegistry,
+        tmp_path: Path,
+    ) -> None:
+        obj, _ = registry.create_object("Experiment", {
+            "name": "test", "status": "designed",
+        })
+        runtime = RuntimeStateStore(tmp_path / "runtime.db")
+        identity = _identity()
+
+        result = registry.execute_action(
+            "Experiment",
+            "Run",
+            obj.id,
+            {"gpu": "A100"},
+            runtime_state=runtime,
+            execution_identity=identity,
+            require_identity=True,
+        )
+
+        assert result.result == "success"
+        ledger = asyncio.run(runtime.get_run_ledger(identity.run_id))
+        receipt_types = [receipt.receipt_type for receipt in ledger["receipts"]]
+        assert "ontology_action_requested" in receipt_types
+        assert "ontology_action_applied" in receipt_types
 
     def test_execute_unknown_action(self, registry: OntologyRegistry) -> None:
         result = registry.execute_action("Experiment", "FakeAction", "id", {})


### PR DESCRIPTION
## Summary
- Adds a deterministic side-effect tollbooth helper for ExecutionIdentity + RuntimeStateStore required-mode enforcement.
- Wires OntologyRegistry.execute_action to fail closed when identity is required and to record ontology_action_requested/applied receipts when identity/runtime are present.
- Wires DiffApplier.apply to fail closed before file writes in required mode and to record self_mod_apply requested/applied/failed receipts.
- Leaves broader AgentRunner/MCP/API chat rewrites out of scope; this slice installs the shared primitive and two selected side-effect paths.

## Coherence Delta
- Organ touched: ontology action path and self-modification diff-apply path.
- Declared-vs-actual gap closed: side-effecting ontology/self-mod surfaces can now be tollbooth-gated with canonical ExecutionIdentity and durable RuntimeStateStore receipts instead of relying only on declarations.
- Proof that re-reads the map: tests/test_ontology_registry.py proves missing identity blocks required ontology action and receipts are queryable by run_id; tests/test_diff_applier.py proves missing identity blocks file mutation and self_mod_apply receipts are written.
- New drift introduced: no broad AgentRunner/MCP/API chat rewiring in this slice. Those remain adapter-ready/quarantine candidates for the next saturation pass; C2 modifies/requires_approval enforcement is still queued, not silently implemented.

## Impact Acknowledgment
- [impact-checked]: governance/self-mod side-effect path changes were reviewed against staged diff and verified with ontology/diff/runtime tests.

## Verification
- pytest -q tests/test_diff_applier.py tests/test_ontology_registry.py tests/test_ontology_telos_hardwire.py -> 144 passed, 1 warning
- pytest -q tests/test_runtime_truth_spine_adoption.py tests/test_spine_mapping_receipts.py tests/test_runtime_truth_spine_v2_evidence.py tests/test_tool_registry.py tests/test_mcp_server.py -> 46 passed, 1 warning
- pytest -q tests/test_diff_applier.py tests/test_ontology_registry.py tests/test_ontology_telos_hardwire.py tests/test_runtime_truth_spine_adoption.py tests/test_spine_mapping_receipts.py tests/test_runtime_truth_spine_v2_evidence.py tests/test_tool_registry.py tests/test_mcp_server.py -> 190 passed, 1 warning
- python -m compileall -q dharma_swarm/diff_applier.py dharma_swarm/ontology.py dharma_swarm/spine/tollbooth.py -> exit 0
- python scripts/docops/check_docops_integrity.py --write-auto-sections -> passed
- git diff --check -> exit 0
- pre-commit hooks passed with DHARMA_UPLIFT_ACK=impact-checked for governance/self-mod side-effect path edits

## Notes
- This is Slice 3 only: shared tollbooth primitive plus ontology and diff-apply integrations.
- It does not call live Palantir/NATS/Temporal/paid LLMs and does not perform workflow unification.