### PR TITLE
feat(ops): add read-only live ops cockpit

### DIFF
--- a/ACTIVE_SURFACE_MANIFEST.yaml
+++ b/ACTIVE_SURFACE_MANIFEST.yaml
@@ -93,6 +93,7 @@ dashboard_nav_sections:
   - label: COMMAND
     items:
       - Overview
+      - Cockpit
       - Control Surface
       - Command Post
       - Qwen Surgeon
@@ -190,6 +191,15 @@ health_check_registry:
 # Every dashboard page: desired state, observed-state checks, gap info.
 
 dashboard_surfaces:
+  - id: cockpit
+    label: "Cockpit"
+    route: /dashboard/cockpit
+    api_dependencies: [/api/control-surface/summary, /api/control-surface/rows]
+    status: live
+    health_check_ids: [dashboard_route_exists, api_router_registered]
+    priority: p0
+    next_action: null
+
   - id: control_surface
     label: "Control Surface"
     route: /dashboard/control-surface

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -37,6 +37,7 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "16.1.6",
+        "openapi-typescript": "^7.4.4",
         "tailwindcss": "^4",
         "typescript": "^5"
       }
@@ -1701,6 +1702,82 @@
         }
       }
     },
+    "node_modules/@redocly/ajv": {
+      "version": "8.11.2",
+      "resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.11.2.tgz",
+      "integrity": "sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js-replace": "^1.0.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@redocly/ajv/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@redocly/config": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.22.0.tgz",
+      "integrity": "sha512-gAy93Ddo01Z3bHuVdPWfCwzgfaYgMdaZPcfL7JZ7hWJoK9V0lXDbigTWkhiPFAaLWzbOJ+kbUQG1+XwIm0KRGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@redocly/openapi-core": {
+      "version": "1.34.15",
+      "resolved": "https://registry.npmjs.org/@redocly/openapi-core/-/openapi-core-1.34.15.tgz",
+      "integrity": "sha512-HAwCnNyKcs5XGQqms+9t7OdAPM/5TDstmhF+0i7tdCFato2QKuYIlyWETwkXd8c5zbltr1oB+6y9NTeQLr2d6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@redocly/ajv": "8.11.2",
+        "@redocly/config": "0.22.0",
+        "colorette": "1.4.0",
+        "https-proxy-agent": "7.0.6",
+        "js-levenshtein": "1.1.6",
+        "js-yaml": "4.1.1",
+        "minimatch": "5.1.9",
+        "pluralize": "8.0.0",
+        "yaml-ast-parser": "0.0.43"
+      },
+      "engines": {
+        "node": ">=18.17.0",
+        "npm": ">=9.5.0"
+      }
+    },
+    "node_modules/@redocly/openapi-core/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@redocly/openapi-core/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@reduxjs/toolkit": {
       "version": "2.11.2",
       "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
@@ -1987,6 +2064,70 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.1",
@@ -3028,6 +3169,16 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -3043,6 +3194,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/ansi-styles": {
@@ -3477,6 +3638,13 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/change-case": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/classcat": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
@@ -3537,6 +3705,13 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/colorette": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
+      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
       "dev": true,
       "license": "MIT"
     },
@@ -5145,6 +5320,20 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -5190,6 +5379,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/index-to-position": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
+      "integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/internal-slot": {
@@ -5671,6 +5873,16 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-levenshtein": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/js-tokens": {
@@ -6473,6 +6685,40 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/openapi-typescript": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-7.13.0.tgz",
+      "integrity": "sha512-EFP392gcqXS7ntPvbhBzbF8TyBA+baIYEm791Hy5YkjDYKTnk/Tn5OQeKm5BIZvJihpp8Zzr4hzx0Irde1LNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@redocly/openapi-core": "^1.34.6",
+        "ansi-colors": "^4.1.3",
+        "change-case": "^5.4.4",
+        "parse-json": "^8.3.0",
+        "supports-color": "^10.2.2",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "openapi-typescript": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "typescript": "^5.x"
+      }
+    },
+    "node_modules/openapi-typescript/node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -6554,6 +6800,24 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-json": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+      "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "index-to-position": "^1.1.0",
+        "type-fest": "^4.39.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -6630,6 +6894,16 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -6939,6 +7213,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/reselect": {
@@ -7677,6 +7961,19 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
@@ -7895,6 +8192,13 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/uri-js-replace": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uri-js-replace/-/uri-js-replace-1.0.1.tgz",
+      "integrity": "sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/use-callback-ref": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
@@ -8090,6 +8394,23 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml-ast-parser": {
+      "version": "0.0.43",
+      "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",
+      "integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/dashboard/src/app/dashboard/cockpit/page.tsx
+++ b/dashboard/src/app/dashboard/cockpit/page.tsx
@@ -1,0 +1,3 @@
+"use client";
+
+export { default } from "../control-surface/page";

--- a/dashboard/src/app/dashboard/control-surface/page.tsx
+++ b/dashboard/src/app/dashboard/control-surface/page.tsx
@@ -21,6 +21,7 @@ import { NeedsJohnQueue } from "@/components/cockpit/NeedsJohnQueue";
 import { SystemTruthMatrix } from "@/components/cockpit/SystemTruthMatrix";
 import { EvidenceDrawer } from "@/components/cockpit/EvidenceDrawer";
 import { RuntimeRail } from "@/components/cockpit/RuntimeRail";
+import { OpsRunbookPanel } from "@/components/cockpit/OpsRunbookPanel";
 
 export default function OperatorCockpitPage() {
   const { rows, isLoading, error, refetch } = useControlSurfaceRows();
@@ -65,6 +66,8 @@ export default function OperatorCockpitPage() {
         onSelectRow={handleSelectRow}
         isLoading={isLoading}
       />
+
+      <OpsRunbookPanel rows={rows} selectedRow={selectedRow} />
 
       {/* Zones 2-5: Split layout */}
       <div className="flex flex-1 gap-0 overflow-hidden rounded-xl border border-sumi-700/30">

--- a/dashboard/src/components/cockpit/OpsRunbookPanel.tsx
+++ b/dashboard/src/components/cockpit/OpsRunbookPanel.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import {
+  AlertTriangle,
+  Battery,
+  Plane,
+  Server,
+  ShieldCheck,
+  SquareTerminal,
+} from "lucide-react";
+import type { ControlSurfaceRow } from "@/lib/types";
+import { colors } from "@/lib/theme";
+
+interface OpsRunbookPanelProps {
+  rows: ControlSurfaceRow[];
+  selectedRow: ControlSurfaceRow | null;
+}
+
+type FlightBucket = "keep" | "blocked" | "review" | "optional";
+
+const FLIGHT_SURFACE_ORDER = [
+  "live_ops.substrate.dharma_daemon",
+  "live_ops.transport.nats",
+  "live_ops.dashboard.local",
+  "live_ops.revenue.cashclaw_gate",
+  "live_ops.remote.agni",
+  "live_ops.mission.forge_reality_arena",
+  "live_ops.agent.merge_master_mike",
+  "live_ops.tmux.cockpit",
+  "live_ops.load.colima_openclaw",
+  "live_ops.terminal.tui",
+];
+
+function rawString(row: ControlSurfaceRow | null, key: string): string {
+  const value = row?.raw?.[key];
+  return typeof value === "string" ? value : "";
+}
+
+function bucketFor(row: ControlSurfaceRow): FlightBucket {
+  if (row.gap_codes.includes("human_authority_required") || row.observed_state === "blocked") {
+    return "blocked";
+  }
+  if (row.id.includes("dharma_daemon") || row.id.includes("transport.nats") || row.id.includes("dashboard.local")) {
+    return "keep";
+  }
+  if (row.gap_codes.includes("heavy_local_load") || row.id.includes("terminal.tui")) {
+    return "optional";
+  }
+  return "review";
+}
+
+function BucketBadge({ bucket }: { bucket: FlightBucket }) {
+  const label = {
+    keep: "Keep",
+    blocked: "Blocked",
+    review: "Review",
+    optional: "Optional",
+  }[bucket];
+  const color = {
+    keep: colors.rokusho,
+    blocked: colors.botan,
+    review: colors.kinpaku,
+    optional: colors.sumi[600],
+  }[bucket];
+  return (
+    <span
+      className="rounded-md border px-2 py-0.5 text-[10px] font-semibold uppercase"
+      style={{
+        borderColor: `color-mix(in srgb, ${color} 40%, transparent)`,
+        backgroundColor: `color-mix(in srgb, ${color} 10%, transparent)`,
+        color,
+      }}
+    >
+      {label}
+    </span>
+  );
+}
+
+function StatPill({
+  label,
+  value,
+  color,
+}: {
+  label: string;
+  value: number;
+  color: string;
+}) {
+  return (
+    <div className="flex min-w-[92px] items-center justify-between gap-3 rounded-md border border-sumi-700/30 bg-sumi-900/40 px-2 py-1.5">
+      <span className="text-[10px] uppercase text-sumi-500">{label}</span>
+      <span className="text-xs font-semibold tabular-nums" style={{ color }}>
+        {value}
+      </span>
+    </div>
+  );
+}
+
+export function OpsRunbookPanel({ rows, selectedRow }: OpsRunbookPanelProps) {
+  const liveOpsRows = rows.filter((row) => row.id.startsWith("live_ops."));
+  const beforeFlightRows = FLIGHT_SURFACE_ORDER
+    .map((id) => liveOpsRows.find((row) => row.id === id))
+    .filter((row): row is ControlSurfaceRow => Boolean(row));
+  const vpsCandidates = liveOpsRows.filter((row) => row.gap_codes.includes("vps_candidate")).length;
+  const heavyLocal = liveOpsRows.filter((row) => row.gap_codes.includes("heavy_local_load")).length;
+  const blocked = liveOpsRows.filter((row) => row.observed_state === "blocked").length;
+  const stale = liveOpsRows.filter((row) => row.observed_state === "stale").length;
+  const restartCommand = rawString(selectedRow, "restart_command");
+  const stopPolicy = rawString(selectedRow, "stop_policy");
+
+  return (
+    <section className="rounded-md border border-sumi-700/30 bg-sumi-950/60">
+      <div className="flex flex-wrap items-center justify-between gap-2 border-b border-sumi-800/40 px-4 py-2.5">
+        <div className="flex items-center gap-2">
+          <Plane size={14} className="text-aozora" />
+          <span className="text-[10px] font-semibold uppercase text-sumi-500">
+            Tonight / Before Flight
+          </span>
+        </div>
+        <div className="flex flex-wrap gap-1.5">
+          <StatPill label="Live Ops" value={liveOpsRows.length} color={colors.aozora} />
+          <StatPill label="Blocked" value={blocked} color={colors.botan} />
+          <StatPill label="Stale" value={stale} color={colors.kinpaku} />
+          <StatPill label="VPS" value={vpsCandidates} color={colors.fuji} />
+          <StatPill label="Heavy" value={heavyLocal} color={colors.bengara} />
+        </div>
+      </div>
+
+      <div className="grid gap-3 p-3 lg:grid-cols-[minmax(0,1fr)_320px]">
+        <div className="flex gap-2 overflow-x-auto">
+          {beforeFlightRows.map((row) => {
+            const bucket = bucketFor(row);
+            return (
+              <div
+                key={row.id}
+                className="min-w-[210px] rounded-md border border-sumi-800/50 bg-sumi-900/40 px-3 py-2"
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <span className="line-clamp-1 text-xs font-medium text-sumi-200">{row.label}</span>
+                  <BucketBadge bucket={bucket} />
+                </div>
+                <div className="mt-2 flex items-center gap-2 text-[10px] text-sumi-500">
+                  {bucket === "keep" && <ShieldCheck size={11} className="text-rokusho" />}
+                  {bucket === "blocked" && <AlertTriangle size={11} style={{ color: colors.botan }} />}
+                  {bucket === "review" && <Server size={11} style={{ color: colors.kinpaku }} />}
+                  {bucket === "optional" && <Battery size={11} className="text-sumi-500" />}
+                  <span className="capitalize">{row.observed_state || "unknown"}</span>
+                  <span>·</span>
+                  <span className="truncate">{row.next_action || row.desired_state || "inspect"}</span>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="rounded-md border border-sumi-800/50 bg-sumi-900/40 px-3 py-2">
+          <div className="flex items-center gap-2">
+            <SquareTerminal size={13} className="text-aozora" />
+            <span className="text-[10px] font-semibold uppercase text-sumi-500">
+              Read-only Runbook
+            </span>
+          </div>
+          <div className="mt-2 space-y-2 text-[10px]">
+            <div>
+              <div className="text-sumi-500">Selected</div>
+              <div className="mt-0.5 truncate text-xs text-sumi-200">{selectedRow?.label ?? "Select a row"}</div>
+            </div>
+            <div>
+              <div className="text-sumi-500">Command Text</div>
+              <code className="mt-0.5 block whitespace-pre-wrap break-words rounded bg-sumi-950/70 px-2 py-1 text-aozora">
+                {restartCommand || "inspect row evidence first"}
+              </code>
+            </div>
+            <div>
+              <div className="text-sumi-500">Stop Policy</div>
+              <code className="mt-0.5 block whitespace-pre-wrap break-words rounded bg-sumi-950/70 px-2 py-1 text-sumi-300">
+                {stopPolicy || "no policy declared"}
+              </code>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/dashboard/src/components/cockpit/SystemTruthMatrix.tsx
+++ b/dashboard/src/components/cockpit/SystemTruthMatrix.tsx
@@ -71,11 +71,29 @@ const PRIORITY_COLORS: Record<string, string> = {
   backlog: colors.sumi[600],
 };
 
-type FilterKey = "all" | "needs_john" | "p0" | "drifted" | "broken_register" | "organs";
+type FilterKey =
+  | "all"
+  | "live"
+  | "stopped"
+  | "stale"
+  | "blocked"
+  | "needs_john"
+  | "vps_candidate"
+  | "heavy_local_load"
+  | "p0"
+  | "drifted"
+  | "broken_register"
+  | "organs";
 
 const FILTER_OPTIONS: { key: FilterKey; label: string }[] = [
   { key: "all", label: "All" },
+  { key: "live", label: "Live" },
+  { key: "stopped", label: "Stopped" },
+  { key: "stale", label: "Stale" },
+  { key: "blocked", label: "Blocked" },
   { key: "needs_john", label: "Needs John" },
+  { key: "vps_candidate", label: "VPS Candidate" },
+  { key: "heavy_local_load", label: "Heavy Local" },
   { key: "p0", label: "P0" },
   { key: "drifted", label: "Drifted" },
   { key: "broken_register", label: "Broken Register" },
@@ -84,8 +102,20 @@ const FILTER_OPTIONS: { key: FilterKey; label: string }[] = [
 
 function applyPreFilter(rows: ControlSurfaceRow[], filter: FilterKey): ControlSurfaceRow[] {
   switch (filter) {
+    case "live":
+      return rows.filter((r) => r.observed_state === "live");
+    case "stopped":
+      return rows.filter((r) => r.observed_state === "stopped");
+    case "stale":
+      return rows.filter((r) => r.observed_state === "stale");
+    case "blocked":
+      return rows.filter((r) => r.observed_state === "blocked");
     case "needs_john":
       return rows.filter((r) => r.human_decision_required);
+    case "vps_candidate":
+      return rows.filter((r) => r.gap_codes.includes("vps_candidate"));
+    case "heavy_local_load":
+      return rows.filter((r) => r.gap_codes.includes("heavy_local_load"));
     case "p0":
       return rows.filter((r) => r.priority === "p0");
     case "drifted":

--- a/dashboard/src/lib/dashboardNav.test.ts
+++ b/dashboard/src/lib/dashboardNav.test.ts
@@ -12,14 +12,27 @@ function commandSection() {
 
 test("buildDashboardNavSections keeps the canonical operator deck contiguous near the top of COMMAND", () => {
   const items = commandSection().items;
+  const expectedLabels = [
+    "Overview",
+    "Cockpit",
+    "Control Surface",
+    ...CONTROL_PLANE_ROUTE_DECK.map((route) => route.label),
+    "Conv. Log",
+  ];
+  const expectedHrefs = [
+    "/dashboard",
+    "/dashboard/cockpit",
+    "/dashboard/control-surface",
+    ...CONTROL_PLANE_ROUTE_DECK.map((route) => route.href),
+  ];
 
   assert.deepEqual(
-    items.slice(0, 6).map((item) => item.label),
-    ["Overview", ...CONTROL_PLANE_ROUTE_DECK.map((route) => route.label), "Conv. Log"],
+    items.slice(0, expectedLabels.length).map((item) => item.label),
+    expectedLabels,
   );
   assert.deepEqual(
-    items.slice(0, 5).map((item) => item.href),
-    ["/dashboard", ...CONTROL_PLANE_ROUTE_DECK.map((route) => route.href)],
+    items.slice(0, expectedHrefs.length).map((item) => item.href),
+    expectedHrefs,
   );
 });
 

--- a/dashboard/src/lib/dashboardNav.ts
+++ b/dashboard/src/lib/dashboardNav.ts
@@ -51,6 +51,7 @@ export function buildDashboardNavSections(): DashboardNavSection[] {
       level: 1,
       items: [
         { label: "Overview", href: "/dashboard", icon: "LayoutDashboard", level: 1 },
+        { label: "Cockpit", href: "/dashboard/cockpit", icon: "Shield", level: 1 },
         { label: "Control Surface", href: "/dashboard/control-surface", icon: "Settings2", level: 1 },
         ...canonicalOperatorDeckItems(),
         { label: "Conv. Log", href: "/dashboard/log", icon: "MessageSquare", level: 1 },

--- a/dharma_swarm/operator_core/control_surface.py
+++ b/dharma_swarm/operator_core/control_surface.py
@@ -31,6 +31,10 @@ from dharma_swarm.operator_core.control_surface_go import (  # noqa: F401
     _go_world_receipt_summary_rows,
 )
 from dharma_swarm.operator_core.control_surface_memory import memory_kernel_control_rows
+from dharma_swarm.operator_core.control_surface_live_ops import (  # noqa: F401
+    _live_ops_census_rows,
+    _rows_from_live_ops_census,
+)
 from dharma_swarm.operator_core.control_surface_models import (
     AUTHORITY_ROLES,
     COHERENCE_STATES,
@@ -970,10 +974,13 @@ def build_control_surface_rows(
     if rt_row is not None:
         rows.append(rt_row)
 
-    # L) MemoryKernel operator controls
+    # L) Live ops census (observed process/port/receipt projection)
+    rows.extend(_live_ops_census_rows(root))
+
+    # M) MemoryKernel operator controls
     rows.extend(memory_kernel_control_rows(root))
 
-    # M) Go receipts (optional)
+    # N) Go receipts (optional)
     rows.extend(_go_receipt_rows(root))
 
     # Apply human-decision policy with structured context
@@ -1016,6 +1023,7 @@ def build_control_surface_summary(
         "module_truth",
         "BROKEN_REGISTER.md",
         "runtime_state",
+        "live_ops_census",
         "go_sdk",
         "recursive_discovery_shadow",
         "MemoryKernel",

--- a/dharma_swarm/operator_core/control_surface_live_ops.py
+++ b/dharma_swarm/operator_core/control_surface_live_ops.py
@@ -1,0 +1,147 @@
+"""Live ops census adapter for the Control Surface Projector."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from dharma_swarm.operator_core.control_surface_models import (
+    ControlSurfaceRow,
+    _utc_now_iso,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _live_ops_census_payload(repo_root: Path | None = None) -> dict[str, Any]:
+    """Load or build the read-only live ops census."""
+    root = repo_root or Path.cwd()
+    output = Path.home() / ".dharma" / "ops" / "live_process_census.json"
+    try:
+        if output.exists():
+            age = datetime.now(timezone.utc).timestamp() - output.stat().st_mtime
+            if age <= 300:
+                return json.loads(output.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        logger.debug("live ops census cache unreadable", exc_info=True)
+
+    try:
+        from scripts.runtime.live_ops_census import build_live_ops_census
+
+        return build_live_ops_census(repo_root=root, run_probes=True)
+    except Exception as exc:
+        logger.warning("live ops census adapter failed: %s", exc)
+        return {
+            "schema_version": "live_ops_census.v1",
+            "generated_at": _utc_now_iso(),
+            "surfaces": [
+                {
+                    "id": "adapter.error",
+                    "label": "Live ops census adapter",
+                    "class": "substrate",
+                    "status": "unknown",
+                    "desired_state": "live",
+                    "priority": "p0",
+                    "evidence": [f"adapter error: {exc}"],
+                    "authority_refs": ["scripts/runtime/live_ops_census.py"],
+                    "human_authority_required": True,
+                    "next_action": "inspect live ops census adapter",
+                    "raw": {},
+                }
+            ],
+        }
+
+
+def _live_ops_coherence(surface: dict[str, Any]) -> str:
+    status = str(surface.get("status") or "unknown")
+    priority = str(surface.get("priority") or "unknown")
+    if status == "live":
+        return "bound"
+    if status in {"blocked", "stale"}:
+        return "drifted"
+    if status == "stopped":
+        return "drifted" if priority == "p0" else "partial"
+    if status == "unknown":
+        return "unknown"
+    return "partial"
+
+
+def _rows_from_live_ops_census(
+    payload: dict[str, Any],
+    repo_root: Path | None = None,
+) -> list[ControlSurfaceRow]:
+    root = repo_root or Path.cwd()
+    rows: list[ControlSurfaceRow] = []
+    for surface in payload.get("surfaces", []):
+        sid = str(surface.get("id") or "unknown")
+        status = str(surface.get("status") or "unknown")
+        gap_codes = [f"live_ops_status:{status}"]
+        if status != "live":
+            gap_codes.append("live_ops_not_live")
+        if surface.get("human_authority_required"):
+            gap_codes.append("human_authority_required")
+        if surface.get("vps_candidate"):
+            gap_codes.append("vps_candidate")
+        if surface.get("class") == "heavy":
+            gap_codes.append("heavy_local_load")
+
+        row = ControlSurfaceRow(
+            id=f"live_ops.{sid}",
+            kind="fleet",
+            label=str(surface.get("label") or sid),
+            authority_role="observed_authority",
+            declared_state=str(surface.get("desired_state") or ""),
+            desired_state=str(surface.get("desired_state") or ""),
+            observed_state=status,
+            coherence_state=_live_ops_coherence(surface),
+            priority=str(surface.get("priority") or "unknown"),
+            owner_module="scripts/runtime/live_ops_census.py",
+            truth_owner="live_ops_census",
+            freshness=str(surface.get("freshness") or payload.get("generated_at") or ""),
+            gap_codes=gap_codes,
+            next_action=str(surface.get("next_action") or ""),
+            raw=surface,
+        )
+        row.add_source_ref("file", "scripts/runtime/live_ops_census.py", exists=True)
+        for ref in surface.get("authority_refs", []):
+            ref_str = str(ref)
+            if not ref_str:
+                continue
+            ref_path = Path(ref_str)
+            if ref_path.is_absolute():
+                row.add_source_ref("config", ref_str, exists=ref_path.exists())
+            else:
+                row.add_source_ref("file", ref_str, exists=(root / ref_str).exists())
+        for ev in surface.get("evidence", []):
+            ev_str = str(ev)
+            if ev_str:
+                row.add_evidence(
+                    "process",
+                    ev_str,
+                    status=status,
+                    provenance_chain=["live_ops_census", sid],
+                )
+        if surface.get("pids"):
+            row.add_evidence(
+                "process",
+                f"pids={','.join(str(pid) for pid in surface.get('pids', []))}",
+                status="present",
+                provenance_chain=["live_ops_census", sid, "process_snapshot"],
+            )
+        if surface.get("port"):
+            port_status = "present" if surface.get("port_listening") else "missing"
+            row.add_evidence(
+                "process",
+                f"port:{surface.get('port')}",
+                status=port_status,
+                provenance_chain=["live_ops_census", sid, "port_snapshot"],
+            )
+        rows.append(row)
+    return rows
+
+
+def _live_ops_census_rows(repo_root: Path | None = None) -> list[ControlSurfaceRow]:
+    return _rows_from_live_ops_census(_live_ops_census_payload(repo_root), repo_root)

--- a/dharma_swarm/operator_core/control_surface_models.py
+++ b/dharma_swarm/operator_core/control_surface_models.py
@@ -247,6 +247,8 @@ _HUMAN_DECISION_KEYWORDS = (
 
 
 def _needs_human_decision(row: ControlSurfaceRow) -> bool:
+    if "human_authority_required" in row.gap_codes:
+        return True
     if row.kind in ("runtime_store", "state_writer", "fleet") and row.authority_role == "incubating":
         return True
     if row.priority == "p0" and row.coherence_state in ("drifted", "unknown"):
@@ -278,7 +280,10 @@ def _build_human_decision_context(row: ControlSurfaceRow) -> HumanDecisionContex
     why_now = ""
     recommended_action = ""
 
-    if row.kind in ("runtime_store", "state_writer", "fleet") and row.authority_role == "incubating":
+    if "human_authority_required" in row.gap_codes:
+        why_now = "Surface is explicitly marked as requiring operator authority"
+        recommended_action = row.next_action or f"Review {row.label} before action"
+    elif row.kind in ("runtime_store", "state_writer", "fleet") and row.authority_role == "incubating":
         why_now = f"Incubating {row.kind} wants to go live"
         recommended_action = f"Review {row.label} and promote or archive"
     elif row.priority == "p0" and row.coherence_state == "drifted":

--- a/docs/architecture/NAVIGATION.md
+++ b/docs/architecture/NAVIGATION.md
@@ -110,6 +110,7 @@ Generated: 2026-03-29 | 500 Python modules | 494 test files | 8,848 tests
 | Check kernel integrity | `dgc dharma status` |
 | See evolution trend | `dgc evolve trend` |
 | See subconscious dreams | `dgc hum` |
+| Inspect live ops cockpit | `python3 scripts/runtime/live_ops_census.py --write`, then `/dashboard/cockpit`; runbook: [`docs/ops/LIVE_OPS_COCKPIT.md`](../ops/LIVE_OPS_COCKPIT.md) |
 | Run the CWT read-only collector v0 | `python3 scripts/runtime/cwt_collect.py` (stdout) or `--out-dir <path>` |
 | Render a CWT v0 report | `python3 scripts/runtime/cwt_report.py` → writes to `reports/control_watch_tower/<ts>/` (doctrine: [`docs/agents/CONTROL_WATCH_TOWER.md`](../agents/CONTROL_WATCH_TOWER.md); schemas: [`schemas/control_watch_tower_*.v0.json`](../../schemas/)) |
 | Govern PR review/merge cleanup | `make pr-queue`, `make pr-packet PR=<n>`, `make pr-run-codex PR=<n>`, `make pr-run-claude PR=<n>`, `make pr-gate PR=<n>`; implementation: `scripts/runtime/pr_merge_control.py`, docs: [`docs/ops/PR_REVIEW_CONTROL.md`](../ops/PR_REVIEW_CONTROL.md), GitHub mention surface: `.github/workflows/codex-mention-router.yml` |

--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -6,16 +6,16 @@ Do not hand-edit the generated block.
 <!-- DOCOPS:START metric=repo_inventory -->
 | Metric | Value |
 |---|---:|
-| Dharma Python modules | 668 |
+| Dharma Python modules | 669 |
 | Top-level Dharma Python modules | 391 |
-| Dharma Python LOC | 283,513 |
-| Test files | 639 |
-| Test function occurrences | 11,005 |
-| Markdown files | 855 |
-| Markdown total lines | 211,690 |
+| Dharma Python LOC | 283,673 |
+| Test files | 640 |
+| Test function occurrences | 11,026 |
+| Markdown files | 859 |
+| Markdown total lines | 212,543 |
 | Bridge files | 24 |
 | Adapter files | 21 |
 | Orchestrator files | 5 |
 | Router files | 14 |
-| Authority candidate docs | 376 |
+| Authority candidate docs | 380 |
 <!-- DOCOPS:END -->

--- a/docs/docops/assertions.yaml
+++ b/docs/docops/assertions.yaml
@@ -222,7 +222,7 @@
       "docs/state/CROSS_AGENT_INVENTORY.md",
       "docs/research/RUNTIME_TRUTH_SPINE_COMPLETION_PLAN.md",
       "docs/research/VERIFIED_EXPERIMENT_LOOP_RFC.md",
-      "docs/research/RECEIPT_AND_VEL_EQUIVALENCE_MATRIX.md"
+      "docs/research/RECEIPT_AND_VEL_EQUIVALENCE_MATRIX.md",
       "docs/governance/NATS_SUBSTRATE_MASTER_SPEC.md",
       "docs/ops/LIVE_OPS_COCKPIT.md",
       "docs/ops/LIVE_OPS_COCKPIT_PR_PACKET.md",

--- a/docs/docops/assertions.yaml
+++ b/docs/docops/assertions.yaml
@@ -223,6 +223,10 @@
       "docs/research/RUNTIME_TRUTH_SPINE_COMPLETION_PLAN.md",
       "docs/research/VERIFIED_EXPERIMENT_LOOP_RFC.md",
       "docs/research/RECEIPT_AND_VEL_EQUIVALENCE_MATRIX.md"
+      "docs/governance/NATS_SUBSTRATE_MASTER_SPEC.md",
+      "docs/ops/LIVE_OPS_COCKPIT.md",
+      "docs/ops/LIVE_OPS_COCKPIT_PR_PACKET.md",
+      "docs/ops/TMUX_AGENT_SUBSTRATE.md"
     ]
   },
   "auto_sections": {

--- a/docs/governance/CANONICAL_DOC_STACK.md
+++ b/docs/governance/CANONICAL_DOC_STACK.md
@@ -61,12 +61,16 @@ is **depth-on-demand**. Read it when you need it. Do not memorise a read order.
 | Architecture / invariants / axioms | `docs/governance/SOVEREIGN_MANIFEST.md`, `docs/doctrine/` | — |
 | Doc ownership | `docs/governance/CANONICAL_DOC_STACK.md` (this file) | — |
 | Anti-slop / repo-rule discipline | `docs/governance/ANTI_SLOP_RULES.md` + `.semgrep/dharma-anti-slop.yml` | — |
+| Internal live transport decision | `docs/governance/NATS_SUBSTRATE_MASTER_SPEC.md` | A2A docs, runtime plans, onboarding output, Live Ops Cockpit |
+| Terminal persistence substrate | `docs/ops/TMUX_AGENT_SUBSTRATE.md` | tmux launchers, VPS recovery plans, onboarding output, Live Ops Cockpit |
+| Live ops cockpit workflow | `docs/ops/LIVE_OPS_COCKPIT.md` | dashboard cockpit route, control-surface rows, operator travel/restart triage |
 | PR coherence gate | `docs/governance/COHERENCE_DELTA.md` | PR template |
 | PR review / merge-control operations | `docs/ops/PR_REVIEW_CONTROL.md` | Merge Master Mike workflows, PR janitor playbook |
 | Action warrant | `docs/governance/FOURFOLD_ACTION_WARRANT.md` | — |
 | Agent onboarding (ops) | `docs/ops/AGENT_ONBOARDING.md`, `docs/ops/CODEX_TOOLBELT_ONBOARDING.md` | — |
 | Module-level what-does-what | `docs/architecture/NAVIGATION.md` | — |
 | Router/TaskBoard domain pinning | `docs/architecture/ROUTERS_AND_TASKBOARD.md` | — |
+| VentureCell portfolio (which cells exist, status, instrument, separation) | `docs/governance/VENTURE_CELL_PORTFOLIO.yaml` | per-cell `VENTURE_CELL_*.md` declarations defer to it |
 | Model / provider routing | `docs/architecture/MODEL_ROUTING_CANON.md` | root `MODEL_ROUTING_MAP.md` (archive pointer) |
 | Memory Kernel production bar | `docs/architecture/MEMORY_KERNEL_PROD_BAR.md` | MemoryLattice, MemoryPalace, projection stores, canon/promotion claims |
 | Perplexity Computer autonomous loop mode | `docs/agents/perplexity-computer/AUTONOMOUS_LOOP.md` | Perplexity Computer agent card loop-mode metadata and deployment notes |

--- a/docs/governance/NATS_SUBSTRATE_MASTER_SPEC.md
+++ b/docs/governance/NATS_SUBSTRATE_MASTER_SPEC.md
@@ -1,0 +1,284 @@
+# NATS SUBSTRATE MASTER SPEC
+
+## Authority
+
+This file owns the internal live-transport decision for Dharma Swarm.
+It is doctrine and operating contract, not live state. Live state is still
+rendered by `make onboard`; current build intent is still owned by
+`docs/governance/ACTIVE_TRACK.yaml`; declared repo surfaces are still owned by
+`ACTIVE_SURFACE_MANIFEST.yaml`.
+
+If any agent, doc, or PR claims that A2A is "live", "ready", or "reachable",
+that claim must be backed by this contract or it is false.
+
+Manifest state: NATS is a declared integration surface in
+`ACTIVE_SURFACE_MANIFEST.yaml`, but it is not live until a JetStream health
+probe and ack-bearing hot-contact receipt exist. A declared surface is not a
+liveness proof.
+
+## Decision
+
+NATS JetStream is the canonical internal fleet transport for live agent
+messaging.
+
+The system split is:
+
+- NATS JetStream: internal fleet nervous system.
+- A2A HTTP / Agent Cards: external and cross-vendor edge.
+- Temporal: durable workflow execution, not message transport.
+- OpenTelemetry: trace envelope, not delivery.
+- Filesystem and SQLite buses: compatibility mirrors and audit trails during
+  migration, not live-contact authority.
+
+## Layer Boundaries
+
+NATS owns delivery, durable consumers, replay, acknowledgements, and internal
+fanout.
+
+A2A HTTP owns interop with independent agents and vendors. It must not be used
+as the internal hot path for local fleet messaging.
+
+Temporal owns long-running workflow state. It must not be used as the fleet
+event bus.
+
+Filesystem paths under `~/.dharma/a2a_bus/` may remain as mirror surfaces for
+receipts, verifier rows, historical compatibility, and human inspection. They
+must not be represented as proof of live agent reachability.
+
+## External A2A Boundary
+
+External A2A HTTP and Agent Cards enter Dharma Swarm only through a gateway.
+Agent cards are discovery metadata, not reachability proof.
+
+External agents do not publish directly to internal fleet subjects. The gateway
+verifies the external identity, mints or resolves the stable internal
+`agent_uid`, wraps the request in the NATS envelope, and publishes to the
+canonical internal subject.
+
+Internal subjects may use `dharma.a2a.*` for migrated task lifecycle events,
+but those subjects are internal NATS subjects. They are not Google A2A wire
+compatibility by themselves.
+
+## Subject Contract
+
+The first NATS substrate implementation must define these subjects before
+implementation spreads:
+
+- `dharma.fleet.heartbeat`
+- `dharma.agent.<agent_uid>.inbox`
+- `dharma.agent.<agent_uid>.outbox`
+- `dharma.a2a.task.claim`
+- `dharma.a2a.task.close`
+- `dharma.a2a.receipt`
+- `dharma.operator.hot_contact`
+- `dharma.substrate.health`
+
+Agents subscribe through durable consumers named from stable agent UIDs. Human
+display names, model names, and temporary worktree names are not durable
+consumer identifiers.
+
+## JetStream Stream Topology
+
+The implementation owns streams, not ad hoc subscribers. Stream definitions are
+part of the contract.
+
+| Stream | Subjects | Retention | Storage | Max age | Duplicate window | Discard |
+|---|---|---|---|---|---|---|
+| `DS_FLEET` | `dharma.fleet.*`, `dharma.substrate.health` | limits | file | 7 days | 10 minutes | old |
+| `DS_AGENT_INBOX` | `dharma.agent.*.inbox`, `dharma.agent.*.outbox` | limits | file | 14 days | 10 minutes | old |
+| `DS_TASKS` | `dharma.a2a.task.*` | workqueue where possible, limits otherwise | file | 30 days | 10 minutes | old |
+| `DS_RECEIPTS` | `dharma.a2a.receipt` | limits | file | 90 days | 10 minutes | old |
+| `DS_OPERATOR` | `dharma.operator.*` | limits | file | 14 days | 10 minutes | old |
+| `DS_DLQ` | `dharma.dlq.*` | limits | file | 90 days | 10 minutes | old |
+
+All publishes use the `Nats-Msg-Id` header set to the envelope `message_id`.
+The first local deployment may use one replica; clustered deployment raises the
+replica count without changing subjects or envelope fields.
+
+## Durable Consumer Contract
+
+Consumer names are stable slugs derived from `agent_uid`. They must contain
+only printable slug characters and must not contain `.`, `*`, `>`, slash,
+whitespace, or path separators.
+
+| Consumer family | Stream | Filter subject | Delivery | Ack policy | Ack wait | Max deliver | Replay |
+|---|---|---|---|---|---|---|---|
+| Agent inbox | `DS_AGENT_INBOX` | `dharma.agent.<agent_uid>.inbox` | pull durable | explicit | 30s | 5 | instant |
+| Agent outbox mirror | `DS_AGENT_INBOX` | `dharma.agent.<agent_uid>.outbox` | pull durable | explicit | 30s | 5 | instant |
+| Task claimant | `DS_TASKS` | `dharma.a2a.task.claim` | pull durable queue group | explicit | 60s | 3 | instant |
+| Task closer | `DS_TASKS` | `dharma.a2a.task.close` | pull durable queue group | explicit | 60s | 3 | instant |
+| Receipt projector | `DS_RECEIPTS` | `dharma.a2a.receipt` | pull durable | explicit | 30s | 5 | instant |
+| Operator hot contact | `DS_OPERATOR` | `dharma.operator.hot_contact` | pull durable | explicit | 15s | 2 | instant |
+| Audit mirror | all streams | configured per stream | pull durable | explicit | 120s | 10 | instant |
+
+New consumers use `DeliverNew` at registration unless they are explicitly
+audit/indexer consumers. Existing durable consumers resume from their durable
+state. Audit/indexer consumers may use `DeliverAll`; command and hot-contact
+consumers must not replay old commands as fresh work.
+
+## Envelope Contract
+
+Every NATS message uses a typed envelope. Minimum fields:
+
+- `schema`: version string, initially `dharma.nats.envelope.v1`.
+- `message_id`: stable unique id.
+- `trace_id`: OpenTelemetry-compatible trace id. Generate one if absent.
+- `span_id`: OpenTelemetry-compatible span id. Generate one if absent.
+- `parent_span_id`: parent span id when this message continues an existing span.
+- `correlation_id`: stable id tying a request, replies, receipts, and mirrors.
+- `causation_id`: prior `message_id` that caused this message, when present.
+- `subject`: published subject.
+- `from_agent`: stable sender uid.
+- `to_agent`: stable target uid or `fleet`.
+- `kind`: heartbeat, command, task, receipt, verifier_row, health, or event.
+- `created_at`: UTC ISO timestamp.
+- `requires_ack`: boolean.
+- `payload`: object.
+
+Raw strings are not fleet messages. If a CLI accepts a string, the CLI wraps it
+in this envelope before publish.
+
+## Trace And Causality
+
+Trace fields are mandatory for commands, task lifecycle events, receipts, and
+verifier rows. Gateways map `trace_id`, `span_id`, and `parent_span_id` to
+OpenTelemetry `traceparent`/`tracestate` headers when crossing process or HTTP
+boundaries.
+
+Receipts must carry the original `trace_id`, `correlation_id`, and triggering
+`message_id`. A reply without causality fields is mirror evidence only.
+
+## Delivery And Ack Contract
+
+For hot contact, success means a broker-owned acknowledgement or a durable
+consumer-visible delivery receipt. Writing a file is not success.
+
+With NATS reachable:
+
+- publish to the canonical subject;
+- require ack for operator commands and task lifecycle events;
+- surface the ack id, subject, and elapsed time.
+
+With NATS unreachable:
+
+- fail fast with `NATS_UNAVAILABLE`;
+- print the exact check that failed;
+- do not crawl `~/.dharma/a2a_bus/` looking for a substitute success signal.
+
+## Ack Tiers
+
+The system must name which ack tier it has proven:
+
+- `PUBLISH_ACCEPTED`: JetStream accepted the publish and returned stream
+  sequence metadata.
+- `DELIVERED_TO_CONSUMER`: a durable consumer saw the message.
+- `HANDLER_ACKED`: the target handler acknowledged completion of the message
+  handling step.
+- `DOMAIN_RECEIPTED`: a typed Dharma receipt exists for the intended domain
+  effect.
+
+Operator hot contact requires `HANDLER_ACKED` or `DOMAIN_RECEIPTED` within the
+configured timeout. `PUBLISH_ACCEPTED` alone is not live human-usable contact.
+
+## Replay And Poison Message Policy
+
+Commands and hot-contact messages must be idempotent and must not replay as new
+commands after agent restart. Durable resume is allowed; accidental command
+re-execution is not.
+
+When `MaxDeliver` is exhausted, the handler publishes a typed failure envelope
+to `dharma.dlq.<stream>.<consumer>` and emits an operator-visible blocker. DLQ
+messages are retained for audit and human replay. The failed original message
+must not be silently treated as handled.
+
+## Hot Contact Protocol
+
+`dgc a2a send <agent_uid> <message>` publishes an `operator_command` envelope to
+`dharma.agent.<agent_uid>.inbox`. `dharma.operator.hot_contact` is an operator
+receipt/coordination subject, not the target inbox.
+
+The CLI prints:
+
+- `message_id`;
+- target `agent_uid`;
+- stream and sequence for `PUBLISH_ACCEPTED`;
+- ack tier reached;
+- elapsed milliseconds;
+- blocker code when the timeout expires.
+
+Without NATS ack proof the command exits non-zero and prints `NATS_UNAVAILABLE`
+or `NATS_ACK_UNVERIFIED`.
+
+## JetStream KV And Object Store
+
+JetStream KV may own ephemeral fleet presence, last heartbeat, lease pointers,
+registry snapshots, and hot-contact pending state. KV compare-and-set is the
+only allowed lease mutation primitive once migrated.
+
+JetStream Object Store may own large transcripts, artifacts, and blobs. NATS
+messages carry object references and hashes, not large payloads.
+
+## Compatibility Mirrors
+
+During migration, existing filesystem and SQLite surfaces may mirror NATS
+events for audit compatibility:
+
+- `~/.dharma/a2a_bus/receipts/`
+- `~/.dharma/a2a_bus/verifier.jsonl`
+- `~/.dharma/a2a_bus/conjunction/`
+- `~/.dharma/a2a_bus/tasks/queue.jsonl`
+- `~/.dharma/a2a_bus/inboxes/`
+- existing `MessageBus` SQLite records when needed by older views
+
+Mirrors are append-only evidence copies. They do not own delivery, liveness,
+ordering, backpressure, or retry semantics.
+
+## Anti-Slop Rules
+
+Agents must not:
+
+- add a new file-poll inbox or queue and call it live A2A;
+- add a new `queue.jsonl` authority path for task dispatch;
+- add a second internal broker, registry, or delivery abstraction without
+  updating this spec first;
+- claim Perplexity, Codex, Opus, Hermes, Warp, Devin, or any other agent is
+  reachable because a card or folder exists;
+- silently fall back from NATS to filesystem for hot contact.
+
+Allowed exceptions:
+
+- tests may use temp filesystem fixtures;
+- legacy compatibility code may read existing mirrors while explicitly naming
+  them as mirrors;
+- governance reports may mention old filesystem paths as broken or historical
+  evidence.
+
+## Onboarding And Enforcement
+
+`make onboard` must render the NATS substrate status every session. It must
+show:
+
+- this spec path;
+- whether TCP port 4222 is listening locally;
+- whether filesystem A2A mirrors exist;
+- that filesystem mirrors are not live-transport proof.
+
+`make nats-substrate-contract` must verify the wiring of this contract.
+`make governance-all` must include that check.
+
+## Supersession
+
+Older Go/event-fabric plans that described NATS as optional or file spool as
+the default remain valid only for evidence ingress, historical compatibility,
+or mirror experiments. They are superseded for live-contact authority by this
+spec.
+
+## Acceptance Criteria
+
+The first NATS substrate implementation is complete only when:
+
+- this spec exists and is referenced from onboarding and governance docs;
+- `make onboard` prints the NATS substrate section without requiring NATS;
+- `make nats-substrate-contract` passes;
+- tests prove the checker fails when this contract is disconnected;
+- no new filesystem inbox is introduced as the hot-contact fix.

--- a/docs/governance/SOVEREIGN_MANIFEST.md
+++ b/docs/governance/SOVEREIGN_MANIFEST.md
@@ -117,15 +117,15 @@ These are the ground-truth metrics. All other documents citing different numbers
 
 | Metric | Value | Verification |
 |--------|-------|-------------|
-| Total Python modules | **668** | find dharma_swarm -name "*.py" -type f |
+| Total Python modules | **669** | find dharma_swarm -name "*.py" -type f |
 | Top-level (flat) modules | **391 (58.7%)** | find dharma_swarm -maxdepth 1 -name "*.py" -type f |
 | Total Python LOC | **283,300** | wc -l across dharma_swarm Python modules |
-| Test files | **639** | find tests -name "*.py" -type f |
-| Test functions | **11,005 `def test_` occurrences under tests/** | rg "def test_" tests |
+| Test files | **640** | find tests -name "*.py" -type f |
+| Test functions | **11,026 `def test_` occurrences under tests/** | rg "def test_" tests |
 | Tests collected (pytest) | **Needs write-permitted refresh** | not run during this DocOps count pass |
 | Collection errors | **Historical: 16 on 2026-04-04** | refresh before relying on this count |
-| Markdown files | **855** | find . -name "*.md" -type f |
-| Markdown total lines | **211,690** | wc -l across all .md |
+| Markdown files | **859** | find . -name "*.md" -type f |
+| Markdown total lines | **212,543** | wc -l across all .md |
 | Bridge files | **24** | find dharma_swarm -name "*bridge*.py" |
 | Adapter files | **21 across 8 locations** | find dharma_swarm -type f \| rg -i "adapter" |
 | Orchestrator files | **4** (6,034 LOC total) | find dharma_swarm -name "*orchestrat*" |

--- a/docs/governance/VENTURE_CELL_PORTFOLIO.yaml
+++ b/docs/governance/VENTURE_CELL_PORTFOLIO.yaml
@@ -1,0 +1,196 @@
+# VENTURE_CELL_PORTFOLIO.yaml   (schema_version 1; structure extended 2026-05-30: telos_tree, envisioned, binocular frame)
+#
+# OWNER OF: "which VentureCells / organs exist, their status, telos placement, and instrument type."
+# This is the cell INDEX of a GROWING, many-tentacled organism — NOT a roster of what to keep small.
+#
+# READ THIS WITH THE FULL-SCALE FRAME, NOT INSTEAD OF IT:
+#   - Vision (current): docs/vision_maps/2026-05-30_binocular_witness_seer_northstar.md (the Binocular Organism)
+#   - Genome: dharma_swarm/foundations/ (10 pillars; "privileging any single level kills the multi-scale property")
+#   - The organism is DESIGNED to run MANY tentacles at once: Beer's requisite variety (a simple controller
+#     for a complex world is a mathematical impossibility) + the Transcendence Principle (collapsing agent/cell
+#     diversity is provably weaker — "transcendence death"). Octopus, not monolith.
+#
+# THE ONE LAW (north-star §V) governs every entry here:
+#   No cell spawns, grows, or claims status except by closing a strange loop on a real, gated, verifiable,
+#   diversity-preserving outcome. The gate is "the bank that gives the river its power" — it makes many wild
+#   tentacles SAFE; it is NOT a reason to have one. Honest status per cell, across MANY cells.
+#
+# HOBBLING GUARD (north-star §VI-bis): do NOT read this index as a mandate to shrink. A constraint that
+#   removes a tentacle that would have been *chosen* is hobbling, not dharma. Subtract only dead wood
+#   (phantom / narration-without-contact); never amputate a live limb to fit one brick.
+#
+# It is NOT the active build track. The active BUILD track is exactly one block in ACTIVE_TRACK.yaml
+# (currently goodworks-dgm-core-2026-05). METHOD = ship one seam at a time. OBJECT = the whole organism.
+# A cell can be live here while the build track points elsewhere. Confusing the two is the "two-arcs drift."
+#
+# SCHEMA: each cell maps to VentureCellV1 (fractal/fractal_room.py:163-200) + _VENTURE_CELL ontology object
+#   (ontology.py:1470-1507). Cells spawn cells via RoomRegistry.spawn_child (budget-conserving); dead cells
+#   recycle via archive_room (dissolution-with-recycling = "kill nothing, metabolize" realized in code).
+#   Lifecycle: docs/architecture/VENTURE_CELL_LIFECYCLE.md. Self-sustaining loops: catalytic_graph.py (Tarjan SCC).
+# DOCTRINE: ~/.claude/cabinet/ARJUNA.md (Palantir of good works; Amendment 2026-05-30).
+# RULE (CANONICAL_DOC_STACK Anti-Doc-Maze #4): active state lives here in YAML; per-cell prose VENTURE_CELL_*.md defer to this index.
+
+schema_version: 1
+generated: "2026-05-30"
+authored_in: dharma_swarm            # primary worktree; not mirrored to lf5/* worktrees
+status_legend:
+  ACTIVE_SEASON_0:    live, serving (or about to serve) a real external party
+  ACTIVE_BUILD_TRACK: this cell IS the current ACTIVE_TRACK.yaml seam
+  INCUBATING:         declared, research-only, no live external contact yet
+  DESIGN_ONLY:        rich design exists, nothing shipped (roadmap slipped)
+  ENVISIONED:         canon-locked ambition; organ/cell not yet instantiated (held, not claimed)
+  DORMANT:            deployed but at zero throughput ("zero sparks") — hands exist, no current flows
+  HELD:               the system's own gauntlet refused it; do not present as ready
+  RETIRED:            metabolized — lessons kept, targets retired (NOT killed)
+
+# ---------------------------------------------------------------------------
+# THE TELOS TREE — the organism serves MANY domains AT ONCE (this is the point, not a bug)
+# Owner of the hierarchy: SOVEREIGN_MANIFEST.md §Telos Hierarchy. This is a placement view.
+# ---------------------------------------------------------------------------
+telos_tree:
+  root: jagat_kalyan                 # universal welfare — "benefits the WHOLE: not self, not collaborator"
+  faces_toward: moksha               # the ultimate direction (telos-orientation skill)
+  domains:
+    silicon_is_sand:                 # SIS — the material body of intelligence, recognized as sand
+      scope: [energy, water, chips, minerals, fabs, labor, land, emissions, e_waste]
+      organs:
+        gaia_reciprocity: "accounting kernel — per-inference carbon attribution / AI reciprocity ledger"
+        loomwork: "evidence-weaving organ — casefiles/alerts/maps/briefs for journalists, NGOs, regulators, citizens"
+    attention_emancipation:          # a separate JK-level domain (NOT SIS; NOT productivity tooling)
+      organs:
+        darshan: "publication — the first LIT tentacle"
+  metabolism:                        # how the organism eats to fund the work (NOT a domain)
+    shakti_ginko: "wealth-metabolism organ, Jagat-Kalyan-DIRECT (trustee-not-possessor; Trading Lab = one cell)"
+  hands: sab_dharmic_agora           # platform-spawning organ — spawns sites/networks, reseeds the noosphere
+  market_position: web_4_0           # trust/verification substrate for the agentic web (gates + witness + A2A receipts)
+  body: dharma_swarm                 # the self-evolving VSM organism (Sakshi+Drishti binocular eye) that ENACTS all of the above
+
+# ---------------------------------------------------------------------------
+# LIT TENTACLES — live / in-motion cells (each held to the One Law)
+# ---------------------------------------------------------------------------
+cells:
+
+  - id: darshan-publication
+    external_name: Darshan
+    instrument: publication          # serves a public reader; identity + trust compounding
+    status: ACTIVE_SEASON_0
+    autonomy_stage: 1
+    telos_domain: attention_emancipation   # a Jagat Kalyan domain; SIS-placement: unresolved
+    customer_or_beneficiary: "serious readers in 2026 overwhelmed by feeds, AI, and institutional incoherence"
+    external_operator: cofounder.co        # operating shell only; supersedes Polsia (2026-05-27)
+    declaration: docs/governance/VENTURE_CELL_DARSHAN.md
+    vision_archive: ~/.dharma/knowledge/wiki/concepts/darshan-publication-venture-cell.md
+    # THE ONE LAW AT THE CELL LEVEL — contact-gate, the spawn-enabler (not a cap):
+    success_metric_primary: external_readers_who_read_and_replied
+    monetization_when_proven: "same-reader paid layer — source packs, living dossiers, membership, institutional licensing"
+    is_not: [cms, paywall, daily_engine, autonomous_writer, consulting_funnel, spiritual_brand]
+    separation:
+      from: campaign-xray
+      why: "different buyer (mass reader vs AI-native founder), different deliverable, ~10x price gap. NOT one receipt loop."
+
+  - id: campaign-xray
+    external_name: "Campaign X-Ray"
+    instrument: advisory_diagnostic  # B2B corpus diagnostic; sells decision-compression
+    status: HELD
+    buyer: "AI-native founder drowning in repos, notes, branches, priorities"
+    gate_evidence: reports/revenue_wedge/first_cash_receipt_status.md
+    gauntlet: { decision: HOLD, score: "28/100", hard_gates_failed: [buyer_pain, budget_wtp, channel, delivery_proof, risk_welfare], revenue_usd: 0, delivery_samples: 0 }
+    blocked_until: [proven_buyer_pain, wtp_evidence, approved_safe_channel, one_real_delivery_sample]
+    separation:
+      from: darshan-publication
+      why: "NOT Darshan's funnel. A separate business. Lives or dies on its own buyer-pain/WTP/channel. Respect the HOLD."
+
+  - id: revenue-wedge
+    instrument: discovery_cell
+    status: INCUBATING
+    declaration: docs/governance/VENTURE_CELL_REVENUE_WEDGE.md
+
+  - id: shakti-ginko
+    instrument: wealth_metabolism
+    status: INCUBATING               # umbrella organ; Trading Lab cell is live-on-Agni (paper-only, hard-gated)
+    telos_domain: jagat_kalyan_direct   # NOT under SIS
+    declaration: docs/architecture/SHAKTI_GINKO_ORGAN.md
+
+  - id: loomwork
+    instrument: publication          # ecological / material pattern surfacing (SIS organ)
+    status: DESIGN_ONLY              # design-rich (level-100 vision), unshipped — held at ambition, honest on status
+    telos_domain: SIS
+    declaration: docs/loomwork/2026-05-07-loomwork-design.md
+
+  - id: goodworks-dgm
+    instrument: verifiable_mrv_core  # ecological / welfare MRV
+    status: ACTIVE_BUILD_TRACK       # this is the current coding seam, NOT a publication
+    intent_owner: docs/governance/ACTIVE_TRACK.yaml   # intent lives there; do not duplicate it here
+
+# ---------------------------------------------------------------------------
+# ENVISIONED / DORMANT — the organism is BUILT TO GROW these (canon, not phantom)
+# Held at full ambition AND honestly marked unbuilt. Holding them is not narration; claiming them
+# as live would be. The One Law lights each one real outcome at a time. This section is what keeps
+# the index from reading as "the system is small" — it is not small; it is early.
+# ---------------------------------------------------------------------------
+envisioned:
+
+  - id: sab-dharmic-agora
+    role: "hands — platform-spawning basin (self-spawning sites/networks; noosphere reseeding)"
+    status: DORMANT                  # deployed, "zero sparks" (north-star §III)
+    one_law_spark: "light ONE real public node that grounds in a real outcome and passes the gate"
+    see: docs/vision_maps/2026-05-30_binocular_witness_seer_northstar.md   # §III
+
+  - id: gaia-reciprocity
+    role: "SIS accounting kernel — reciprocity ledger (per-inference carbon attribution)"
+    status: ENVISIONED
+
+  - id: web-4-0-trust-substrate
+    role: "market position — the verification protocol for the internet of agents"
+    status: ENVISIONED               # the deeper frame the welfare arms are applications OF (north-star §IV)
+    grounded_by: "A2A correlation-stamped receipts + gates-as-block + witness logs"
+
+  - id: future-organs
+    role: "learning organ, community organ, ecological organ, advisory/customer-ops cells (open-ended)"
+    status: ENVISIONED
+    mechanism: "IdeationNoticer proposes new cells -> operator approves birth -> spawn_child instantiates"
+
+# ---------------------------------------------------------------------------
+# RETIRED — metabolize the lessons, retire the targets (kill nothing; compost)
+# ---------------------------------------------------------------------------
+retired:
+
+  - id: arjuna-ngo-target-roster
+    what: "OCCRP Aleph Co-Pilot / GFW Forest-Loss Defender / Methane Accountability MVPs + foundation-plumbing F1-F6"
+    status: RETIRED
+    reason: agent_generated_phantom
+    disowned_on: "2026-05-27"
+    operator_quote: "I still don't even know what OCCRP / GFW is."
+    # NOTE: retired for being PHANTOM (narrated-as-done with no contact), NOT because the AMBITION was wrong.
+    #       The Palantir-of-good-works ambition — many weapons at many broken things — is canon (ARJUNA.md).
+    #       What was retired is the FABRICATION (pitches "sent Day 0" that were never sent), not the plurality.
+    metabolize_keep:
+      - the business-idea gauntlet (it correctly HELD an unready offer)
+      - the conductor-loop architecture (dharma_swarm/venture_cell/darshan/)
+      - the substrate-leak discipline (reader meets the seeing, never the engine)
+      - the PGE / long-running-harness pattern
+    retire:
+      - the 15-target roster as COMMITMENTS (no confirmed warm partner on any — but they remain valid AMBITION)
+      - the partner pitches that were narrated as "sent Day 0" but never sent
+      - the 6/04-6/18 deadline cascade
+    see: ~/.claude/projects/-Users-dhyana/memory/feedback_agent_generated_phantoms.md
+
+# ---------------------------------------------------------------------------
+# THE BINOCULAR FRAME — why this index is held at full scale (north-star)
+# ---------------------------------------------------------------------------
+# One organism, two eyes (north-star §I):
+#   - Sakshi (Witness, inward): heartbeat, Gnani verdict, telos gates, R_V < 1.0.
+#   - Drishti (Seer, outward): shakti_zeitgeist_executive.py, zeitgeist.py, world_radar/, the 6-domain world_model.
+# Depth perception = locating real leverage in the world. A monocular system (one eye, or one cell) is a
+# hall of mirrors. The portfolio is the set of places the two eyes have found leverage and acted — and it is
+# DESIGNED TO GROW by autocatalytic closure (cells funding/enabling/improving each other into self-sustaining
+# loops; target beta_1 >= 3).
+#
+# Both are true at once (anekantavada):
+#   - AMBITION (the OBJECT): a many-domain welfare organism — SIS/Loomwork/GAIA + Attention-Emancipation/Darshan
+#     + Shakti-Ginko metabolism + SAB hands + Web 4.0 position — running simultaneously, by design.
+#   - DISCIPLINE (the METHOD): every tentacle closes its loop through a real external outcome, or it does not
+#     spawn. Darshan's contact-gate is this One Law at the cell level.
+# The earlier "two-arcs drift" was real (a phantom NGO roster narrated as live). The fix is honest status per
+# cell across MANY cells — never collapsing the organism to one. Subtract toward the Tao (compost dead wood);
+# do not amputate live limbs. See ARJUNA.md Amendment 2026-05-30 and the binocular north-star §V–VI-bis.

--- a/docs/ops/LIVE_OPS_COCKPIT.md
+++ b/docs/ops/LIVE_OPS_COCKPIT.md
@@ -1,0 +1,142 @@
+# Live Ops Cockpit
+
+Status: active runbook for the read-only operator cockpit.
+
+## Purpose
+
+The Live Ops Cockpit gives the operator one deterministic view of local swarm
+operations after restarts, travel, or multi-agent drift. It does not start,
+stop, kill, message, spend, merge, or mutate anything. It reads the existing
+owner files and runtime evidence, writes a census receipt, and projects that
+evidence into `/dashboard/cockpit`.
+
+## Authority Stack
+
+Read in this order:
+
+1. `make onboard`
+2. `docs/governance/ACTIVE_TRACK.yaml`
+3. `ACTIVE_SURFACE_MANIFEST.yaml`
+4. `docs/state/LIVE_OPS_DASHBOARD.md`
+5. `docs/state/BROKEN_REGISTER.md`
+6. `docs/governance/SOVEREIGN_MANIFEST.md`
+7. `docs/governance/ANTI_SLOP_RULES.md`
+8. `docs/governance/CANONICAL_DOC_STACK.md`
+9. `docs/governance/NATS_SUBSTRATE_MASTER_SPEC.md`
+10. `docs/ops/TMUX_AGENT_SUBSTRATE.md`
+
+`make onboard` is the front door. The files above own intent, declared
+surfaces, operating state, known breaks, doctrine, anti-duplication rules,
+transport boundaries, and terminal-persistence boundaries.
+
+## Census Receipt
+
+Run:
+
+```bash
+python3 scripts/runtime/live_ops_census.py --write
+```
+
+Receipt:
+
+```text
+~/.dharma/ops/live_process_census.json
+```
+
+The census is read-only. Its probes inspect process names, listening ports,
+tmux sessions, and known receipt files. It records status, desired state,
+evidence, authority refs, restart command text, stop policy text, freshness,
+operator-authority flags, VPS-candidate flags, and local-heavy-load flags.
+
+## Dashboard
+
+Open:
+
+```text
+/dashboard/cockpit
+```
+
+The route uses the existing control-surface API:
+
+```text
+/api/control-surface/summary
+/api/control-surface/rows
+```
+
+The cockpit highlights:
+
+- Live
+- Stopped
+- Stale
+- Blocked
+- Needs John
+- VPS Candidate
+- Heavy Local Load
+
+The runbook panel displays commands and stop policies as text only. It does
+not execute commands.
+
+## Before Flight Mode
+
+Use the top runbook strip before travel or sleep:
+
+Keep alive:
+
+- Dharma daemon
+- local NATS JetStream when A2A contact is needed
+- dashboard API and web
+
+Keep blocked unless explicitly approved:
+
+- CashClaw / revenue outreach
+- AGNI real-money or trading action
+- Merge Master Mike automerge authority
+
+Review or refresh:
+
+- AGNI watcher receipts and feed freshness
+- Forge Hydra latest handoff and heartbeat
+- tmux cockpit lanes
+- terminal TUI only if it is the active operator surface
+
+Optional local load:
+
+- Colima / OpenClaw VM, if not being actively used
+
+## Guardrails
+
+- NATS is live transport, not workflow truth.
+- tmux is terminal persistence, not task truth.
+- Filesystem mirrors are evidence, not authority.
+- RuntimeStateStore owns durable runtime facts.
+- Operator approval is required for money, outreach, merges, process killing,
+  VPS changes, and external actions.
+- Kill nothing immediately. Classify, quarantine, or recommend.
+
+## Verification
+
+Run:
+
+```bash
+make onboard
+/Users/dhyana/dharma_swarm/.venv/bin/python scripts/runtime/live_ops_census.py --write
+/Users/dhyana/dharma_swarm/.venv/bin/python -m pytest tests/test_live_ops_census.py -q
+/Users/dhyana/dharma_swarm/.venv/bin/python -m pytest tests/test_control_surface.py::TestDashboardControlSurfacePage -q
+/Users/dhyana/dharma_swarm/.venv/bin/python -m pytest tests/test_control_surface.py::TestControlSurfaceAPI -q
+/Users/dhyana/dharma_swarm/.venv/bin/python -m pytest tests/test_control_surface.py -q
+/Users/dhyana/dharma_swarm/.venv/bin/python -m pytest tests/test_agent_onboard.py::test_onboard_renders_required_sections -q
+/Users/dhyana/dharma_swarm/.venv/bin/python -m pytest tests/test_agent_onboard.py::test_onboard_does_not_write_to_owners -q
+/Users/dhyana/dharma_swarm/.venv/bin/python -m pytest tests/test_agent_onboard.py -q
+bun test dashboard/src/lib/dashboardNav.test.ts
+/Users/dhyana/dharma_swarm/.venv/bin/python -m pytest tests/test_live_ops_census.py tests/test_agent_onboard.py tests/test_control_surface.py -q
+git diff --check
+```
+
+If the dashboard API is already running, restart it only with explicit operator
+approval. Without a restart, direct Python/API tests still prove the branch
+projection, but the running process may show the old code until reload.
+
+Dashboard lint/build require dashboard dependencies in the clean worktree. If
+`dashboard/node_modules` is missing, `npm run lint` and `npm run build` fail at
+tool bootstrap (`eslint` / `next` not found), not at cockpit source validation.
+Do not use a symlinked `node_modules` as build evidence; Turbopack rejects it.

--- a/docs/ops/LIVE_OPS_COCKPIT_PR_PACKET.md
+++ b/docs/ops/LIVE_OPS_COCKPIT_PR_PACKET.md
@@ -12,6 +12,24 @@ receipt into the Control Surface dashboard.
 This packet is the merge-facing evidence bundle. It is not a supervisor and
 does not grant process-control authority.
 
+## Coherence Delta
+
+- Organ touched: Operator live-ops surface — `scripts/runtime/live_ops_census.py`,
+  Control Surface projection, onboarding output, and read-only dashboard cockpit.
+- Declared-vs-actual gap closed: The repo already declared NATS, tmux,
+  venture-cell, and operator-gated runtime surfaces, but the operator had no
+  single read-only restart/travel cockpit. This PR turns those declarations into
+  a deterministic census receipt and dashboard/onboard projection without
+  making any process-control action executable.
+- Proof that re-reads the map: `make onboard`, `tests/test_live_ops_census.py`,
+  `tests/test_control_surface.py`, `tests/test_agent_onboard.py`, and
+  `dashboard/src/lib/dashboardNav.test.ts` re-read the manifest, canonical
+  docs, census rows, dashboard nav, and operator gate surfaces.
+- New drift introduced: A new cockpit docs packet and canonical registry entries
+  add one operator-facing surface; known drift remains limited to clean-worktree
+  dashboard dependency bootstrap and stale already-running local API evidence,
+  both called out in Risks.
+
 ## Non-Goals
 
 - Do not start, stop, restart, kill, or message live processes.

--- a/docs/ops/LIVE_OPS_COCKPIT_PR_PACKET.md
+++ b/docs/ops/LIVE_OPS_COCKPIT_PR_PACKET.md
@@ -1,0 +1,287 @@
+# Live Ops Cockpit v1 PR Packet
+
+Status: PR-hardening packet for `codex/live-ops-cockpit-v1`.
+
+## Purpose
+
+Live Ops Cockpit v1 gives the operator one read-only cockpit for local swarm
+operations after restart, travel, or multi-agent drift. The branch folds the
+existing authority stack into a deterministic census receipt and projects that
+receipt into the Control Surface dashboard.
+
+This packet is the merge-facing evidence bundle. It is not a supervisor and
+does not grant process-control authority.
+
+## Non-Goals
+
+- Do not start, stop, restart, kill, or message live processes.
+- Do not call live Palantir, external NATS, Temporal, paid LLMs, or GitHub merge
+  APIs.
+- Do not make filesystem mirrors source-of-truth.
+- Do not make NATS workflow truth.
+- Do not make tmux task truth.
+- Do not authorize money, outreach, merges, process killing, VPS changes, or
+  external actions without the operator.
+- Do not add a new substrate or new agents.
+
+## Changed Files
+
+Core:
+
+- `scripts/runtime/live_ops_census.py`
+- `dharma_swarm/operator_core/control_surface.py`
+- `dharma_swarm/operator_core/control_surface_live_ops.py`
+- `dharma_swarm/operator_core/control_surface_models.py`
+- `scripts/governance/agent_onboard.py`
+
+Dashboard:
+
+- `dashboard/src/app/dashboard/cockpit/page.tsx`
+- `dashboard/src/app/dashboard/control-surface/page.tsx`
+- `dashboard/src/components/cockpit/OpsRunbookPanel.tsx`
+- `dashboard/src/components/cockpit/SystemTruthMatrix.tsx`
+- `dashboard/src/lib/dashboardNav.ts`
+- `dashboard/src/lib/dashboardNav.test.ts`
+
+Docs and manifests:
+
+- `ACTIVE_SURFACE_MANIFEST.yaml`
+- `docs/architecture/NAVIGATION.md`
+- `docs/docops/AUTO_INVENTORY.md`
+- `docs/governance/CANONICAL_DOC_STACK.md`
+- `docs/governance/NATS_SUBSTRATE_MASTER_SPEC.md`
+- `docs/governance/SOVEREIGN_MANIFEST.md`
+- `docs/governance/VENTURE_CELL_PORTFOLIO.yaml`
+- `docs/ops/LIVE_OPS_COCKPIT.md`
+- `docs/ops/LIVE_OPS_COCKPIT_PR_PACKET.md`
+- `docs/ops/TMUX_AGENT_SUBSTRATE.md`
+
+Tests:
+
+- `tests/test_agent_onboard.py`
+- `tests/test_control_surface.py`
+- `tests/test_live_ops_census.py`
+
+## Current Census Snapshot
+
+Latest receipt:
+
+```text
+~/.dharma/ops/live_process_census.json
+```
+
+Current surfaces from the latest local receipt:
+
+- Live: `substrate.dharma_daemon`, `transport.nats`,
+  `evidence.a2a_mirrors`, `evidence.nats_receipts`,
+  `external.hermes_a2a`, `dashboard.local`
+- Stale: `remote.agni`
+- Blocked: `revenue.cashclaw_gate`
+- VPS candidate: `remote.agni`
+- Operator authority required: `revenue.cashclaw_gate`, `remote.agni`,
+  `agent.merge_master_mike`, `load.colima_openclaw`
+
+These are observations from the local machine. They are not promises that a
+different checkout, laptop state, or VPS state has the same status.
+
+## Verification Commands
+
+Required before PR handoff:
+
+```bash
+make onboard
+/Users/dhyana/dharma_swarm/.venv/bin/python scripts/runtime/live_ops_census.py --write
+/Users/dhyana/dharma_swarm/.venv/bin/python -m pytest tests/test_live_ops_census.py -q
+/Users/dhyana/dharma_swarm/.venv/bin/python -m pytest tests/test_control_surface.py::TestDashboardControlSurfacePage -q
+/Users/dhyana/dharma_swarm/.venv/bin/python -m pytest tests/test_agent_onboard.py::test_onboard_renders_required_sections -q
+/Users/dhyana/dharma_swarm/.venv/bin/python -m pytest tests/test_agent_onboard.py::test_onboard_does_not_write_to_owners -q
+/Users/dhyana/dharma_swarm/.venv/bin/python -m pytest tests/test_agent_onboard.py -q
+bun test dashboard/src/lib/dashboardNav.test.ts
+/Users/dhyana/dharma_swarm/.venv/bin/python -m pytest tests/test_control_surface.py -q
+/Users/dhyana/dharma_swarm/.venv/bin/python -m pytest tests/test_live_ops_census.py tests/test_agent_onboard.py tests/test_control_surface.py -q
+git diff --check
+```
+
+Dashboard verification:
+
+```bash
+cd dashboard
+npm run lint
+npm run build
+```
+
+## Latest Verification Results
+
+Last verified locally on the clean branch worktree:
+
+```text
+make onboard
+  PASS — renders LIVE OPS COCKPIT with 15 surfaces, 4 operator gates, 1 VPS candidate
+
+/Users/dhyana/dharma_swarm/.venv/bin/python scripts/runtime/live_ops_census.py --write
+  PASS — wrote /Users/dhyana/.dharma/ops/live_process_census.json
+
+/Users/dhyana/dharma_swarm/.venv/bin/python -m pytest tests/test_live_ops_census.py -q
+  PASS — 13 passed
+
+/Users/dhyana/dharma_swarm/.venv/bin/python -m pytest tests/test_control_surface.py::TestDashboardControlSurfacePage -q
+  PASS — 9 passed
+
+/Users/dhyana/dharma_swarm/.venv/bin/python -m pytest tests/test_control_surface.py::TestControlSurfaceAPI -q
+  PASS — 6 passed in 244.43s
+
+/Users/dhyana/dharma_swarm/.venv/bin/python -m pytest tests/test_control_surface.py -q
+  PASS — 91 passed in 884.70s
+
+/Users/dhyana/dharma_swarm/.venv/bin/python -m pytest tests/test_live_ops_census.py tests/test_agent_onboard.py tests/test_control_surface.py -q
+  PASS — 111 passed in 972.67s after restack onto current origin/main
+
+/Users/dhyana/dharma_swarm/.venv/bin/python -m pytest tests/test_agent_onboard.py::test_onboard_renders_required_sections -q
+  PASS — 1 passed
+
+/Users/dhyana/dharma_swarm/.venv/bin/python -m pytest tests/test_agent_onboard.py::test_onboard_does_not_write_to_owners -q
+  PASS — 1 passed
+
+/Users/dhyana/dharma_swarm/.venv/bin/python -m pytest tests/test_agent_onboard.py -q
+  PASS — 7 passed in 141.54s
+
+bun test dashboard/src/lib/dashboardNav.test.ts
+  PASS — 4 passed
+
+/Users/dhyana/dharma_swarm/.venv/bin/python scripts/docops/check_docops_integrity.py --write-auto-sections
+  PASS — refreshed DocOps auto inventory and updated governed count assertions
+
+direct control-surface projection smoke
+  PASS — live_ops_rows=15, has_live_ops_source=True, human_decision_rows=7
+
+curl http://127.0.0.1:3420/dashboard/cockpit
+  PASS — already-running dashboard route responds
+
+curl http://127.0.0.1:8420/api/control-surface/summary
+  STALE-RUNTIME — already-running API responds, but sources_consulted does not
+  include live_ops_census; do not use this process as branch evidence without
+  an operator-approved restart
+
+adapter extraction smoke
+  PASS — control_surface.py reduced to 1009 LOC; live ops adapter isolated in control_surface_live_ops.py
+
+git diff --check
+  PASS
+
+Context+/MCP static analysis
+  BLOCKED — contextplus/run_static_analysis returned Transport closed
+
+/Users/dhyana/dharma_swarm/.venv/bin/python -m ruff check <changed Python files>
+  BLOCKED — repo venv has no ruff module
+
+/Users/dhyana/dharma_swarm/.venv/bin/python -m mypy <changed Python files>
+  BLOCKED — repo venv has no mypy module
+```
+
+Dashboard dependency commands from the clean worktree:
+
+```text
+test -d dashboard/node_modules
+  node_modules_missing
+
+cd dashboard && npm run lint
+  FAIL — sh: eslint: command not found
+
+cd dashboard && npm run build
+  FAIL — sh: next: command not found
+```
+
+Those dashboard failures are dependency/bootstrap failures in the clean worktree,
+not cockpit source failures. Reusing the primary checkout by symlinking
+`node_modules` is not acceptable evidence because Turbopack rejects the symlink:
+
+```text
+TurbopackInternalError: Symlink node_modules is invalid, it points out of the filesystem root
+```
+
+The merge packet therefore treats static route tests and direct control-surface
+projection smoke checks as the available local evidence until the
+clean-worktree dashboard dependency bootstrap is fixed.
+
+## Read-Only Evidence
+
+The hardened tests assert:
+
+- `subprocess.run` is centralized inside `live_ops_census._run`.
+- The census does not use `shell=True`, `subprocess.Popen`, `subprocess.call`,
+  `os.system`, `os.kill`, or related process-control APIs.
+- `_run` call sites only invoke `git`, `pgrep`, `lsof`, or `tmux`.
+- `build_live_ops_census()` and CLI execution without `--write` do not create a
+  receipt file.
+- The only write calls in `scripts/runtime/live_ops_census.py` are inside the
+  explicit `write_census()` function.
+- The Control Surface live-ops adapter has no file write/delete/mkdir calls.
+- The census emits the full 15-surface contract with stable fields,
+  authority refs, operator-authority flags, and VPS flags.
+- Displayed `restart_command` and `stop_policy` strings are not executed during
+  census construction.
+- Control-surface rows preserve status, evidence, source refs,
+  `restart_command`, `stop_policy`, `vps_candidate`, and
+  `human_authority_required`.
+- `make onboard` renders the cockpit section and does not mutate owner files.
+- `/dashboard/cockpit` exists and aliases the control-surface page.
+- `OpsRunbookPanel` has no click handler, fetch call, browser command call, or
+  child-process execution token.
+- The Control Surface page and runbook panel do not import the pre-existing
+  `controlPlaneShell` helper.
+- The static dashboard nav and manifest both advertise Cockpit.
+
+## Risks
+
+- The dashboard build gate remains weaker than desired until clean-worktree
+  dashboard dependencies are installed or scripted.
+- Adversarial grep finds pre-existing command strings in
+  `dashboard/src/lib/controlPlaneShell.ts`; the new `/dashboard/cockpit` and
+  `OpsRunbookPanel` path does not import that shell.
+- The cockpit is only as fresh as the latest local receipt when the dashboard API
+  reads the cache.
+- The already-running local dashboard/API process appears stale relative to this
+  worktree: HTTP responds, but the live API summary did not include
+  `live_ops_census`. Source/tests/direct Python projection are the branch
+  evidence unless the operator approves a restart.
+- `/dashboard/cockpit` reuses the existing Control Surface route; this is good
+  for avoiding duplicate UI, but it means Control Surface regressions affect the
+  cockpit.
+- Process pattern matching can produce false positives or false negatives; the
+  census records evidence, not authority.
+- The branch imports NATS/TMUX/VentureCell authority docs from the previously
+  dirty lane. They are now explicit docs in this branch, but they should still
+  be reviewed as operator-facing doctrine.
+- `make onboard` still reports the existing missing correlation-spine
+  `A2ATaskReceipt` layer. This PR surfaces operating state; it does not close
+  that runtime-truth-spine gap.
+
+## Rollback Plan
+
+1. Remove `/dashboard/cockpit` route and the Cockpit nav/manifest entries.
+2. Remove `OpsRunbookPanel` from the Control Surface page.
+3. Remove `_live_ops_census_rows` from `build_control_surface_rows`.
+4. Remove `render_live_ops_cockpit()` from `agent_onboard.py`.
+5. Keep or delete `docs/ops/LIVE_OPS_COCKPIT.md` depending on whether the
+   operator wants the runbook retained as a plan.
+
+No database migration or external service rollback is required.
+
+## Operator Merge Checklist
+
+- Confirm the branch is still based on the intended `origin/main`.
+- Review that no UI code executes process-control commands.
+- Review the NATS/TMUX/VentureCell docs for doctrine fit.
+- Run the verification commands above.
+- Confirm no `node_modules` symlink, `.next`, `__pycache__`, or timestamp-only
+  generated evidence files are present.
+- Confirm generated receipt writes only to `~/.dharma/ops/live_process_census.json`.
+
+## Exactly Three Next Slices
+
+1. Add a clean-worktree dashboard dependency/bootstrap verifier so `npm run
+   build` can be run without symlink hacks.
+2. Add operator-approved action packets for start/stop/restart as explicit
+   proposals, while keeping the cockpit UI read-only.
+3. Add a VPS migration planner that uses the census to recommend AGNI, Forge,
+   CashClaw, Mike, and heavy local compute placement without executing moves.

--- a/docs/ops/TMUX_AGENT_SUBSTRATE.md
+++ b/docs/ops/TMUX_AGENT_SUBSTRATE.md
@@ -1,0 +1,117 @@
+# tmux Agent Substrate
+
+Role: active_spec. This file owns the terminal-persistence contract for long
+agent work on the local Mac and reachable VPS hosts.
+
+## Authority
+
+tmux is execution and health evidence, not identity authority. It keeps
+inspectable terminal lanes alive across SSH disconnects, laptop sleep, and
+operator context switches. It does not prove that an agent is registered,
+authorized, correct, or done.
+
+Identity remains owned by the agent registry surfaces. Work authority remains
+owned by leases, task receipts, A2A/NATS delivery contracts, and the active
+mission gate. Do not use tmux session existence as proof that an agent completed work.
+
+## Decision
+
+Dharma Swarm uses tmux as the default persistent terminal substrate for:
+
+- long-running local operator lanes;
+- inspectable overnight build lanes;
+- VPS-hosted agent shells reached over SSH;
+- terminal UI harnesses that need a real TTY;
+- emergency recovery from phone or another laptop.
+
+Raw terminal tabs are acceptable for short commands. Any unattended or
+multi-hour agent lane should run in a named tmux session or a stronger
+supervisor such as launchd/systemd with tmux available for inspection.
+
+## Local And VPS Topology
+
+The default local sessions are:
+
+| Session | Purpose |
+|---|---|
+| `dharma-control` | repo control lane: onboarding, governance checks, git state |
+| `dharma-agents` | safe shells for Hermes, Codex, A2A, and NATS observation |
+| `dharma-vps` | SSH coordination lanes for `agni` and `rushabdev` |
+
+VPS hosts should expose the same substrate shape when SSH is available:
+
+- `tmux` installed;
+- mouse support enabled;
+- history limit large enough for audit capture;
+- at least one `dharma-control` session available for status and recovery.
+
+## Session Contract
+
+Every durable tmux lane should satisfy these constraints:
+
+1. The session name is stable and human-readable.
+2. The working directory is explicit.
+3. A pane can be captured with `tmux capture-pane`.
+4. Long-running work writes a receipt, heartbeat, log, or task artifact outside
+   the pane.
+5. Expensive or authority-bearing agents are started by their canonical script,
+   not by ad hoc pasted prompts.
+6. A stopped pane is not treated as failed work unless the receipt or heartbeat
+   says so.
+
+## Agent Safety Rules
+
+- Do not paste API keys, Slack tokens, SSH keys, or other secrets into panes.
+- Do not use `tmux kill-server` as a cleanup primitive unless the operator
+  explicitly asks to destroy all sessions.
+- Do not run multiple modifying agents on the same dirty worktree without a
+  lease, branch, or worktree boundary.
+- Do not use permission-skipping agent flags as the default lane posture.
+- Do not treat a visible pane as a trusted witness. The witness is the receipt.
+
+## Status And Bootstrap
+
+Canonical commands:
+
+```bash
+make tmux-bootstrap
+make tmux-status
+make tmux-substrate-contract
+```
+
+`make tmux-bootstrap` is idempotent. It installs the Dharma Swarm tmux config
+block into `~/.tmux.conf` and creates the standard local sessions if tmux is
+available.
+
+`make tmux-status` reports installed version, config state, local sessions, and
+optional VPS probes. It must distinguish "tmux installed" from "agent work
+proved".
+
+## Unified Substrate Projection
+
+`make tmux-status` is the operator projection for the related live surfaces:
+
+- NATS owns live internal transport.
+- A2A receipts/verifier rows own cross-agent collaboration proof.
+- tmux owns inspectable persistent terminal lanes.
+
+These surfaces must be shown together without collapsing their authority. A
+tmux lane can be `READY` while A2A remains `PARTIAL`, and a NATS port can be
+open while live contact is still blocked until publish/consumer ack evidence
+exists. The status surface must show those differences directly.
+
+## Not Authority
+
+tmux is below A2A/NATS in the control hierarchy. It is a durable terminal
+container and inspection surface, not live-contact proof. It is not:
+
+- a broker;
+- not live identity authority or an agent registry;
+- not live completion proof;
+- not live task queue authority;
+- a replacement for wake receipts;
+- a replacement for launchd/systemd when a service must auto-restart.
+
+The correct claim is: "this lane is inspectable and persistent." The incorrect
+claim is: "this agent is alive and producing useful work because a tmux session
+exists."

--- a/scripts/governance/agent_onboard.py
+++ b/scripts/governance/agent_onboard.py
@@ -179,6 +179,35 @@ def render_live_ops() -> None:
             print("  NOTE: dashboard prose may lag reality. Trust git log + this command.")
 
 
+def render_live_ops_cockpit() -> None:
+    section("LIVE OPS COCKPIT — READ-ONLY OPERATIONS CONTROL")
+    runbook = REPO_ROOT / "docs/ops/LIVE_OPS_COCKPIT.md"
+    census_script = REPO_ROOT / "scripts/runtime/live_ops_census.py"
+    cockpit_page = REPO_ROOT / "dashboard/src/app/dashboard/cockpit/page.tsx"
+    receipt = Path.home() / ".dharma/ops/live_process_census.json"
+    nats_spec = REPO_ROOT / "docs/governance/NATS_SUBSTRATE_MASTER_SPEC.md"
+    tmux_spec = REPO_ROOT / "docs/ops/TMUX_AGENT_SUBSTRATE.md"
+
+    print(f"  Runbook       : {'present' if runbook.exists() else 'missing'} docs/ops/LIVE_OPS_COCKPIT.md")
+    print(f"  Census script : {'present' if census_script.exists() else 'missing'} scripts/runtime/live_ops_census.py")
+    print(f"  Dashboard     : {'present' if cockpit_page.exists() else 'missing'} /dashboard/cockpit")
+    print(f"  NATS spec     : {'present' if nats_spec.exists() else 'missing'} docs/governance/NATS_SUBSTRATE_MASTER_SPEC.md")
+    print(f"  tmux spec     : {'present' if tmux_spec.exists() else 'missing'} docs/ops/TMUX_AGENT_SUBSTRATE.md")
+    if receipt.exists():
+        try:
+            payload = json.loads(receipt.read_text(encoding="utf-8"))
+            summary = payload.get("summary", {})
+            print(f"  Receipt       : present {receipt}")
+            print(f"  Surfaces      : {summary.get('total', '?')} total; status={summary.get('by_status', {})}")
+            print(f"  Operator gates: {summary.get('human_authority_required', '?')} require John")
+            print(f"  VPS candidates: {summary.get('vps_candidates', '?')}")
+        except (OSError, json.JSONDecodeError):
+            print(f"  Receipt       : unreadable {receipt}")
+    else:
+        print("  Receipt       : missing — run python3 scripts/runtime/live_ops_census.py --write")
+    print("  Authority     : read-only; shows commands/policies but executes nothing")
+
+
 def render_manifest_health() -> None:
     section("SURFACE MANIFEST HEALTH (owner: ACTIVE_SURFACE_MANIFEST.yaml)")
     if not SURFACE_MANIFEST.exists():
@@ -778,6 +807,7 @@ def main() -> int:
     render_repo_state()
     render_active_track(evidence, track)
     render_live_ops()
+    render_live_ops_cockpit()
     render_manifest_health()
     render_broken_register()
     render_axioms()

--- a/scripts/runtime/live_ops_census.py
+++ b/scripts/runtime/live_ops_census.py
@@ -1,0 +1,695 @@
+#!/usr/bin/env python3
+"""Build a read-only live-ops census for the operator cockpit.
+
+This script is an observation surface, not a supervisor. It does not start,
+stop, restart, kill, message, or mutate live processes. It folds the existing
+governance owner files into one runtime census so the dashboard can show
+declared intent, observed state, evidence paths, and operator policy together.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+from collections import Counter
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_STATE_ROOT = Path(os.environ.get("DHARMA_STATE_DIR", "~/.dharma")).expanduser()
+DEFAULT_OUTPUT = DEFAULT_STATE_ROOT / "ops" / "live_process_census.json"
+
+
+AUTHORITY_SOURCES: tuple[dict[str, str], ...] = (
+    {
+        "id": "onboard_renderer",
+        "layer": "renderer",
+        "path": "scripts/governance/agent_onboard.py",
+        "role": "single-door render of current operating reality",
+    },
+    {
+        "id": "intent",
+        "layer": "intent",
+        "path": "docs/governance/ACTIVE_TRACK.yaml",
+        "role": "single owner of active build-track intent",
+    },
+    {
+        "id": "surface_manifest",
+        "layer": "surface",
+        "path": "ACTIVE_SURFACE_MANIFEST.yaml",
+        "role": "single owner of declared surfaces, state dirs, routers, and dashboard nav",
+    },
+    {
+        "id": "live_ops",
+        "layer": "state",
+        "path": "docs/state/LIVE_OPS_DASHBOARD.md",
+        "role": "plain-language live-state briefing; may be stale",
+    },
+    {
+        "id": "broken_register",
+        "layer": "state",
+        "path": "docs/state/BROKEN_REGISTER.md",
+        "role": "known breakage register",
+    },
+    {
+        "id": "sovereign_manifest",
+        "layer": "doctrine",
+        "path": "docs/governance/SOVEREIGN_MANIFEST.md",
+        "role": "architecture, axioms, and invariants",
+    },
+    {
+        "id": "anti_slop",
+        "layer": "governance",
+        "path": "docs/governance/ANTI_SLOP_RULES.md",
+        "role": "anti-duplication and no-new-substrate discipline",
+    },
+    {
+        "id": "canonical_doc_stack",
+        "layer": "governance",
+        "path": "docs/governance/CANONICAL_DOC_STACK.md",
+        "role": "doc ownership map and three-layer SSoT model",
+    },
+    {
+        "id": "nats_substrate",
+        "layer": "transport",
+        "path": "docs/governance/NATS_SUBSTRATE_MASTER_SPEC.md",
+        "role": "internal live-transport contract",
+    },
+    {
+        "id": "tmux_substrate",
+        "layer": "terminal",
+        "path": "docs/ops/TMUX_AGENT_SUBSTRATE.md",
+        "role": "terminal-persistence contract",
+    },
+)
+
+
+PROCESS_PATTERNS: dict[str, str] = {
+    "dharma_daemon": r"dharma_swarm\.dgc_cli orchestrate-live",
+    "dharma_cron": r"dharma_swarm\.dgc_cli cron daemon",
+    "nats": r"nats-server .*local-nats\.conf",
+    "nats_a2a_bridge": r"dharma_swarm\.operator_core\.nats_a2a_bridge",
+    "hermes_a2a": r"hermes_a2a_server\.py",
+    "hermes_llm_bridge": r"hermes_llm_bridge\.py",
+    "dashboard_api": r"uvicorn api\.main:app|api\.main:app",
+    "dashboard_web": r"next-server|next dev|node .*:3420",
+    "forge_hydra": r"codex_overnight_autopilot\.py|forge-reality-arena-master",
+    "revenue_gate": r"revenue_wedge_gate",
+    "cashclaw": r"cashclaw|CashClaw",
+    "agni": r"kaizen_agni|agni-trading|ssh agni",
+    "merge_master_mike": r"merge_master_mike|merge-master-mike",
+    "terminal_tui": r"dharma_terminal_tui|terminal_tui_interaction|terminal.*start",
+    "colima_openclaw": r"colima-openclaw-secure|qemu-system-aarch64 .*openclaw",
+}
+
+
+PORTS: dict[str, int] = {
+    "dharma_daemon": 7433,
+    "nats": 4222,
+    "nats_monitor": 8222,
+    "hermes_a2a": 8421,
+    "hermes_llm_bridge": 9421,
+    "dashboard_api": 8420,
+    "dashboard_web": 3420,
+}
+
+
+def utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _iso_mtime(path: Path) -> str:
+    if not path.exists():
+        return ""
+    try:
+        return datetime.fromtimestamp(path.stat().st_mtime, UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    except OSError:
+        return ""
+
+
+def _age_hours(iso_ts: str) -> float | None:
+    if not iso_ts:
+        return None
+    try:
+        ts = datetime.fromisoformat(iso_ts.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return round((datetime.now(UTC) - ts).total_seconds() / 3600, 2)
+
+
+def _run(args: list[str], *, cwd: Path | None = None, timeout: int = 5) -> tuple[int, str]:
+    try:
+        proc = subprocess.run(
+            args,
+            cwd=cwd,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return 127, str(exc)
+    return proc.returncode, proc.stdout.strip()
+
+
+def _authority_sources(repo_root: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for item in AUTHORITY_SOURCES:
+        path = repo_root / item["path"]
+        rows.append(
+            {
+                **item,
+                "exists": path.exists(),
+                "mtime": _iso_mtime(path),
+            }
+        )
+    return rows
+
+
+def _git_boundary(repo_root: Path) -> dict[str, Any]:
+    rc_head, head = _run(["git", "rev-parse", "--short", "HEAD"], cwd=repo_root)
+    rc_branch, branch = _run(["git", "branch", "--show-current"], cwd=repo_root)
+    rc_status, status = _run(["git", "status", "--short"], cwd=repo_root)
+    dirty_lines = [line for line in status.splitlines() if line.strip()] if rc_status == 0 else []
+    return {
+        "branch": branch if rc_branch == 0 else "",
+        "head": head if rc_head == 0 else "",
+        "dirty_count": len(dirty_lines),
+        "dirty_sample": dirty_lines[:20],
+    }
+
+
+def _parse_pgrep(output: str) -> list[dict[str, str]]:
+    rows: list[dict[str, str]] = []
+    for line in output.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        parts = line.split(maxsplit=1)
+        if len(parts) == 1:
+            rows.append({"pid": parts[0], "command": ""})
+        else:
+            rows.append({"pid": parts[0], "command": parts[1]})
+    return rows
+
+
+def _process_snapshot(run_probes: bool) -> dict[str, list[dict[str, str]]]:
+    if not run_probes:
+        return {key: [] for key in PROCESS_PATTERNS}
+    snapshot: dict[str, list[dict[str, str]]] = {}
+    for key, pattern in PROCESS_PATTERNS.items():
+        rc, out = _run(["pgrep", "-fl", pattern], timeout=4)
+        snapshot[key] = _parse_pgrep(out) if rc == 0 else []
+    return snapshot
+
+
+def _port_snapshot(run_probes: bool) -> dict[str, dict[str, Any]]:
+    if not run_probes:
+        return {key: {"port": port, "listening": False, "evidence": ""} for key, port in PORTS.items()}
+    snapshot: dict[str, dict[str, Any]] = {}
+    for key, port in PORTS.items():
+        rc, out = _run(["lsof", "-nP", f"-iTCP:{port}", "-sTCP:LISTEN"], timeout=4)
+        snapshot[key] = {
+            "port": port,
+            "listening": rc == 0 and bool(out.strip()),
+            "evidence": out.splitlines()[-1] if rc == 0 and out.splitlines() else "",
+        }
+    return snapshot
+
+
+def _tmux_sessions(run_probes: bool) -> list[str]:
+    if not run_probes:
+        return []
+    rc, out = _run(["tmux", "ls"], timeout=4)
+    if rc != 0:
+        return []
+    return [line.split(":", 1)[0] for line in out.splitlines() if ":" in line]
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _latest_path(root: Path, pattern: str) -> Path | None:
+    if not root.exists():
+        return None
+    paths = sorted(root.glob(pattern), key=lambda p: p.stat().st_mtime if p.exists() else 0, reverse=True)
+    return paths[0] if paths else None
+
+
+def _count_files(root: Path, pattern: str) -> int:
+    if not root.exists():
+        return 0
+    try:
+        return sum(1 for path in root.glob(pattern) if path.is_file())
+    except OSError:
+        return 0
+
+
+def _freshest_existing(paths: list[Path | None]) -> Path | None:
+    existing = [path for path in paths if path and path.exists()]
+    if not existing:
+        return None
+    return max(existing, key=lambda path: path.stat().st_mtime)
+
+
+def _surface(
+    *,
+    surface_id: str,
+    label: str,
+    surface_class: str,
+    status: str,
+    desired_state: str,
+    evidence: list[str],
+    authority_refs: list[str],
+    priority: str = "p1",
+    freshness: str = "",
+    process_key: str | None = None,
+    processes: dict[str, list[dict[str, str]]] | None = None,
+    ports: dict[str, dict[str, Any]] | None = None,
+    restart_command: str = "",
+    stop_policy: str = "",
+    next_action: str = "",
+    human_authority_required: bool = False,
+    vps_candidate: bool = False,
+    raw: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    proc_rows = processes.get(process_key, []) if process_key and processes else []
+    port = ports.get(process_key, {}) if process_key and ports else {}
+    return {
+        "id": surface_id,
+        "label": label,
+        "class": surface_class,
+        "status": status,
+        "desired_state": desired_state,
+        "priority": priority,
+        "freshness": freshness,
+        "age_hours": _age_hours(freshness) if freshness else None,
+        "pid_count": len(proc_rows),
+        "pids": [row["pid"] for row in proc_rows],
+        "port": port.get("port"),
+        "port_listening": port.get("listening", False),
+        "evidence": [item for item in evidence if item],
+        "authority_refs": authority_refs,
+        "restart_command": restart_command,
+        "stop_policy": stop_policy,
+        "next_action": next_action,
+        "human_authority_required": human_authority_required,
+        "vps_candidate": vps_candidate,
+        "raw": raw or {},
+    }
+
+
+def _live_if_process_or_port(process_key: str, processes: dict[str, list[dict[str, str]]], ports: dict[str, dict[str, Any]]) -> str:
+    return "live" if processes.get(process_key) or ports.get(process_key, {}).get("listening") else "stopped"
+
+
+def build_live_ops_census(
+    *,
+    repo_root: Path | str = DEFAULT_REPO_ROOT,
+    state_root: Path | str = DEFAULT_STATE_ROOT,
+    run_probes: bool = True,
+    processes: dict[str, list[dict[str, str]]] | None = None,
+    ports: dict[str, dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Return the live-ops census as a pure data structure."""
+    root = Path(repo_root)
+    state = Path(state_root).expanduser()
+    processes = processes if processes is not None else _process_snapshot(run_probes)
+    ports = ports if ports is not None else _port_snapshot(run_probes)
+    tmux = _tmux_sessions(run_probes)
+
+    forge_heartbeat = state / "forge_reality_arena_master" / "codex_overnight_heartbeat.json"
+    forge_handoff = state / "forge_reality_arena_master" / "shared" / "codex_overnight_handoff.md"
+    forge_data = _read_json(forge_heartbeat)
+    forge_freshness = str(forge_data.get("ts") or _iso_mtime(forge_heartbeat))
+    forge_live = bool(processes.get("forge_hydra"))
+    forge_status = "live" if forge_live else "stopped" if forge_heartbeat.exists() else "unknown"
+
+    revenue_state = state / "state" / "revenue_wedge_last_state.json"
+    revenue_data = _read_json(revenue_state)
+    gate_decision = str(revenue_data.get("gauntlet_decision") or "unknown")
+    revenue_status = "blocked" if gate_decision == "HOLD" else _live_if_process_or_port("revenue_gate", processes, ports)
+
+    agni_json = state / "remote_nodes" / "agni" / "kaizen_agni_latest.json"
+    agni_md = state / "remote_nodes" / "agni" / "kaizen_agni_latest.md"
+    agni_data = _read_json(agni_json)
+    agni_freshness = str(agni_data.get("updated_at") or agni_data.get("ts") or _iso_mtime(agni_json))
+    agni_age = _age_hours(agni_freshness) if agni_freshness else None
+    agni_status = "live" if processes.get("agni") else "stale" if agni_age is not None and agni_age > 6 else "blocked" if agni_json.exists() else "unknown"
+
+    managed_tmux = {"dharma-control", "dharma-agents", "dharma-vps"}
+    tmux_missing = sorted(managed_tmux - set(tmux))
+    tmux_status = "live" if not tmux_missing and tmux else "stopped"
+
+    dashboard_live = (
+        ports.get("dashboard_api", {}).get("listening")
+        and ports.get("dashboard_web", {}).get("listening")
+    )
+
+    sources = _authority_sources(root)
+    source_refs = [item["path"] for item in sources if item.get("exists")]
+    a2a_root = state / "a2a_bus"
+    a2a_receipts_root = a2a_root / "receipts"
+    a2a_messages_root = a2a_root / "messages"
+    a2a_queue = a2a_root / "tasks" / "queue.jsonl"
+    latest_a2a_receipt = _latest_path(a2a_receipts_root, "**/*.json")
+    latest_a2a_message = _latest_path(a2a_messages_root, "*.json")
+    nats_receipts_root = state / "nats" / "receipts"
+    latest_nats_receipt = _latest_path(nats_receipts_root, "*.json")
+    nats_log = state / "nats" / "nats-server.log"
+    nats_live_receipt = a2a_root / "nats_live_receipt.json"
+    nats_contact_receipts = a2a_root / "nats_contact_receipts.jsonl"
+    nats_oz_receipts = a2a_root / "nats_oz_receipts.jsonl"
+    freshest_nats_evidence = _freshest_existing([
+        latest_nats_receipt,
+        nats_live_receipt,
+        nats_contact_receipts,
+        nats_oz_receipts,
+        nats_log,
+    ])
+
+    surfaces = [
+        _surface(
+            surface_id="substrate.dharma_daemon",
+            label="Dharma daemon",
+            surface_class="substrate",
+            status=_live_if_process_or_port("dharma_daemon", processes, ports),
+            desired_state="live",
+            evidence=["port:7433", "/Users/dhyana/.dharma/logs/swarm.log"],
+            authority_refs=["docs/state/LIVE_OPS_DASHBOARD.md", "ACTIVE_SURFACE_MANIFEST.yaml"],
+            priority="p0",
+            process_key="dharma_daemon",
+            processes=processes,
+            ports=ports,
+            restart_command="launchctl kickstart gui/$UID/com.dharma.swarm",
+            stop_policy="do-not-stop-before-travel",
+        ),
+        _surface(
+            surface_id="substrate.dharma_cron",
+            label="Dharma cron daemon",
+            surface_class="substrate",
+            status="live" if processes.get("dharma_cron") else "stopped",
+            desired_state="live",
+            evidence=["dharma_swarm.dgc_cli cron daemon"],
+            authority_refs=["scripts/governance/agent_onboard.py", "docs/governance/ACTIVE_TRACK.yaml"],
+            priority="p0",
+            process_key="dharma_cron",
+            processes=processes,
+            ports=ports,
+            restart_command="launchctl kickstart gui/$UID/com.dharma.cron-daemon",
+            stop_policy="do-not-stop-before-travel",
+        ),
+        _surface(
+            surface_id="transport.nats",
+            label="Local NATS JetStream",
+            surface_class="substrate",
+            status=_live_if_process_or_port("nats", processes, ports),
+            desired_state="live",
+            evidence=["127.0.0.1:4222", str(state / "nats" / "nats-server.log")],
+            authority_refs=["docs/governance/NATS_SUBSTRATE_MASTER_SPEC.md"],
+            priority="p0",
+            process_key="nats",
+            processes=processes,
+            ports=ports,
+            restart_command="make onboard  # verify; launcher is persistent layer owned",
+            stop_policy="do-not-stop-if-A2A-needed",
+        ),
+        _surface(
+            surface_id="transport.a2a_bridge",
+            label="NATS A2A bridge",
+            surface_class="substrate",
+            status="live" if processes.get("nats_a2a_bridge") else "stopped",
+            desired_state="live",
+            evidence=["dharma_swarm.operator_core.nats_a2a_bridge"],
+            authority_refs=["docs/governance/NATS_SUBSTRATE_MASTER_SPEC.md"],
+            priority="p0",
+            process_key="nats_a2a_bridge",
+            processes=processes,
+            ports=ports,
+            restart_command="make onboard  # verify persistent substrate",
+            stop_policy="do-not-stop-if-A2A-needed",
+        ),
+        _surface(
+            surface_id="evidence.a2a_mirrors",
+            label="A2A filesystem mirrors",
+            surface_class="evidence",
+            status="live" if latest_a2a_receipt or latest_a2a_message or a2a_queue.exists() else "unknown",
+            desired_state="evidence-mirror-not-authority",
+            evidence=[
+                str(a2a_receipts_root),
+                str(a2a_messages_root),
+                str(a2a_queue),
+                f"latest_receipt={latest_a2a_receipt}" if latest_a2a_receipt else "",
+                f"latest_message={latest_a2a_message}" if latest_a2a_message else "",
+            ],
+            authority_refs=["docs/governance/NATS_SUBSTRATE_MASTER_SPEC.md"],
+            priority="p1",
+            freshness=_iso_mtime(latest_a2a_receipt or latest_a2a_message or a2a_queue),
+            stop_policy="mirror-only; do not treat as live-contact authority",
+            next_action="inspect NATS ack receipts for live-contact proof",
+            raw={
+                "receipt_count": _count_files(a2a_receipts_root, "**/*.json"),
+                "message_count": _count_files(a2a_messages_root, "*.json"),
+                "queue_exists": a2a_queue.exists(),
+            },
+        ),
+        _surface(
+            surface_id="evidence.nats_receipts",
+            label="NATS receipts and logs",
+            surface_class="evidence",
+            status="live" if freshest_nats_evidence else "unknown",
+            desired_state="ack-receipt-evidence",
+            evidence=[
+                str(nats_receipts_root),
+                str(nats_log),
+                str(nats_live_receipt),
+                str(nats_contact_receipts),
+                str(nats_oz_receipts),
+                f"latest_receipt={latest_nats_receipt}" if latest_nats_receipt else "",
+            ],
+            authority_refs=["docs/governance/NATS_SUBSTRATE_MASTER_SPEC.md"],
+            priority="p0",
+            freshness=_iso_mtime(freshest_nats_evidence or nats_log),
+            stop_policy="receipt-only; NATS process lifecycle remains operator-controlled",
+            next_action="verify ack tier before claiming live contact",
+            raw={
+                "receipt_count": _count_files(nats_receipts_root, "*.json"),
+                "log_exists": nats_log.exists(),
+                "nats_live_receipt_exists": nats_live_receipt.exists(),
+                "nats_contact_receipts_exists": nats_contact_receipts.exists(),
+                "nats_oz_receipts_exists": nats_oz_receipts.exists(),
+            },
+        ),
+        _surface(
+            surface_id="external.hermes_a2a",
+            label="Hermes A2A server",
+            surface_class="substrate",
+            status=_live_if_process_or_port("hermes_a2a", processes, ports),
+            desired_state="live",
+            evidence=["127.0.0.1:8421", str(Path.home() / ".hermes" / "logs" / "a2a-server.log")],
+            authority_refs=["docs/governance/NATS_SUBSTRATE_MASTER_SPEC.md"],
+            priority="p1",
+            process_key="hermes_a2a",
+            processes=processes,
+            ports=ports,
+            restart_command="make onboard  # verify A2A readiness",
+            stop_policy="safe-to-stop-only-if-no-agent-contact-needed",
+        ),
+        _surface(
+            surface_id="dashboard.local",
+            label="Dashboard API and web",
+            surface_class="dashboard",
+            status="live" if dashboard_live else "stopped",
+            desired_state="live",
+            evidence=["127.0.0.1:8420", "127.0.0.1:3420", "scripts/dashboard_ctl.sh status"],
+            authority_refs=["ACTIVE_SURFACE_MANIFEST.yaml", "docs/governance/CANONICAL_DOC_STACK.md"],
+            priority="p0",
+            process_key="dashboard_api",
+            processes=processes,
+            ports=ports,
+            restart_command="bash scripts/dashboard_ctl.sh start",
+            stop_policy="safe-to-restart-for-dashboard-work",
+        ),
+        _surface(
+            surface_id="tmux.cockpit",
+            label="Canonical tmux cockpit",
+            surface_class="terminal",
+            status=tmux_status,
+            desired_state="live",
+            evidence=[f"sessions={','.join(tmux) if tmux else 'none'}"],
+            authority_refs=["docs/ops/TMUX_AGENT_SUBSTRATE.md"],
+            priority="p0",
+            restart_command="make tmux-bootstrap",
+            stop_policy="safe-to-recreate; tmux-is-not-truth",
+            next_action="bootstrap managed sessions" if tmux_missing else "",
+            raw={"sessions": tmux, "missing": tmux_missing},
+        ),
+        _surface(
+            surface_id="mission.forge_reality_arena",
+            label="Forge Reality Arena Hydra",
+            surface_class="mission",
+            status=forge_status,
+            desired_state="supervised",
+            evidence=[str(forge_heartbeat), str(forge_handoff)],
+            authority_refs=["docs/governance/ACTIVE_TRACK.yaml", "docs/ops/LIVE_OPS_COCKPIT.md"],
+            priority="p1",
+            freshness=forge_freshness,
+            process_key="forge_hydra",
+            processes=processes,
+            ports=ports,
+            restart_command="scripts/start_forge_hydra_long_run.sh",
+            stop_policy="restart-only-after-reading-latest-handoff",
+            next_action="read handoff before restart",
+            raw={"heartbeat": forge_data},
+        ),
+        _surface(
+            surface_id="revenue.cashclaw_gate",
+            label="Revenue / CashClaw gate",
+            surface_class="revenue",
+            status=revenue_status,
+            desired_state="blocked-until-operator-approval",
+            evidence=[str(revenue_state), "reports/revenue_wedge/first_cash_receipt_status.md"],
+            authority_refs=["docs/governance/ACTIVE_TRACK.yaml", "docs/governance/VENTURE_CELL_PORTFOLIO.yaml"],
+            priority="p0",
+            freshness=str(revenue_data.get("fire_ts") or _iso_mtime(revenue_state)),
+            process_key="revenue_gate",
+            processes=processes,
+            ports=ports,
+            restart_command="launchd loop revenue_wedge_gate",
+            stop_policy="monitor-only; no outreach or money without operator approval",
+            next_action="keep HOLD until explicit operator approval" if gate_decision == "HOLD" else "inspect gate state",
+            human_authority_required=True,
+            raw={"revenue_state": revenue_data},
+        ),
+        _surface(
+            surface_id="remote.agni",
+            label="AGNI remote watcher / trading",
+            surface_class="remote",
+            status=agni_status,
+            desired_state="remote-observed-or-blocked",
+            evidence=[str(agni_json), str(agni_md)],
+            authority_refs=["docs/ops/TMUX_AGENT_SUBSTRATE.md", "docs/governance/VENTURE_CELL_PORTFOLIO.yaml"],
+            priority="p0",
+            freshness=agni_freshness,
+            process_key="agni",
+            processes=processes,
+            ports=ports,
+            restart_command="ssh agni  # inspect remote receipts before launching anything",
+            stop_policy="no-real-money-without-operator-approval",
+            next_action="refresh remote receipts and feeds",
+            human_authority_required=True,
+            vps_candidate=True,
+            raw={"agni": agni_data},
+        ),
+        _surface(
+            surface_id="agent.merge_master_mike",
+            label="Merge Master Mike",
+            surface_class="mission",
+            status="live" if processes.get("merge_master_mike") else "stopped",
+            desired_state="operator-mediated",
+            evidence=["scripts/runtime/merge_master_mike_daemon.py"],
+            authority_refs=["docs/ops/PR_REVIEW_CONTROL.md", "docs/governance/COHERENCE_DELTA.md"],
+            priority="p1",
+            process_key="merge_master_mike",
+            processes=processes,
+            ports=ports,
+            restart_command="make mike-status && make mike-wake",
+            stop_policy="no-automerge-without-operator-authority",
+            next_action="restart only when PR queue triage is active",
+            human_authority_required=True,
+        ),
+        _surface(
+            surface_id="terminal.tui",
+            label="Terminal TUI",
+            surface_class="terminal",
+            status="live" if processes.get("terminal_tui") else "stopped",
+            desired_state="optional-cockpit",
+            evidence=["scripts/status_terminal_tui_tmux.sh", "scripts/runtime/terminal_tui_interaction_smoke.py"],
+            authority_refs=["docs/ops/TMUX_AGENT_SUBSTRATE.md", "specs/DGC_TERMINAL_ARCHITECTURE_v1.1.md"],
+            priority="p1",
+            process_key="terminal_tui",
+            processes=processes,
+            ports=ports,
+            restart_command="./scripts/start_terminal_tui_tmux.sh",
+            stop_policy="optional; dashboard cockpit is primary tonight",
+            next_action="restore only after dashboard truth lane is stable",
+        ),
+        _surface(
+            surface_id="load.colima_openclaw",
+            label="Colima / OpenClaw VM",
+            surface_class="heavy",
+            status="live" if processes.get("colima_openclaw") else "stopped",
+            desired_state="operator-choice",
+            evidence=["colima-openclaw-secure", "qemu-system-aarch64"],
+            authority_refs=["docs/ops/LIVE_OPS_COCKPIT.md"],
+            priority="p2",
+            process_key="colima_openclaw",
+            processes=processes,
+            ports=ports,
+            restart_command="colima start openclaw-secure",
+            stop_policy="safe-to-stop-if-not-using-openclaw",
+            next_action="stop for battery/flight if not needed",
+            human_authority_required=True,
+        ),
+    ]
+
+    counts = Counter(surface["status"] for surface in surfaces)
+    return {
+        "schema_version": "live_ops_census.v1",
+        "generated_at": utc_now(),
+        "repo_root": str(root),
+        "state_root": str(state),
+        "git": _git_boundary(root),
+        "authority_sources": sources,
+        "summary": {
+            "total": len(surfaces),
+            "by_status": dict(sorted(counts.items())),
+            "human_authority_required": sum(1 for item in surfaces if item["human_authority_required"]),
+            "vps_candidates": sum(1 for item in surfaces if item["vps_candidate"]),
+        },
+        "surfaces": surfaces,
+        "source_refs": source_refs,
+    }
+
+
+def write_census(payload: dict[str, Any], output: Path = DEFAULT_OUTPUT) -> Path:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return output
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Build the read-only live ops census.")
+    parser.add_argument("--repo-root", type=Path, default=DEFAULT_REPO_ROOT)
+    parser.add_argument("--state-root", type=Path, default=DEFAULT_STATE_ROOT)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--write", action="store_true", help="write the census JSON to --output")
+    parser.add_argument("--no-probes", action="store_true", help="skip process/port/tmux probes")
+    args = parser.parse_args()
+
+    payload = build_live_ops_census(
+        repo_root=args.repo_root,
+        state_root=args.state_root,
+        run_probes=not args.no_probes,
+    )
+    if args.write:
+        path = write_census(payload, args.output)
+        print(path)
+    else:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_agent_onboard.py
+++ b/tests/test_agent_onboard.py
@@ -54,6 +54,7 @@ def test_onboard_renders_required_sections():
         "DHARMA SWARM — AGENT ONBOARDING",
         "ACTIVE TRACK",
         "LIVE OPS SNAPSHOT",
+        "LIVE OPS COCKPIT",
         "SURFACE MANIFEST HEALTH",
         "BROKEN REGISTER",
         "LIVING AXIOMS",

--- a/tests/test_control_surface.py
+++ b/tests/test_control_surface.py
@@ -16,6 +16,7 @@ import yaml
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+import dharma_swarm.operator_core.control_surface as control_surface
 from dharma_swarm.operator_core.control_surface import (
     COHERENCE_STATES,
     AgentHandoffPrompt,
@@ -313,6 +314,26 @@ class TestManifestIsNotObservedTruth:
 
         assert overview.coherence_state == "bound"
         assert overview.observed_state == "live"
+
+    def test_build_rows_appends_live_ops_projection(self, monkeypatch, tmp_repo: Path) -> None:
+        sentinel = ControlSurfaceRow(
+            id="live_ops.test",
+            kind="fleet",
+            label="Live Ops Sentinel",
+            authority_role="observed_authority",
+            declared_state="live",
+            desired_state="live",
+            observed_state="live",
+            coherence_state="bound",
+            priority="p0",
+            owner_module="scripts/runtime/live_ops_census.py",
+            truth_owner="live_ops_census",
+        )
+
+        monkeypatch.setattr(control_surface, "_live_ops_census_rows", lambda _root: [sentinel])
+
+        rows = build_control_surface_rows(repo_root=tmp_repo)
+        assert any(row.id == "live_ops.test" for row in rows)
 
 
 # ---------------------------------------------------------------------------
@@ -762,6 +783,65 @@ class TestDashboardControlSurfacePage:
         page = repo_root / "dashboard" / "src" / "app" / "dashboard" / "control-surface" / "page.tsx"
         assert page.exists(), f"control-surface page missing: {page}"
 
+    def test_cockpit_page_file_exists(self) -> None:
+        repo_root = Path(__file__).resolve().parent.parent
+        page = repo_root / "dashboard" / "src" / "app" / "dashboard" / "cockpit" / "page.tsx"
+        assert page.exists(), f"cockpit page missing: {page}"
+
+    def test_cockpit_aliases_control_surface_page(self) -> None:
+        repo_root = Path(__file__).resolve().parent.parent
+        page = repo_root / "dashboard" / "src" / "app" / "dashboard" / "cockpit" / "page.tsx"
+        text = page.read_text(encoding="utf-8")
+        assert 'export { default } from "../control-surface/page";' in text
+
+    def test_control_surface_renders_ops_runbook_panel(self) -> None:
+        repo_root = Path(__file__).resolve().parent.parent
+        page = repo_root / "dashboard" / "src" / "app" / "dashboard" / "control-surface" / "page.tsx"
+        text = page.read_text(encoding="utf-8")
+        assert "OpsRunbookPanel" in text
+        assert 'from "@/components/cockpit/OpsRunbookPanel"' in text
+        assert "<OpsRunbookPanel rows={rows} selectedRow={selectedRow} />" in text
+
+    def test_control_surface_page_does_not_import_shell_control(self) -> None:
+        repo_root = Path(__file__).resolve().parent.parent
+        page = repo_root / "dashboard" / "src" / "app" / "dashboard" / "control-surface" / "page.tsx"
+        text = page.read_text(encoding="utf-8")
+        assert "controlPlaneShell" not in text
+        assert "runCommand" not in text
+        assert "executeCommand" not in text
+
+    def test_ops_runbook_panel_is_display_only(self) -> None:
+        repo_root = Path(__file__).resolve().parent.parent
+        panel = repo_root / "dashboard" / "src" / "components" / "cockpit" / "OpsRunbookPanel.tsx"
+        text = panel.read_text(encoding="utf-8")
+        forbidden_tokens = [
+            "onClick",
+            "fetch(",
+            "window.",
+            "navigator.",
+            "child_process",
+            "controlPlaneShell",
+            "runCommand",
+            "executeCommand",
+            "exec(",
+            "spawn(",
+            "tracking-",
+            "rounded-xl",
+        ]
+        for token in forbidden_tokens:
+            assert token not in text
+        assert "restartCommand" in text
+        assert "stopPolicy" in text
+        assert "<code" in text
+        assert "break-words" in text
+
+    def test_static_dashboard_nav_links_cockpit(self) -> None:
+        repo_root = Path(__file__).resolve().parent.parent
+        nav = repo_root / "dashboard" / "src" / "lib" / "dashboardNav.ts"
+        text = nav.read_text(encoding="utf-8")
+        assert 'label: "Cockpit"' in text
+        assert 'href: "/dashboard/cockpit"' in text
+
     def test_control_surface_in_manifest_nav(self) -> None:
         repo_root = Path(__file__).resolve().parent.parent
         manifest = load_active_surface_manifest(repo_root)
@@ -772,6 +852,15 @@ class TestDashboardControlSurfacePage:
         assert "Control Surface" in all_items, (
             "Control Surface not in manifest dashboard_nav_sections"
         )
+
+    def test_cockpit_in_manifest_nav(self) -> None:
+        repo_root = Path(__file__).resolve().parent.parent
+        manifest = load_active_surface_manifest(repo_root)
+        nav_sections = manifest.get("dashboard_nav_sections", [])
+        all_items: list[str] = []
+        for section in nav_sections:
+            all_items.extend(section.get("items", []))
+        assert "Cockpit" in all_items, "Cockpit not in manifest dashboard_nav_sections"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_live_ops_census.py
+++ b/tests/test_live_ops_census.py
@@ -1,0 +1,428 @@
+from __future__ import annotations
+
+import ast
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+from dharma_swarm.operator_core.control_surface import (
+    _rows_from_live_ops_census,
+    build_control_surface_summary,
+)
+from dharma_swarm.operator_core.control_surface_models import (
+    _build_human_decision_context,
+)
+import scripts.runtime.live_ops_census as live_ops_census
+from scripts.runtime.live_ops_census import AUTHORITY_SOURCES, build_live_ops_census
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _write(path: Path, content: str = "ok\n") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_live_ops_census_folds_in_canonical_sources(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    state = tmp_path / "state_root"
+    for source in AUTHORITY_SOURCES:
+        _write(repo / source["path"])
+    _write(
+        state / "state" / "revenue_wedge_last_state.json",
+        json.dumps(
+            {
+                "gauntlet_decision": "HOLD",
+                "human_approved_outreach": False,
+                "revenue_usd": 0,
+                "fire_ts": "2026-06-02T00:00:00Z",
+            }
+        ),
+    )
+    _write(
+        state / "forge_reality_arena_master" / "codex_overnight_heartbeat.json",
+        json.dumps({"ts": "2026-06-02T00:00:00Z", "status": "handoff"}),
+    )
+    _write(state / "a2a_bus" / "receipts" / "hermes" / "receipt_1.json", "{}")
+    _write(state / "a2a_bus" / "messages" / "message_1.json", "{}")
+    _write(state / "a2a_bus" / "tasks" / "queue.jsonl", "{}\n")
+    _write(state / "a2a_bus" / "nats_live_receipt.json", "{}")
+    _write(state / "a2a_bus" / "nats_contact_receipts.jsonl", "{}\n")
+    _write(state / "a2a_bus" / "nats_oz_receipts.jsonl", "{}\n")
+    _write(state / "nats" / "receipts" / "receipt_1.json", "{}")
+    _write(state / "nats" / "nats-server.log", "ready\n")
+
+    payload = build_live_ops_census(
+        repo_root=repo,
+        state_root=state,
+        run_probes=False,
+        processes={
+            "dharma_daemon": [{"pid": "101", "command": "dharma_swarm.dgc_cli orchestrate-live"}],
+            "nats": [{"pid": "102", "command": "nats-server local-nats.conf"}],
+        },
+        ports={
+            "dharma_daemon": {"port": 7433, "listening": True, "evidence": "daemon"},
+            "nats": {"port": 4222, "listening": True, "evidence": "nats"},
+            "dashboard_api": {"port": 8420, "listening": True, "evidence": "api"},
+            "dashboard_web": {"port": 3420, "listening": True, "evidence": "web"},
+        },
+    )
+
+    assert payload["schema_version"] == "live_ops_census.v1"
+    assert {source["path"] for source in payload["authority_sources"]} >= {
+        "ACTIVE_SURFACE_MANIFEST.yaml",
+        "docs/governance/ACTIVE_TRACK.yaml",
+        "docs/governance/SOVEREIGN_MANIFEST.md",
+        "docs/governance/ANTI_SLOP_RULES.md",
+        "docs/governance/NATS_SUBSTRATE_MASTER_SPEC.md",
+        "docs/ops/TMUX_AGENT_SUBSTRATE.md",
+    }
+    assert all(source["exists"] for source in payload["authority_sources"])
+
+    surfaces = {surface["id"]: surface for surface in payload["surfaces"]}
+    assert surfaces["substrate.dharma_daemon"]["status"] == "live"
+    assert surfaces["transport.nats"]["status"] == "live"
+    assert surfaces["evidence.a2a_mirrors"]["status"] == "live"
+    assert surfaces["evidence.a2a_mirrors"]["desired_state"] == "evidence-mirror-not-authority"
+    assert surfaces["evidence.nats_receipts"]["status"] == "live"
+    assert surfaces["evidence.nats_receipts"]["desired_state"] == "ack-receipt-evidence"
+    assert surfaces["evidence.nats_receipts"]["raw"]["nats_live_receipt_exists"] is True
+    assert surfaces["dashboard.local"]["status"] == "live"
+    assert surfaces["revenue.cashclaw_gate"]["status"] == "blocked"
+    assert surfaces["revenue.cashclaw_gate"]["human_authority_required"] is True
+
+
+def test_live_ops_census_surface_contract_is_complete(tmp_path: Path) -> None:
+    payload = build_live_ops_census(
+        repo_root=tmp_path,
+        state_root=tmp_path / "state",
+        run_probes=False,
+    )
+    surfaces = payload["surfaces"]
+    required = {
+        "id",
+        "label",
+        "class",
+        "status",
+        "desired_state",
+        "priority",
+        "evidence",
+        "authority_refs",
+        "restart_command",
+        "stop_policy",
+        "next_action",
+        "human_authority_required",
+        "vps_candidate",
+        "raw",
+    }
+
+    assert payload["summary"]["total"] == len(surfaces) == 15
+    for surface in surfaces:
+        assert required <= set(surface)
+        assert isinstance(surface["evidence"], list)
+        assert isinstance(surface["authority_refs"], list)
+        assert surface["authority_refs"], surface["id"]
+        assert isinstance(surface["restart_command"], str)
+        assert isinstance(surface["stop_policy"], str)
+        assert isinstance(surface["human_authority_required"], bool)
+        assert isinstance(surface["vps_candidate"], bool)
+
+    human_authority_ids = {
+        surface["id"]
+        for surface in surfaces
+        if surface["human_authority_required"]
+    }
+    assert {
+        "revenue.cashclaw_gate",
+        "remote.agni",
+        "agent.merge_master_mike",
+        "load.colima_openclaw",
+    } <= human_authority_ids
+    assert payload["summary"]["human_authority_required"] == len(human_authority_ids)
+
+
+def test_live_ops_census_projects_into_control_surface_rows(tmp_path: Path) -> None:
+    payload = {
+        "schema_version": "live_ops_census.v1",
+        "generated_at": "2026-06-02T00:00:00Z",
+        "surfaces": [
+            {
+                "id": "revenue.cashclaw_gate",
+                "label": "Revenue / CashClaw gate",
+                "class": "revenue",
+                "status": "blocked",
+                "desired_state": "blocked-until-operator-approval",
+                "priority": "p0",
+                "evidence": ["state/revenue_wedge_last_state.json"],
+                "authority_refs": ["docs/governance/ACTIVE_TRACK.yaml"],
+                "human_authority_required": True,
+                "vps_candidate": False,
+                "next_action": "keep HOLD until explicit operator approval",
+                "raw": {},
+            }
+        ],
+    }
+    _write(tmp_path / "docs" / "governance" / "ACTIVE_TRACK.yaml")
+
+    rows = _rows_from_live_ops_census(payload, tmp_path)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.id == "live_ops.revenue.cashclaw_gate"
+    assert row.kind == "fleet"
+    assert row.coherence_state == "drifted"
+    assert "human_authority_required" in row.gap_codes
+    assert any(ref.path == "docs/governance/ACTIVE_TRACK.yaml" for ref in row.source_refs)
+
+    ctx = _build_human_decision_context(row)
+    assert ctx.required is True
+    assert "operator authority" in ctx.why_now
+
+
+def test_live_ops_rows_preserve_operator_contract_fields(tmp_path: Path) -> None:
+    payload = {
+        "schema_version": "live_ops_census.v1",
+        "generated_at": "2026-06-02T00:00:00Z",
+        "surfaces": [
+            {
+                "id": "remote.agni",
+                "label": "AGNI remote watcher / trading",
+                "class": "remote",
+                "status": "stale",
+                "desired_state": "remote-observed-or-blocked",
+                "priority": "p0",
+                "evidence": ["remote_nodes/agni/kaizen_agni_latest.json"],
+                "authority_refs": ["docs/ops/TMUX_AGENT_SUBSTRATE.md"],
+                "human_authority_required": True,
+                "vps_candidate": True,
+                "next_action": "refresh remote receipts and feeds",
+                "restart_command": "ssh agni  # inspect remote receipts before launching anything",
+                "stop_policy": "no-real-money-without-operator-approval",
+                "raw": {"ack": "fixture"},
+            },
+            {
+                "id": "load.colima_openclaw",
+                "label": "Colima / OpenClaw VM",
+                "class": "heavy",
+                "status": "live",
+                "desired_state": "operator-choice",
+                "priority": "p2",
+                "evidence": ["colima-openclaw-secure"],
+                "authority_refs": ["docs/ops/LIVE_OPS_COCKPIT.md"],
+                "human_authority_required": True,
+                "vps_candidate": False,
+                "next_action": "stop for battery/flight if not needed",
+                "restart_command": "colima start openclaw-secure",
+                "stop_policy": "safe-to-stop-if-not-using-openclaw",
+                "raw": {},
+            },
+        ],
+    }
+    _write(tmp_path / "docs" / "ops" / "TMUX_AGENT_SUBSTRATE.md")
+    _write(tmp_path / "docs" / "ops" / "LIVE_OPS_COCKPIT.md")
+
+    rows = {row.id: row for row in _rows_from_live_ops_census(payload, tmp_path)}
+    agni = rows["live_ops.remote.agni"]
+    assert agni.observed_state == "stale"
+    assert "live_ops_status:stale" in agni.gap_codes
+    assert "live_ops_not_live" in agni.gap_codes
+    assert "human_authority_required" in agni.gap_codes
+    assert "vps_candidate" in agni.gap_codes
+    assert agni.raw["restart_command"].startswith("ssh agni")
+    assert agni.raw["stop_policy"] == "no-real-money-without-operator-approval"
+    assert any(ref.path == "docs/ops/TMUX_AGENT_SUBSTRATE.md" and ref.exists for ref in agni.source_refs)
+    assert any(ev.source == "remote_nodes/agni/kaizen_agni_latest.json" for ev in agni.evidence)
+
+    colima = rows["live_ops.load.colima_openclaw"]
+    assert colima.observed_state == "live"
+    assert "heavy_local_load" in colima.gap_codes
+    assert "human_authority_required" in colima.gap_codes
+    assert colima.raw["restart_command"] == "colima start openclaw-secure"
+    assert colima.raw["stop_policy"] == "safe-to-stop-if-not-using-openclaw"
+
+
+def test_control_surface_summary_names_live_ops_source() -> None:
+    summary = build_control_surface_summary(rows=[])
+    assert "live_ops_census" in summary["sources_consulted"]
+
+
+def test_build_live_ops_census_without_write_does_not_create_receipt(tmp_path: Path) -> None:
+    output = tmp_path / "state" / "ops" / "live_process_census.json"
+
+    payload = live_ops_census.build_live_ops_census(
+        repo_root=tmp_path,
+        state_root=tmp_path / "state",
+        run_probes=False,
+    )
+
+    assert payload["schema_version"] == "live_ops_census.v1"
+    assert not output.exists()
+
+
+def test_live_ops_census_cli_requires_write_flag_for_receipt(monkeypatch, capsys, tmp_path: Path) -> None:
+    output = tmp_path / "receipt.json"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "live_ops_census.py",
+            "--repo-root",
+            str(tmp_path),
+            "--state-root",
+            str(tmp_path / "state"),
+            "--output",
+            str(output),
+            "--no-probes",
+        ],
+    )
+
+    assert live_ops_census.main() == 0
+    assert not output.exists()
+    assert "live_ops_census.v1" in capsys.readouterr().out
+
+
+def test_control_surface_live_ops_adapter_does_not_write_receipts() -> None:
+    tree = ast.parse((REPO_ROOT / "dharma_swarm/operator_core/control_surface_live_ops.py").read_text())
+    write_calls: list[str] = []
+    forbidden_path_attrs = {
+        "chmod",
+        "mkdir",
+        "open",
+        "rename",
+        "replace",
+        "rmdir",
+        "touch",
+        "unlink",
+        "write_bytes",
+        "write_text",
+    }
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if isinstance(node.func, ast.Attribute) and node.func.attr in forbidden_path_attrs:
+            write_calls.append(node.func.attr)
+        if isinstance(node.func, ast.Name) and node.func.id in {"open", "write_census"}:
+            write_calls.append(node.func.id)
+    assert write_calls == []
+
+
+def test_live_ops_census_subprocess_is_centralized_in_run_helper() -> None:
+    tree = ast.parse((REPO_ROOT / "scripts/runtime/live_ops_census.py").read_text())
+    call_owners: list[str] = []
+    shell_true_locations: list[int] = []
+
+    class Visitor(ast.NodeVisitor):
+        def __init__(self) -> None:
+            self.stack: list[str] = []
+
+        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+            self.stack.append(node.name)
+            self.generic_visit(node)
+            self.stack.pop()
+
+        def visit_Call(self, node: ast.Call) -> None:
+            if (
+                isinstance(node.func, ast.Attribute)
+                and node.func.attr == "run"
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "subprocess"
+            ):
+                call_owners.append(self.stack[-1] if self.stack else "<module>")
+                for keyword in node.keywords:
+                    if keyword.arg == "shell" and isinstance(keyword.value, ast.Constant):
+                        if keyword.value.value is True:
+                            shell_true_locations.append(node.lineno)
+            self.generic_visit(node)
+
+    Visitor().visit(tree)
+    assert call_owners == ["_run"]
+    assert shell_true_locations == []
+
+
+def test_live_ops_census_writes_only_from_explicit_write_census_function() -> None:
+    tree = ast.parse((REPO_ROOT / "scripts/runtime/live_ops_census.py").read_text())
+    write_owners: list[str] = []
+
+    class Visitor(ast.NodeVisitor):
+        def __init__(self) -> None:
+            self.stack: list[str] = []
+
+        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+            self.stack.append(node.name)
+            self.generic_visit(node)
+            self.stack.pop()
+
+        def visit_Call(self, node: ast.Call) -> None:
+            if isinstance(node.func, ast.Attribute) and node.func.attr in {"mkdir", "write_text", "write_bytes"}:
+                write_owners.append(self.stack[-1] if self.stack else "<module>")
+            self.generic_visit(node)
+
+    Visitor().visit(tree)
+    assert write_owners
+    assert set(write_owners) == {"write_census"}
+
+
+def test_live_ops_census_has_no_process_control_api_calls() -> None:
+    tree = ast.parse((REPO_ROOT / "scripts/runtime/live_ops_census.py").read_text())
+    forbidden_names = {"system", "popen", "spawn", "kill", "killpg", "execv", "execve"}
+    forbidden_subprocess_attrs = {"Popen", "call", "check_call", "check_output"}
+    observed: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if (
+            isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id in {"os", "subprocess"}
+        ):
+            if node.func.value.id == "subprocess" and node.func.attr in forbidden_subprocess_attrs:
+                observed.append(f"subprocess.{node.func.attr}")
+            if node.func.value.id == "os" and node.func.attr in forbidden_names:
+                observed.append(f"os.{node.func.attr}")
+    assert observed == []
+
+
+def test_live_ops_census_only_uses_read_only_probe_commands_static() -> None:
+    tree = ast.parse((REPO_ROOT / "scripts/runtime/live_ops_census.py").read_text())
+    allowed = {"git", "pgrep", "lsof", "tmux"}
+    observed: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not isinstance(node.func, ast.Name) or node.func.id != "_run":
+            continue
+        if not node.args or not isinstance(node.args[0], ast.List) or not node.args[0].elts:
+            continue
+        first = node.args[0].elts[0]
+        if isinstance(first, ast.Constant) and isinstance(first.value, str):
+            observed.add(first.value)
+    assert observed
+    assert observed <= allowed
+
+
+def test_live_ops_census_does_not_execute_displayed_policy_commands(monkeypatch, tmp_path: Path) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(args, **_kwargs):
+        calls.append(list(args))
+        return SimpleNamespace(returncode=1, stdout="")
+
+    monkeypatch.setattr(live_ops_census.subprocess, "run", fake_run)
+
+    payload = live_ops_census.build_live_ops_census(
+        repo_root=tmp_path,
+        state_root=tmp_path / "state",
+        run_probes=True,
+    )
+
+    allowed = {"git", "pgrep", "lsof", "tmux"}
+    observed = {call[0] for call in calls}
+    display_first_words = {
+        str(surface.get("restart_command", "")).split()[0]
+        for surface in payload["surfaces"]
+        if str(surface.get("restart_command", "")).strip()
+    }
+    assert observed
+    assert observed <= allowed
+    assert not (display_first_words - allowed) & observed


### PR DESCRIPTION
# Live Ops Cockpit v1 PR Packet

Status: PR-hardening packet for `codex/live-ops-cockpit-v1`.

## Purpose

Live Ops Cockpit v1 gives the operator one read-only cockpit for local swarm
operations after restart, travel, or multi-agent drift. The branch folds the
existing authority stack into a deterministic census receipt and projects that
receipt into the Control Surface dashboard.

This packet is the merge-facing evidence bundle. It is not a supervisor and
does not grant process-control authority.

## Coherence Delta

- Organ touched: Operator live-ops surface — `scripts/runtime/live_ops_census.py`,
  Control Surface projection, onboarding output, and read-only dashboard cockpit.
- Declared-vs-actual gap closed: The repo already declared NATS, tmux,
  venture-cell, and operator-gated runtime surfaces, but the operator had no
  single read-only restart/travel cockpit. This PR turns those declarations into
  a deterministic census receipt and dashboard/onboard projection without
  making any process-control action executable.
- Proof that re-reads the map: `make onboard`, `tests/test_live_ops_census.py`,
  `tests/test_control_surface.py`, `tests/test_agent_onboard.py`, and
  `dashboard/src/lib/dashboardNav.test.ts` re-read the manifest, canonical
  docs, census rows, dashboard nav, and operator gate surfaces.
- New drift introduced: A new cockpit docs packet and canonical registry entries
  add one operator-facing surface; known drift remains limited to clean-worktree
  dashboard dependency bootstrap and stale already-running local API evidence,
  both called out in Risks.

## Non-Goals

- Do not start, stop, restart, kill, or message live processes.
- Do not call live Palantir, external NATS, Temporal, paid LLMs, or GitHub merge
  APIs.
- Do not make filesystem mirrors source-of-truth.
- Do not make NATS workflow truth.
- Do not make tmux task truth.
- Do not authorize money, outreach, merges, process killing, VPS changes, or
  external actions without the operator.
- Do not add a new substrate or new agents.

## Changed Files

Core:

- `scripts/runtime/live_ops_census.py`
- `dharma_swarm/operator_core/control_surface.py`
- `dharma_swarm/operator_core/control_surface_live_ops.py`
- `dharma_swarm/operator_core/control_surface_models.py`
- `scripts/governance/agent_onboard.py`

Dashboard:

- `dashboard/src/app/dashboard/cockpit/page.tsx`
- `dashboard/src/app/dashboard/control-surface/page.tsx`
- `dashboard/src/components/cockpit/OpsRunbookPanel.tsx`
- `dashboard/src/components/cockpit/SystemTruthMatrix.tsx`
- `dashboard/src/lib/dashboardNav.ts`
- `dashboard/src/lib/dashboardNav.test.ts`

Docs and manifests:

- `ACTIVE_SURFACE_MANIFEST.yaml`
- `docs/architecture/NAVIGATION.md`
- `docs/docops/AUTO_INVENTORY.md`
- `docs/governance/CANONICAL_DOC_STACK.md`
- `docs/governance/NATS_SUBSTRATE_MASTER_SPEC.md`
- `docs/governance/SOVEREIGN_MANIFEST.md`
- `docs/governance/VENTURE_CELL_PORTFOLIO.yaml`
- `docs/ops/LIVE_OPS_COCKPIT.md`
- `docs/ops/LIVE_OPS_COCKPIT_PR_PACKET.md`
- `docs/ops/TMUX_AGENT_SUBSTRATE.md`

Tests:

- `tests/test_agent_onboard.py`
- `tests/test_control_surface.py`
- `tests/test_live_ops_census.py`

## Current Census Snapshot

Latest receipt:

```text
~/.dharma/ops/live_process_census.json
```

Current surfaces from the latest local receipt:

- Live: `substrate.dharma_daemon`, `transport.nats`,
  `evidence.a2a_mirrors`, `evidence.nats_receipts`,
  `external.hermes_a2a`, `dashboard.local`
- Stale: `remote.agni`
- Blocked: `revenue.cashclaw_gate`
- VPS candidate: `remote.agni`
- Operator authority required: `revenue.cashclaw_gate`, `remote.agni`,
  `agent.merge_master_mike`, `load.colima_openclaw`

These are observations from the local machine. They are not promises that a
different checkout, laptop state, or VPS state has the same status.

## Verification Commands

Required before PR handoff:

```bash
make onboard
/Users/dhyana/dharma_swarm/.venv/bin/python scripts/runtime/live_ops_census.py --write
/Users/dhyana/dharma_swarm/.venv/bin/python -m pytest tests/test_live_ops_census.py -q
/Users/dhyana/dharma_swarm/.venv/bin/python -m pytest tests/test_control_surface.py::TestDashboardControlSurfacePage -q
/Users/dhyana/dharma_swarm/.venv/bin/python -m pytest tests/test_agent_onboard.py::test_onboard_renders_required_sections -q
/Users/dhyana/dharma_swarm/.venv/bin/python -m pytest tests/test_agent_onboard.py::test_onboard_does_not_write_to_owners -q
/Users/dhyana/dharma_swarm/.venv/bin/python -m pytest tests/test_agent_onboard.py -q
bun test dashboard/src/lib/dashboardNav.test.ts
/Users/dhyana/dharma_swarm/.venv/bin/python -m pytest tests/test_control_surface.py -q
/Users/dhyana/dharma_swarm/.venv/bin/python -m pytest tests/test_live_ops_census.py tests/test_agent_onboard.py tests/test_control_surface.py -q
git diff --check
```

Dashboard verification:

```bash
cd dashboard
npm run lint
npm run build
```

## Latest Verification Results

Last verified locally on the clean branch worktree:

```text
make onboard
  PASS — renders LIVE OPS COCKPIT with 15 surfaces, 4 operator gates, 1 VPS candidate

/Users/dhyana/dharma_swarm/.venv/bin/python scripts/runtime/live_ops_census.py --write
  PASS — wrote /Users/dhyana/.dharma/ops/live_process_census.json

/Users/dhyana/dharma_swarm/.venv/bin/python -m pytest tests/test_live_ops_census.py -q
  PASS — 13 passed

/Users/dhyana/dharma_swarm/.venv/bin/python -m pytest tests/test_control_surface.py::TestDashboardControlSurfacePage -q
  PASS — 9 passed

/Users/dhyana/dharma_swarm/.venv/bin/python -m pytest tests/test_control_surface.py::TestControlSurfaceAPI -q
  PASS — 6 passed in 244.43s

/Users/dhyana/dharma_swarm/.venv/bin/python -m pytest tests/test_control_surface.py -q
  PASS — 91 passed in 884.70s

/Users/dhyana/dharma_swarm/.venv/bin/python -m pytest tests/test_live_ops_census.py tests/test_agent_onboard.py tests/test_control_surface.py -q
  PASS — 111 passed in 972.67s after restack onto current origin/main

/Users/dhyana/dharma_swarm/.venv/bin/python -m pytest tests/test_agent_onboard.py::test_onboard_renders_required_sections -q
  PASS — 1 passed

/Users/dhyana/dharma_swarm/.venv/bin/python -m pytest tests/test_agent_onboard.py::test_onboard_does_not_write_to_owners -q
  PASS — 1 passed

/Users/dhyana/dharma_swarm/.venv/bin/python -m pytest tests/test_agent_onboard.py -q
  PASS — 7 passed in 141.54s

bun test dashboard/src/lib/dashboardNav.test.ts
  PASS — 4 passed

/Users/dhyana/dharma_swarm/.venv/bin/python scripts/docops/check_docops_integrity.py --write-auto-sections
  PASS — refreshed DocOps auto inventory and updated governed count assertions

direct control-surface projection smoke
  PASS — live_ops_rows=15, has_live_ops_source=True, human_decision_rows=7

curl http://127.0.0.1:3420/dashboard/cockpit
  PASS — already-running dashboard route responds

curl http://127.0.0.1:8420/api/control-surface/summary
  STALE-RUNTIME — already-running API responds, but sources_consulted does not
  include live_ops_census; do not use this process as branch evidence without
  an operator-approved restart

adapter extraction smoke
  PASS — control_surface.py reduced to 1009 LOC; live ops adapter isolated in control_surface_live_ops.py

git diff --check
  PASS

Context+/MCP static analysis
  BLOCKED — contextplus/run_static_analysis returned Transport closed

/Users/dhyana/dharma_swarm/.venv/bin/python -m ruff check <changed Python files>
  BLOCKED — repo venv has no ruff module

/Users/dhyana/dharma_swarm/.venv/bin/python -m mypy <changed Python files>
  BLOCKED — repo venv has no mypy module
```

Dashboard dependency commands from the clean worktree:

```text
test -d dashboard/node_modules
  node_modules_missing

cd dashboard && npm run lint
  FAIL — sh: eslint: command not found

cd dashboard && npm run build
  FAIL — sh: next: command not found
```

Those dashboard failures are dependency/bootstrap failures in the clean worktree,
not cockpit source failures. Reusing the primary checkout by symlinking
`node_modules` is not acceptable evidence because Turbopack rejects the symlink:

```text
TurbopackInternalError: Symlink node_modules is invalid, it points out of the filesystem root
```

The merge packet therefore treats static route tests and direct control-surface
projection smoke checks as the available local evidence until the
clean-worktree dashboard dependency bootstrap is fixed.

## Read-Only Evidence

The hardened tests assert:

- `subprocess.run` is centralized inside `live_ops_census._run`.
- The census does not use `shell=True`, `subprocess.Popen`, `subprocess.call`,
  `os.system`, `os.kill`, or related process-control APIs.
- `_run` call sites only invoke `git`, `pgrep`, `lsof`, or `tmux`.
- `build_live_ops_census()` and CLI execution without `--write` do not create a
  receipt file.
- The only write calls in `scripts/runtime/live_ops_census.py` are inside the
  explicit `write_census()` function.
- The Control Surface live-ops adapter has no file write/delete/mkdir calls.
- The census emits the full 15-surface contract with stable fields,
  authority refs, operator-authority flags, and VPS flags.
- Displayed `restart_command` and `stop_policy` strings are not executed during
  census construction.
- Control-surface rows preserve status, evidence, source refs,
  `restart_command`, `stop_policy`, `vps_candidate`, and
  `human_authority_required`.
- `make onboard` renders the cockpit section and does not mutate owner files.
- `/dashboard/cockpit` exists and aliases the control-surface page.
- `OpsRunbookPanel` has no click handler, fetch call, browser command call, or
  child-process execution token.
- The Control Surface page and runbook panel do not import the pre-existing
  `controlPlaneShell` helper.
- The static dashboard nav and manifest both advertise Cockpit.

## Risks

- The dashboard build gate remains weaker than desired until clean-worktree
  dashboard dependencies are installed or scripted.
- Adversarial grep finds pre-existing command strings in
  `dashboard/src/lib/controlPlaneShell.ts`; the new `/dashboard/cockpit` and
  `OpsRunbookPanel` path does not import that shell.
- The cockpit is only as fresh as the latest local receipt when the dashboard API
  reads the cache.
- The already-running local dashboard/API process appears stale relative to this
  worktree: HTTP responds, but the live API summary did not include
  `live_ops_census`. Source/tests/direct Python projection are the branch
  evidence unless the operator approves a restart.
- `/dashboard/cockpit` reuses the existing Control Surface route; this is good
  for avoiding duplicate UI, but it means Control Surface regressions affect the
  cockpit.
- Process pattern matching can produce false positives or false negatives; the
  census records evidence, not authority.
- The branch imports NATS/TMUX/VentureCell authority docs from the previously
  dirty lane. They are now explicit docs in this branch, but they should still
  be reviewed as operator-facing doctrine.
- `make onboard` still reports the existing missing correlation-spine
  `A2ATaskReceipt` layer. This PR surfaces operating state; it does not close
  that runtime-truth-spine gap.

## Rollback Plan

1. Remove `/dashboard/cockpit` route and the Cockpit nav/manifest entries.
2. Remove `OpsRunbookPanel` from the Control Surface page.
3. Remove `_live_ops_census_rows` from `build_control_surface_rows`.
4. Remove `render_live_ops_cockpit()` from `agent_onboard.py`.
5. Keep or delete `docs/ops/LIVE_OPS_COCKPIT.md` depending on whether the
   operator wants the runbook retained as a plan.

No database migration or external service rollback is required.

## Operator Merge Checklist

- Confirm the branch is still based on the intended `origin/main`.
- Review that no UI code executes process-control commands.
- Review the NATS/TMUX/VentureCell docs for doctrine fit.
- Run the verification commands above.
- Confirm no `node_modules` symlink, `.next`, `__pycache__`, or timestamp-only
  generated evidence files are present.
- Confirm generated receipt writes only to `~/.dharma/ops/live_process_census.json`.

## Exactly Three Next Slices

1. Add a clean-worktree dashboard dependency/bootstrap verifier so `npm run
   build` can be run without symlink hacks.
2. Add operator-approved action packets for start/stop/restart as explicit
   proposals, while keeping the cockpit UI read-only.
3. Add a VPS migration planner that uses the census to recommend AGNI, Forge,
   CashClaw, Mike, and heavy local compute placement without executing moves.
