### PR TITLE
Pin Merge Master Mike workflow actions

### DIFF
--- a/.github/workflows/codex-mention-router.yml
+++ b/.github/workflows/codex-mention-router.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false

--- a/.github/workflows/merge-master-mike-backlog.yml
+++ b/.github/workflows/merge-master-mike-backlog.yml
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
@@ -130,7 +130,7 @@ jobs:
 
       - name: Upload Mike receipts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: merge-master-mike-pr-review
           path: ${{ runner.temp }}/dharma-pr-review


### PR DESCRIPTION
## Summary
- pin actions/checkout and actions/upload-artifact in the Merge Master Mike workflows to full commit SHAs
- unblock the repository policy requiring pinned third-party actions

## Coherence Delta
- Organ touched: .github/workflows/codex-mention-router.yml and .github/workflows/merge-master-mike-backlog.yml.
- Declared-vs-actual gap closed: the live backlog workflow failed at runner setup because actions were referenced by floating v4 tags; this pins them to full commit SHAs.
- Proof that re-reads the map: workflow YAML parsed locally, search found no remaining actions/*@vN refs in the two Mike workflows, and commit hooks passed.
- New drift introduced: no runtime authority change; this is a workflow supply-chain pinning fix only.

## Verification
- workflow YAML parse for both Mike workflows
- rg check for floating actions refs in both Mike workflows
- pre-commit hooks during commit: test hygiene, contract tests, uplift guards, docops, gitleaks, semgrep, whitespace, YAML