### PR TITLE
fix: trust private CA for Mike NATS fanout

### DIFF
--- a/.github/workflows/merge-master-mike-backlog.yml
+++ b/.github/workflows/merge-master-mike-backlog.yml
@@ -83,6 +83,8 @@ jobs:
           DEVIN_NATS_URL: ${{ secrets.DEVIN_NATS_URL }}
           DEVIN_NATS_USER: ${{ secrets.DEVIN_NATS_USER }}
           DEVIN_NATS_PW: ${{ secrets.DEVIN_NATS_PW }}
+          DEVIN_NATS_CA_PEM: ${{ secrets.DEVIN_NATS_CA_PEM }}
+          DEVIN_NATS_TLS_HOSTNAME: ${{ vars.DEVIN_NATS_TLS_HOSTNAME || secrets.DEVIN_NATS_TLS_HOSTNAME }}
           MODE: ${{ inputs.mode }}
           MAX_PRS: ${{ inputs.max_prs }}
           LIMIT: ${{ inputs.limit }}

--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -10,9 +10,9 @@ Do not hand-edit the generated block.
 | Top-level Dharma Python modules | 389 |
 | Dharma Python LOC | 281,387 |
 | Test files | 625 |
-| Test function occurrences | 10,792 |
+| Test function occurrences | 10,794 |
 | Markdown files | 771 |
-| Markdown total lines | 193,180 |
+| Markdown total lines | 193,194 |
 | Bridge files | 24 |
 | Adapter files | 21 |
 | Orchestrator files | 4 |

--- a/docs/governance/SOVEREIGN_MANIFEST.md
+++ b/docs/governance/SOVEREIGN_MANIFEST.md
@@ -129,11 +129,11 @@ These are the ground-truth metrics. All other documents citing different numbers
 | Top-level (flat) modules | **389 (59.0%)** | find dharma_swarm -maxdepth 1 -name "*.py" -type f |
 | Total Python LOC | **281,387** | wc -l across dharma_swarm Python modules |
 | Test files | **625** | find tests -name "*.py" -type f |
-| Test functions | **10,792 `def test_` occurrences under tests/** | rg "def test_" tests |
+| Test functions | **10,794 `def test_` occurrences under tests/** | rg "def test_" tests |
 | Tests collected (pytest) | **Needs write-permitted refresh** | not run during this DocOps count pass |
 | Collection errors | **Historical: 16 on 2026-04-04** | refresh before relying on this count |
 | Markdown files | **771** | find . -name "*.md" -type f |
-| Markdown total lines | **193,180** | wc -l across all .md |
+| Markdown total lines | **193,194** | wc -l across all .md |
 | Bridge files | **24** | find dharma_swarm -name "*bridge*.py" |
 | Adapter files | **21 across 8 locations** | find dharma_swarm -type f \| rg -i "adapter" |
 | Orchestrator files | **4** (6,034 LOC total) | find dharma_swarm -name "*orchestrat*" |

--- a/docs/ops/DEVIN_NATS_PR_JANITOR_PLAYBOOK.md
+++ b/docs/ops/DEVIN_NATS_PR_JANITOR_PLAYBOOK.md
@@ -35,11 +35,22 @@ DEVIN_NATS_USER=devin
 DEVIN_NATS_PW=<stored secret>
 ```
 
+Optional TLS trust settings for GitHub-hosted runners:
+
+```text
+DEVIN_NATS_CA_PEM=<PEM for the CA that signed the AGNI NATS certificate>
+DEVIN_NATS_TLS_HOSTNAME=<certificate DNS name, only if different from URL host>
+```
+
+Use `DEVIN_NATS_CA_PEM` when AGNI presents a private or self-signed
+certificate. Do not disable certificate verification for the Mike lane; either
+install a public TLS certificate on AGNI or provide the CA PEM as a repo secret.
+
 Installed surfaces:
 
 - Devin Cloud org secrets: `DEVIN_NATS_URL`, `DEVIN_NATS_USER`, `DEVIN_NATS_PW`
 - GitHub Actions repo secrets: `DEVIN_NATS_URL`, `DEVIN_NATS_USER`,
-  `DEVIN_NATS_PW`
+  `DEVIN_NATS_PW`, and `DEVIN_NATS_CA_PEM` when AGNI uses a private CA
 - AGNI root credential file: `/root/.dharma/nats/devin_cred.txt`
 
 ## AGNI NATS Contract
@@ -220,7 +231,10 @@ The NATS receipt is fail-closed. If `DEVIN_NATS_URL`, `DEVIN_NATS_USER`, or
 `DEVIN_NATS_PW` is absent, the run records `NATS_SECRETS_MISSING` and exits
 non-zero when `nats_required=true`. If JetStream publish is not ack-verified,
 the run records `NATS_PUBLISH_FAILED` or `NATS_ACK_FAILED`; do not claim live
-fleet collaboration from that run.
+fleet collaboration from that run. If the failure is
+`CERTIFICATE_VERIFY_FAILED`, add `DEVIN_NATS_CA_PEM` as a GitHub Actions repo
+secret or move AGNI behind a publicly trusted TLS certificate, then rerun the
+backlog workflow.
 
 ## Fallbacks
 

--- a/scripts/runtime/pr_merge_control.py
+++ b/scripts/runtime/pr_merge_control.py
@@ -15,6 +15,7 @@ import os
 import re
 import signal
 import shlex
+import ssl
 import subprocess
 import sys
 import time
@@ -88,6 +89,8 @@ class NATSConfig:
     user: str
     credential: str
     missing: tuple[str, ...]
+    ca_pem: str = ""
+    tls_hostname: str = ""
 
 
 def utc_now() -> str:
@@ -1445,11 +1448,32 @@ def _nats_config(env: dict[str, str], *, require_devin_secrets: bool) -> NATSCon
         or env.get("NATS_PASSWORD")
         or ""
     )
+    ca_pem = env.get("DEVIN_NATS_CA_PEM") or env.get("DHARMA_NATS_CA_PEM") or env.get("NATS_CA_PEM") or ""
+    tls_hostname = (
+        env.get("DEVIN_NATS_TLS_HOSTNAME")
+        or env.get("DHARMA_NATS_TLS_HOSTNAME")
+        or env.get("NATS_TLS_HOSTNAME")
+        or ""
+    )
     if require_devin_secrets:
         missing = [name for name in NATS_REQUIRED_SECRET_NAMES if not env.get(name)]
     else:
         missing = [] if endpoint else ["DEVIN_NATS_URL or DHARMA_NATS_URL or NATS_URL"]
-    return NATSConfig(endpoint=endpoint, user=user, credential=auth_value, missing=tuple(missing))
+    return NATSConfig(
+        endpoint=endpoint,
+        user=user,
+        credential=auth_value,
+        missing=tuple(missing),
+        ca_pem=_normalize_ca_pem(ca_pem),
+        tls_hostname=tls_hostname.strip(),
+    )
+
+
+def _normalize_ca_pem(value: str) -> str:
+    normalized = value.strip()
+    if "\\n" in normalized and "\n" not in normalized:
+        normalized = normalized.replace("\\n", "\n")
+    return normalized + "\n" if normalized and not normalized.endswith("\n") else normalized
 
 
 def _redacted_nats_config(config: NATSConfig) -> dict[str, Any]:
@@ -1457,8 +1481,22 @@ def _redacted_nats_config(config: NATSConfig) -> dict[str, Any]:
         "endpoint": config.endpoint,
         "has_user": bool(config.user),
         "has_auth_credential": bool(config.credential),
+        "has_ca_pem": bool(config.ca_pem),
+        "tls_hostname": config.tls_hostname,
+        "tls_trust": "custom_ca_pem" if config.ca_pem else "system_ca_store",
         "missing": list(config.missing),
     }
+
+
+def _nats_tls_kwargs(config: NATSConfig) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {}
+    if config.ca_pem:
+        tls_context = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH)
+        tls_context.load_verify_locations(cadata=config.ca_pem)
+        kwargs["tls"] = tls_context
+    if config.tls_hostname:
+        kwargs["tls_hostname"] = config.tls_hostname
+    return kwargs
 
 
 def _a2a_target_for_subject(subject: str) -> str:
@@ -1601,6 +1639,7 @@ async def _publish_a2a_messages_async(
         connect_timeout=timeout_s,
         allow_reconnect=False,
         max_reconnect_attempts=0,
+        **_nats_tls_kwargs(config),
     )
     try:
         js = nc.jetstream()

--- a/tests/test_pr_merge_control.py
+++ b/tests/test_pr_merge_control.py
@@ -329,6 +329,60 @@ def test_publish_a2a_fanout_session_blocks_when_required_secrets_missing(tmp_pat
     assert set(receipt["config"]["missing"]) == set(prc.NATS_REQUIRED_SECRET_NAMES)
 
 
+def test_nats_config_records_ca_pem_without_leaking_secret_material():
+    config = prc._nats_config(
+        {
+            "DEVIN_NATS_URL": "wss://nats.example.test:8443",
+            "DEVIN_NATS_USER": "devin",
+            "DEVIN_NATS_PW": "super-secret",
+            "DEVIN_NATS_CA_PEM": "-----BEGIN CERTIFICATE-----\\nabc\\n-----END CERTIFICATE-----",
+            "DEVIN_NATS_TLS_HOSTNAME": "nats.agni.example",
+        },
+        require_devin_secrets=True,
+    )
+
+    redacted = prc._redacted_nats_config(config)
+
+    assert config.ca_pem == "-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----\n"
+    assert config.tls_hostname == "nats.agni.example"
+    assert redacted["has_ca_pem"] is True
+    assert redacted["tls_hostname"] == "nats.agni.example"
+    assert redacted["tls_trust"] == "custom_ca_pem"
+    assert "BEGIN CERTIFICATE" not in str(redacted)
+    assert "super-secret" not in str(redacted)
+
+
+def test_nats_tls_kwargs_loads_custom_ca_and_hostname(monkeypatch):
+    seen = {}
+
+    class FakeTLSContext:
+        def load_verify_locations(self, *, cadata):
+            seen["cadata"] = cadata
+
+    fake_context = FakeTLSContext()
+
+    def fake_create_default_context(*, purpose):
+        seen["purpose"] = purpose
+        return fake_context
+
+    monkeypatch.setattr(prc.ssl, "create_default_context", fake_create_default_context)
+    kwargs = prc._nats_tls_kwargs(
+        prc.NATSConfig(
+            endpoint="wss://nats.example.test:8443",
+            user="devin",
+            credential="credential",
+            missing=(),
+            ca_pem="-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----\n",
+            tls_hostname="nats.agni.example",
+        )
+    )
+
+    assert kwargs["tls"] is fake_context
+    assert kwargs["tls_hostname"] == "nats.agni.example"
+    assert seen["purpose"] == prc.ssl.Purpose.SERVER_AUTH
+    assert seen["cadata"] == "-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----\n"
+
+
 def test_publish_a2a_fanout_session_records_verified_acks_without_secret(tmp_path):
     seen = {}
 


### PR DESCRIPTION
## Summary

- add optional `DEVIN_NATS_CA_PEM` and `DEVIN_NATS_TLS_HOSTNAME` support for Merge Master Mike's A2A NATS publisher
- pass those values through the `merge-master-mike-backlog` GitHub Actions workflow
- keep NATS receipts redacted while recording whether custom CA trust was used
- document the self-signed/private CA path for AGNI NATS

## Why

The live backlog workflow can reach AGNI NATS over WebSocket, but GitHub-hosted runners reject the current self-signed TLS certificate with `CERTIFICATE_VERIFY_FAILED`. This keeps `nats_required=true` fail-closed while giving the runner a secure trust path.

## Coherence Delta

- Organ touched: GitHub-hosted Merge Master Mike backlog fanout and AGNI NATS trust configuration.
- Declared-vs-actual gap closed: Mike already had fail-closed NATS fanout, but live Actions runs could not verify JetStream acks against AGNI's private TLS certificate. This adds the missing secure CA trust path.
- Proof that re-reads the map: Verified the failed live run error, `nats-py` TLS context support, workflow env plumbing, redacted receipt output, focused tests, workflow YAML parse, DocOps integrity, and pre-commit hooks.
- New drift introduced: Adds optional CA and hostname inputs only; no merge policy, reviewer authority, branch protection, approval, or TLS-verification bypass is introduced.

## Verification

- `scripts/governance/run_pytest_with_repo_env.sh -q tests/test_pr_merge_control.py`
- `python3 -m py_compile scripts/runtime/pr_merge_control.py scripts/runtime/merge_master_mike_daemon.py`
- workflow YAML parse for `merge-master-mike-backlog.yml` and `codex-mention-router.yml`
- `make docops-integrity`
- pre-commit hooks: hygiene, contracts, uplift guards, DocOps, gitleaks, Semgrep, whitespace, YAML
