### PR TITLE
fix: use Mike NATS credentials for backlog fanout

### DIFF
--- a/.github/workflows/merge-master-mike-backlog.yml
+++ b/.github/workflows/merge-master-mike-backlog.yml
@@ -80,6 +80,11 @@ jobs:
       - name: Run Merge Master Mike backlog fanout
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MERGE_MASTER_MIKE_NATS_URL: ${{ secrets.MERGE_MASTER_MIKE_NATS_URL }}
+          MERGE_MASTER_MIKE_NATS_USER: ${{ secrets.MERGE_MASTER_MIKE_NATS_USER }}
+          MERGE_MASTER_MIKE_NATS_PW: ${{ secrets.MERGE_MASTER_MIKE_NATS_PW }}
+          MERGE_MASTER_MIKE_NATS_CA_PEM: ${{ secrets.MERGE_MASTER_MIKE_NATS_CA_PEM }}
+          MERGE_MASTER_MIKE_NATS_TLS_HOSTNAME: ${{ vars.MERGE_MASTER_MIKE_NATS_TLS_HOSTNAME || secrets.MERGE_MASTER_MIKE_NATS_TLS_HOSTNAME }}
           DEVIN_NATS_URL: ${{ secrets.DEVIN_NATS_URL }}
           DEVIN_NATS_USER: ${{ secrets.DEVIN_NATS_USER }}
           DEVIN_NATS_PW: ${{ secrets.DEVIN_NATS_PW }}

--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -10,9 +10,9 @@ Do not hand-edit the generated block.
 | Top-level Dharma Python modules | 389 |
 | Dharma Python LOC | 281,387 |
 | Test files | 625 |
-| Test function occurrences | 10,794 |
+| Test function occurrences | 10,796 |
 | Markdown files | 771 |
-| Markdown total lines | 193,194 |
+| Markdown total lines | 193,208 |
 | Bridge files | 24 |
 | Adapter files | 21 |
 | Orchestrator files | 4 |

--- a/docs/governance/SOVEREIGN_MANIFEST.md
+++ b/docs/governance/SOVEREIGN_MANIFEST.md
@@ -129,11 +129,11 @@ These are the ground-truth metrics. All other documents citing different numbers
 | Top-level (flat) modules | **389 (59.0%)** | find dharma_swarm -maxdepth 1 -name "*.py" -type f |
 | Total Python LOC | **281,387** | wc -l across dharma_swarm Python modules |
 | Test files | **625** | find tests -name "*.py" -type f |
-| Test functions | **10,794 `def test_` occurrences under tests/** | rg "def test_" tests |
+| Test functions | **10,796 `def test_` occurrences under tests/** | rg "def test_" tests |
 | Tests collected (pytest) | **Needs write-permitted refresh** | not run during this DocOps count pass |
 | Collection errors | **Historical: 16 on 2026-04-04** | refresh before relying on this count |
 | Markdown files | **771** | find . -name "*.md" -type f |
-| Markdown total lines | **193,194** | wc -l across all .md |
+| Markdown total lines | **193,208** | wc -l across all .md |
 | Bridge files | **24** | find dharma_swarm -name "*bridge*.py" |
 | Adapter files | **21 across 8 locations** | find dharma_swarm -type f \| rg -i "adapter" |
 | Orchestrator files | **4** (6,034 LOC total) | find dharma_swarm -name "*orchestrat*" |

--- a/docs/ops/DEVIN_NATS_PR_JANITOR_PLAYBOOK.md
+++ b/docs/ops/DEVIN_NATS_PR_JANITOR_PLAYBOOK.md
@@ -27,7 +27,15 @@ protected source, or bypass governance.
 Use secret storage. Do not paste credentials in PR comments, chat transcripts,
 docs, or committed files.
 
-Required secret names:
+Required AGNI NATS secret names for the GitHub-hosted Mike backlog workflow:
+
+```text
+MERGE_MASTER_MIKE_NATS_URL=wss://157.245.193.15:8443
+MERGE_MASTER_MIKE_NATS_USER=merge_master_mike
+MERGE_MASTER_MIKE_NATS_PW=<stored secret>
+```
+
+Compatibility fallback secret names for Devin-only lanes:
 
 ```text
 DEVIN_NATS_URL=wss://157.245.193.15:8443
@@ -38,20 +46,24 @@ DEVIN_NATS_PW=<stored secret>
 Optional TLS trust settings for GitHub-hosted runners:
 
 ```text
-DEVIN_NATS_CA_PEM=<PEM for the CA that signed the AGNI NATS certificate>
-DEVIN_NATS_TLS_HOSTNAME=<certificate DNS name, only if different from URL host>
+MERGE_MASTER_MIKE_NATS_CA_PEM=<PEM for the CA that signed the AGNI NATS certificate>
+MERGE_MASTER_MIKE_NATS_TLS_HOSTNAME=<certificate DNS name, only if different from URL host>
 ```
 
-Use `DEVIN_NATS_CA_PEM` when AGNI presents a private or self-signed
-certificate. Do not disable certificate verification for the Mike lane; either
-install a public TLS certificate on AGNI or provide the CA PEM as a repo secret.
+Use `MERGE_MASTER_MIKE_NATS_CA_PEM` when AGNI presents a private or self-signed
+certificate. The workflow also accepts `DEVIN_NATS_CA_PEM` as a fallback. Do not
+disable certificate verification for the Mike lane; either install a public TLS
+certificate on AGNI or provide the CA PEM as a repo secret.
 
 Installed surfaces:
 
 - Devin Cloud org secrets: `DEVIN_NATS_URL`, `DEVIN_NATS_USER`, `DEVIN_NATS_PW`
-- GitHub Actions repo secrets: `DEVIN_NATS_URL`, `DEVIN_NATS_USER`,
-  `DEVIN_NATS_PW`, and `DEVIN_NATS_CA_PEM` when AGNI uses a private CA
+- GitHub Actions repo secrets: `MERGE_MASTER_MIKE_NATS_URL`,
+  `MERGE_MASTER_MIKE_NATS_USER`, `MERGE_MASTER_MIKE_NATS_PW`, and
+  `DEVIN_NATS_CA_PEM` or `MERGE_MASTER_MIKE_NATS_CA_PEM` when AGNI uses a
+  private CA
 - AGNI root credential file: `/root/.dharma/nats/devin_cred.txt`
+- AGNI Mike credential file: `/root/.dharma/nats/merge_master_mike_cred.txt`
 
 ## AGNI NATS Contract
 
@@ -227,14 +239,16 @@ dharma.a2a.hermes
 dharma.a2a.perplexity
 ```
 
-The NATS receipt is fail-closed. If `DEVIN_NATS_URL`, `DEVIN_NATS_USER`, or
-`DEVIN_NATS_PW` is absent, the run records `NATS_SECRETS_MISSING` and exits
-non-zero when `nats_required=true`. If JetStream publish is not ack-verified,
-the run records `NATS_PUBLISH_FAILED` or `NATS_ACK_FAILED`; do not claim live
-fleet collaboration from that run. If the failure is
-`CERTIFICATE_VERIFY_FAILED`, add `DEVIN_NATS_CA_PEM` as a GitHub Actions repo
-secret or move AGNI behind a publicly trusted TLS certificate, then rerun the
-backlog workflow.
+The NATS receipt is fail-closed. If any `MERGE_MASTER_MIKE_NATS_*` secret is
+present, all three primary Mike secrets are required. If the Mike family is
+absent, the workflow falls back to the legacy `DEVIN_NATS_URL`,
+`DEVIN_NATS_USER`, and `DEVIN_NATS_PW` names. Missing required values record
+`NATS_SECRETS_MISSING` and exit non-zero when `nats_required=true`. If
+JetStream publish is not ack-verified, the run records `NATS_PUBLISH_FAILED` or
+`NATS_ACK_FAILED`; do not claim live fleet collaboration from that run. If the
+failure is `CERTIFICATE_VERIFY_FAILED`, add `MERGE_MASTER_MIKE_NATS_CA_PEM` or
+`DEVIN_NATS_CA_PEM` as a GitHub Actions repo secret, or move AGNI behind a
+publicly trusted TLS certificate, then rerun the backlog workflow.
 
 ## Fallbacks
 

--- a/scripts/runtime/pr_merge_control.py
+++ b/scripts/runtime/pr_merge_control.py
@@ -51,7 +51,13 @@ DEFAULT_A2A_NATS_SUBJECTS = (
     "dharma.a2a.perplexity",
 )
 DEFAULT_REQUIRED_REVIEWERS = ("codex", "claude")
-NATS_REQUIRED_SECRET_NAMES = ("DEVIN_NATS_URL", "DEVIN_NATS_USER", "DEVIN_NATS_PW")
+MERGE_MASTER_MIKE_NATS_SECRET_NAMES = (
+    "MERGE_MASTER_MIKE_NATS_URL",
+    "MERGE_MASTER_MIKE_NATS_USER",
+    "MERGE_MASTER_MIKE_NATS_PW",
+)
+DEVIN_NATS_SECRET_NAMES = ("DEVIN_NATS_URL", "DEVIN_NATS_USER", "DEVIN_NATS_PW")
+NATS_REQUIRED_SECRET_NAMES = DEVIN_NATS_SECRET_NAMES
 MERGE_MODES = ("off", "auto-when-clean")
 HOT_PATH_PATTERNS = (
     ".github/",
@@ -91,6 +97,7 @@ class NATSConfig:
     missing: tuple[str, ...]
     ca_pem: str = ""
     tls_hostname: str = ""
+    credential_family: str = "devin"
 
 
 def utc_now() -> str:
@@ -1438,27 +1445,51 @@ def required_reviewer_agents(args: argparse.Namespace) -> list[str]:
 
 
 def _nats_config(env: dict[str, str], *, require_devin_secrets: bool) -> NATSConfig:
-    endpoint = env.get("DEVIN_NATS_URL") or env.get("DHARMA_NATS_URL") or env.get("NATS_URL") or ""
-    user = env.get("DEVIN_NATS_USER") or env.get("DHARMA_NATS_USER") or env.get("NATS_USER") or ""
+    mike_present = any(env.get(name) for name in MERGE_MASTER_MIKE_NATS_SECRET_NAMES)
+    credential_family = "merge_master_mike" if mike_present else "devin"
+    endpoint = (
+        env.get("MERGE_MASTER_MIKE_NATS_URL")
+        or env.get("DEVIN_NATS_URL")
+        or env.get("DHARMA_NATS_URL")
+        or env.get("NATS_URL")
+        or ""
+    )
+    user = (
+        env.get("MERGE_MASTER_MIKE_NATS_USER")
+        or env.get("DEVIN_NATS_USER")
+        or env.get("DHARMA_NATS_USER")
+        or env.get("NATS_USER")
+        or ""
+    )
     auth_value = (
-        env.get("DEVIN_NATS_PW")
+        env.get("MERGE_MASTER_MIKE_NATS_PW")
+        or env.get("MERGE_MASTER_MIKE_NATS_PASSWORD")
+        or env.get("DEVIN_NATS_PW")
         or env.get("DEVIN_NATS_PASSWORD")
         or env.get("DHARMA_NATS_PW")
         or env.get("DHARMA_NATS_PASSWORD")
         or env.get("NATS_PASSWORD")
         or ""
     )
-    ca_pem = env.get("DEVIN_NATS_CA_PEM") or env.get("DHARMA_NATS_CA_PEM") or env.get("NATS_CA_PEM") or ""
+    ca_pem = (
+        env.get("MERGE_MASTER_MIKE_NATS_CA_PEM")
+        or env.get("DEVIN_NATS_CA_PEM")
+        or env.get("DHARMA_NATS_CA_PEM")
+        or env.get("NATS_CA_PEM")
+        or ""
+    )
     tls_hostname = (
-        env.get("DEVIN_NATS_TLS_HOSTNAME")
+        env.get("MERGE_MASTER_MIKE_NATS_TLS_HOSTNAME")
+        or env.get("DEVIN_NATS_TLS_HOSTNAME")
         or env.get("DHARMA_NATS_TLS_HOSTNAME")
         or env.get("NATS_TLS_HOSTNAME")
         or ""
     )
     if require_devin_secrets:
-        missing = [name for name in NATS_REQUIRED_SECRET_NAMES if not env.get(name)]
+        required_names = MERGE_MASTER_MIKE_NATS_SECRET_NAMES if mike_present else DEVIN_NATS_SECRET_NAMES
+        missing = [name for name in required_names if not env.get(name)]
     else:
-        missing = [] if endpoint else ["DEVIN_NATS_URL or DHARMA_NATS_URL or NATS_URL"]
+        missing = [] if endpoint else ["MERGE_MASTER_MIKE_NATS_URL or DEVIN_NATS_URL or DHARMA_NATS_URL or NATS_URL"]
     return NATSConfig(
         endpoint=endpoint,
         user=user,
@@ -1466,6 +1497,7 @@ def _nats_config(env: dict[str, str], *, require_devin_secrets: bool) -> NATSCon
         missing=tuple(missing),
         ca_pem=_normalize_ca_pem(ca_pem),
         tls_hostname=tls_hostname.strip(),
+        credential_family=credential_family,
     )
 
 
@@ -1484,6 +1516,7 @@ def _redacted_nats_config(config: NATSConfig) -> dict[str, Any]:
         "has_ca_pem": bool(config.ca_pem),
         "tls_hostname": config.tls_hostname,
         "tls_trust": "custom_ca_pem" if config.ca_pem else "system_ca_store",
+        "credential_family": config.credential_family,
         "missing": list(config.missing),
     }
 

--- a/tests/test_pr_merge_control.py
+++ b/tests/test_pr_merge_control.py
@@ -345,11 +345,51 @@ def test_nats_config_records_ca_pem_without_leaking_secret_material():
 
     assert config.ca_pem == "-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----\n"
     assert config.tls_hostname == "nats.agni.example"
+    assert config.credential_family == "devin"
     assert redacted["has_ca_pem"] is True
     assert redacted["tls_hostname"] == "nats.agni.example"
     assert redacted["tls_trust"] == "custom_ca_pem"
+    assert redacted["credential_family"] == "devin"
     assert "BEGIN CERTIFICATE" not in str(redacted)
     assert "super-secret" not in str(redacted)
+
+
+def test_nats_config_prefers_merge_master_mike_credentials():
+    config = prc._nats_config(
+        {
+            "MERGE_MASTER_MIKE_NATS_URL": "wss://mike-nats.example.test:8443",
+            "MERGE_MASTER_MIKE_NATS_USER": "merge_master_mike",
+            "MERGE_MASTER_MIKE_NATS_PW": "mike-secret",
+            "MERGE_MASTER_MIKE_NATS_CA_PEM": "-----BEGIN CERTIFICATE-----\\nmike\\n-----END CERTIFICATE-----",
+            "DEVIN_NATS_URL": "wss://devin-nats.example.test:8443",
+            "DEVIN_NATS_USER": "devin",
+            "DEVIN_NATS_PW": "devin-secret",
+            "DEVIN_NATS_CA_PEM": "-----BEGIN CERTIFICATE-----\\ndevin\\n-----END CERTIFICATE-----",
+        },
+        require_devin_secrets=True,
+    )
+
+    assert config.endpoint == "wss://mike-nats.example.test:8443"
+    assert config.user == "merge_master_mike"
+    assert config.credential == "mike-secret"
+    assert config.ca_pem == "-----BEGIN CERTIFICATE-----\nmike\n-----END CERTIFICATE-----\n"
+    assert config.credential_family == "merge_master_mike"
+    assert config.missing == ()
+
+
+def test_nats_config_requires_complete_mike_family_when_any_mike_secret_present():
+    config = prc._nats_config(
+        {
+            "MERGE_MASTER_MIKE_NATS_URL": "wss://mike-nats.example.test:8443",
+            "DEVIN_NATS_URL": "wss://devin-nats.example.test:8443",
+            "DEVIN_NATS_USER": "devin",
+            "DEVIN_NATS_PW": "devin-secret",
+        },
+        require_devin_secrets=True,
+    )
+
+    assert config.credential_family == "merge_master_mike"
+    assert set(config.missing) == {"MERGE_MASTER_MIKE_NATS_USER", "MERGE_MASTER_MIKE_NATS_PW"}
 
 
 def test_nats_tls_kwargs_loads_custom_ca_and_hostname(monkeypatch):


### PR DESCRIPTION
## Summary

- make `MERGE_MASTER_MIKE_NATS_*` the primary credential family for the backlog fanout workflow
- keep the existing `DEVIN_NATS_*` names as compatibility fallback
- record the selected credential family in the redacted NATS receipt
- document the Mike-first GitHub Actions secret setup

## Operational Receipt

- AGNI NATS config was validated and patched to allow `merge_master_mike` to publish to the peer A2A subjects: GitHub Copilot, Claude, Devin, Codex, Hermes, and Perplexity.
- AGNI backup: `/root/.dharma/nats/config_backups/nats-server.conf.bak-20260604T153048Z`
- GitHub repo secrets now include `MERGE_MASTER_MIKE_NATS_URL`, `MERGE_MASTER_MIKE_NATS_USER`, `MERGE_MASTER_MIKE_NATS_PW`, and `MERGE_MASTER_MIKE_NATS_CA_PEM`.

## Coherence Delta

- Organ touched: Merge Master Mike's GitHub-hosted NATS credential path and AGNI peer fanout authorization.
- Declared-vs-actual gap closed: The backlog workflow had Mike fanout semantics but authenticated with Devin's restricted NATS user. This makes Mike the primary publisher and keeps Devin only as fallback.
- Proof that re-reads the map: Verified the live failure moved past TLS to NATS publish authorization, inspected AGNI's Mike user allow-list, applied a validated server permission patch, set Mike repo secrets, and tested parser/workflow/docs locally.
- New drift introduced: Adds a credential-family preference only; no merge policy, branch protection bypass, approval authority, or insecure TLS option is introduced.

## Verification

- `scripts/governance/run_pytest_with_repo_env.sh -q tests/test_pr_merge_control.py`
- `python3 -m py_compile scripts/runtime/pr_merge_control.py scripts/runtime/merge_master_mike_daemon.py`
- workflow YAML parse for `merge-master-mike-backlog.yml` and `codex-mention-router.yml`
- `make docops-integrity`
- pre-commit hooks: hygiene, contracts, uplift guards, DocOps, gitleaks, Semgrep, whitespace, YAML
