### PR TITLE
Install aiohttp for Merge Master Mike NATS websocket

### DIFF
--- a/.github/workflows/merge-master-mike-backlog.yml
+++ b/.github/workflows/merge-master-mike-backlog.yml
@@ -75,7 +75,7 @@ jobs:
           persist-credentials: false
 
       - name: Install NATS client
-        run: python3 -m pip install 'nats-py>=2.9'
+        run: python3 -m pip install 'nats-py>=2.9' 'aiohttp>=3.9'
 
       - name: Run Merge Master Mike backlog fanout
         env:


### PR DESCRIPTION
## Summary
- install aiohttp alongside nats-py in the Merge Master Mike backlog workflow
- unblocks WebSocket NATS transport for the configured DEVIN_NATS_URL

## Coherence Delta
- Organ touched: .github/workflows/merge-master-mike-backlog.yml.
- Declared-vs-actual gap closed: the live packet-only workflow reached A2A publish and failed because nats-py could not import aiohttp WebSocket transport; the workflow now installs the required transport dependency.
- Proof that re-reads the map: live run 26960095344 selected PR #373, created packet/gate, wrote receipts, and failed with ImportError asking to install aiohttp; local workflow YAML parse passed and commit hooks passed.
- New drift introduced: no authority or gate behavior change; dependency install only.

## Verification
- workflow YAML parse for merge-master-mike-backlog
- pre-commit hooks during commit