### PR TITLE
Bound Merge Master Mike A2A publish deadline

### DIFF
--- a/.github/workflows/merge-master-mike-backlog.yml
+++ b/.github/workflows/merge-master-mike-backlog.yml
@@ -115,7 +115,7 @@ jobs:
             args+=(--nats-required)
           fi
           set +e
-          python3 scripts/runtime/pr_merge_control.py "${args[@]}"
+          python3 -u scripts/runtime/pr_merge_control.py "${args[@]}"
           exit_code="$?"
           set -e
           latest="$(find "${state_root}/mike_fanout" -name summary.md -type f | sort | tail -1 || true)"

--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -10,7 +10,7 @@ Do not hand-edit the generated block.
 | Top-level Dharma Python modules | 389 |
 | Dharma Python LOC | 281,387 |
 | Test files | 625 |
-| Test function occurrences | 10,791 |
+| Test function occurrences | 10,792 |
 | Markdown files | 771 |
 | Markdown total lines | 193,180 |
 | Bridge files | 24 |

--- a/docs/governance/SOVEREIGN_MANIFEST.md
+++ b/docs/governance/SOVEREIGN_MANIFEST.md
@@ -129,7 +129,7 @@ These are the ground-truth metrics. All other documents citing different numbers
 | Top-level (flat) modules | **389 (59.0%)** | find dharma_swarm -maxdepth 1 -name "*.py" -type f |
 | Total Python LOC | **281,387** | wc -l across dharma_swarm Python modules |
 | Test files | **625** | find tests -name "*.py" -type f |
-| Test functions | **10,791 `def test_` occurrences under tests/** | rg "def test_" tests |
+| Test functions | **10,792 `def test_` occurrences under tests/** | rg "def test_" tests |
 | Tests collected (pytest) | **Needs write-permitted refresh** | not run during this DocOps count pass |
 | Collection errors | **Historical: 16 on 2026-04-04** | refresh before relying on this count |
 | Markdown files | **771** | find . -name "*.md" -type f |

--- a/scripts/runtime/pr_merge_control.py
+++ b/scripts/runtime/pr_merge_control.py
@@ -1622,12 +1622,24 @@ async def _publish_a2a_messages_async(
         await nc.close()
 
 
+async def _publish_a2a_messages_with_deadline(
+    config: NATSConfig,
+    messages: list[dict[str, Any]],
+    timeout_s: float,
+) -> list[dict[str, Any]]:
+    overall_timeout_s = timeout_s * max(len(messages) + 2, 2)
+    return await asyncio.wait_for(
+        _publish_a2a_messages_async(config, messages, timeout_s),
+        timeout=overall_timeout_s,
+    )
+
+
 def default_a2a_nats_publisher(
     config: NATSConfig,
     messages: list[dict[str, Any]],
     timeout_s: float,
 ) -> list[dict[str, Any]]:
-    return asyncio.run(_publish_a2a_messages_async(config, messages, timeout_s))
+    return asyncio.run(_publish_a2a_messages_with_deadline(config, messages, timeout_s))
 
 
 A2ANatsPublisher = Callable[[NATSConfig, list[dict[str, Any]], float], list[dict[str, Any]]]

--- a/tests/test_pr_merge_control.py
+++ b/tests/test_pr_merge_control.py
@@ -1,6 +1,9 @@
 import argparse
+import asyncio
 import sys
+import time
 
+import pytest
 from scripts.runtime import pr_merge_control as prc
 
 
@@ -372,6 +375,26 @@ def test_publish_a2a_fanout_session_records_verified_acks_without_secret(tmp_pat
     assert receipt["code"] == "NATS_ACK_VERIFIED"
     assert len(receipt["acks"]) == 2
     assert "super-secret" not in str(receipt)
+
+
+def test_a2a_publisher_deadline_bounds_slow_publish(monkeypatch):
+    async def slow_publish(_config, _messages, _timeout_s):
+        await asyncio.sleep(0.2)
+        return []
+
+    monkeypatch.setattr(prc, "_publish_a2a_messages_async", slow_publish)
+    started = time.monotonic()
+
+    with pytest.raises(asyncio.TimeoutError):
+        asyncio.run(
+            prc._publish_a2a_messages_with_deadline(
+                prc.NATSConfig(endpoint="nats://example.invalid", user="agent", credential="credential", missing=()),
+                [{"subject": "dharma.a2a.fleet", "payload": {}}],
+                timeout_s=0.01,
+            )
+        )
+
+    assert time.monotonic() - started < 0.2
 
 
 def test_render_fanout_markdown_states_no_external_authority():


### PR DESCRIPTION
## Summary
- wrap the A2A NATS publisher in an overall async deadline based on message count and nats timeout
- run the backlog workflow Python command unbuffered for better GitHub Actions logs
- add a regression test for slow publisher timeout handling

## Coherence Delta
- Organ touched: scripts/runtime/pr_merge_control.py, .github/workflows/merge-master-mike-backlog.yml, and PR-control tests.
- Declared-vs-actual gap closed: the live packet-only workflow created a packet and gate but hung during A2A publish until job timeout; the publisher now has a bounded overall deadline and the workflow emits unbuffered logs.
- Proof that re-reads the map: focused pytest passed, Python compile passed, workflow YAML parsed, NATS-missing smoke still fails closed, docops integrity passed, and commit hooks passed.
- New drift introduced: no merge-authority expansion; this only bounds A2A publish behavior and improves logs.

## Verification
- pytest -q tests/test_pr_merge_control.py tests/test_merge_master_mike_daemon.py
- python3 -m py_compile scripts/runtime/pr_merge_control.py scripts/runtime/merge_master_mike_daemon.py
- workflow YAML parse for merge-master-mike-backlog
- NATS-missing smoke: exit 3 with NATS_SECRETS_MISSING
- make docops-integrity
- pre-commit hooks during commit