### PR TITLE
fix(providers): preserve OpenAI dumped content parts

### DIFF
--- a/dharma_swarm/providers.py
+++ b/dharma_swarm/providers.py
@@ -102,53 +102,65 @@ class LLMProvider(BaseProvider):
         yield  # type: ignore[misc]  # required for async generator signature
 
 
+def _mapping_from_sdk_object(value: Any) -> dict[str, Any] | None:
+    if isinstance(value, dict):
+        return value
+    for method_name in ("model_dump", "dict"):
+        method = getattr(value, method_name, None)
+        if not callable(method):
+            continue
+        try:
+            dumped = method()
+        except TypeError:
+            continue
+        if isinstance(dumped, dict):
+            return dumped
+    return None
+
+
+def _get_openai_compatible_field(value: Any, key: str) -> Any:
+    mapping = _mapping_from_sdk_object(value)
+    if mapping is not None and key in mapping:
+        return mapping.get(key)
+    return getattr(value, key, None)
+
+
 def _coerce_openrouter_text(value: Any) -> str:
+    if value is None:
+        return ""
     if isinstance(value, str):
         return value.strip()
     if isinstance(value, list):
         chunks: list[str] = []
         for item in value:
-            if isinstance(item, str):
-                text = item.strip()
-                if text:
-                    chunks.append(text)
-                continue
-            if isinstance(item, dict):
-                text = item.get("text") or item.get("content")
-                if isinstance(text, str) and text.strip():
-                    chunks.append(text.strip())
-                continue
-            text = getattr(item, "text", None) or getattr(item, "content", None)
-            if isinstance(text, str) and text.strip():
-                chunks.append(text.strip())
+            text = _coerce_openrouter_text(item)
+            if text:
+                chunks.append(text)
         return "\n".join(chunks).strip()
-    if isinstance(value, dict):
-        text = value.get("text") or value.get("content")
-        if isinstance(text, str):
-            return text.strip()
-    text = getattr(value, "text", None) or getattr(value, "content", None)
-    if isinstance(text, str):
-        return text.strip()
+    mapping = _mapping_from_sdk_object(value)
+    if mapping is not None:
+        for key in ("text", "content", "output_text"):
+            text = _coerce_openrouter_text(mapping.get(key))
+            if text:
+                return text
+        return ""
+    for key in ("text", "content", "output_text"):
+        text = _coerce_openrouter_text(getattr(value, key, None))
+        if text:
+            return text
     return ""
 
 
 def _extract_openai_compatible_message_text(message: Any) -> str:
-    if isinstance(message, dict):
-        content = _coerce_openrouter_text(message.get("content"))
-        if content:
-            return content
-        reasoning = _coerce_openrouter_text(message.get("reasoning"))
-        if reasoning:
-            return reasoning
-        return _coerce_openrouter_text(message.get("reasoning_details"))
-
-    content = _coerce_openrouter_text(getattr(message, "content", None))
+    content = _coerce_openrouter_text(_get_openai_compatible_field(message, "content"))
     if content:
         return content
-    reasoning = _coerce_openrouter_text(getattr(message, "reasoning", None))
+    reasoning = _coerce_openrouter_text(_get_openai_compatible_field(message, "reasoning"))
     if reasoning:
         return reasoning
-    return _coerce_openrouter_text(getattr(message, "reasoning_details", None))
+    return _coerce_openrouter_text(
+        _get_openai_compatible_field(message, "reasoning_details")
+    )
 
 
 def _extract_openrouter_message_text(message: Any) -> str:
@@ -329,11 +341,16 @@ class OpenAIProvider(LLMProvider):
         resp = await client.chat.completions.create(**kwargs)
         choice = resp.choices[0]
         msg = choice.message
-        tool_calls: list[dict[str, Any]] = [
-            {"id": tc.id, "name": tc.function.name,
-             "arguments": tc.function.arguments}
-            for tc in (msg.tool_calls or [])
-        ]
+        tool_calls: list[dict[str, Any]] = []
+        for tc in (_get_openai_compatible_field(msg, "tool_calls") or []):
+            fn = _get_openai_compatible_field(tc, "function") or {}
+            tool_calls.append(
+                {
+                    "id": _get_openai_compatible_field(tc, "id"),
+                    "name": _get_openai_compatible_field(fn, "name"),
+                    "arguments": _get_openai_compatible_field(fn, "arguments"),
+                }
+            )
         return LLMResponse(
             content=_extract_openai_compatible_message_text(msg), model=resp.model,
             usage={"prompt_tokens": resp.usage.prompt_tokens,

--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -8,9 +8,9 @@ Do not hand-edit the generated block.
 |---|---:|
 | Dharma Python modules | 662 |
 | Top-level Dharma Python modules | 389 |
-| Dharma Python LOC | 281,387 |
+| Dharma Python LOC | 281,404 |
 | Test files | 625 |
-| Test function occurrences | 10,796 |
+| Test function occurrences | 10,797 |
 | Markdown files | 771 |
 | Markdown total lines | 193,218 |
 | Bridge files | 24 |

--- a/docs/governance/SOVEREIGN_MANIFEST.md
+++ b/docs/governance/SOVEREIGN_MANIFEST.md
@@ -127,9 +127,9 @@ These are the ground-truth metrics. All other documents citing different numbers
 |--------|-------|-------------|
 | Total Python modules | **662** | find dharma_swarm -name "*.py" -type f |
 | Top-level (flat) modules | **389 (59.0%)** | find dharma_swarm -maxdepth 1 -name "*.py" -type f |
-| Total Python LOC | **281,387** | wc -l across dharma_swarm Python modules |
+| Total Python LOC | **281,404** | wc -l across dharma_swarm Python modules |
 | Test files | **625** | find tests -name "*.py" -type f |
-| Test functions | **10,796 `def test_` occurrences under tests/** | rg "def test_" tests |
+| Test functions | **10,797 `def test_` occurrences under tests/** | rg "def test_" tests |
 | Tests collected (pytest) | **Needs write-permitted refresh** | not run during this DocOps count pass |
 | Collection errors | **Historical: 16 on 2026-04-04** | refresh before relying on this count |
 | Markdown files | **771** | find . -name "*.md" -type f |

--- a/tests/test_providers_quality_track.py
+++ b/tests/test_providers_quality_track.py
@@ -36,6 +36,14 @@ class _DummyProvider:
         yield self.content
 
 
+class _Dumpable:
+    def __init__(self, payload: dict[str, object]) -> None:
+        self._payload = payload
+
+    def model_dump(self) -> dict[str, object]:
+        return self._payload
+
+
 def _mk_resp(
     content: str | None = "ok",
     *,
@@ -289,6 +297,33 @@ async def test_openai_provider_uses_max_tokens_for_non_gpt5_models(monkeypatch):
     assert kwargs["max_tokens"] == 32
     assert "max_completion_tokens" not in kwargs
     assert kwargs["temperature"] == req.temperature
+
+
+@pytest.mark.asyncio
+async def test_openai_provider_preserves_dumped_content_parts(monkeypatch):
+    p = OpenAIProvider(api_key="k")
+    req = LLMRequest(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": "hi"}],
+    )
+
+    message = _Dumpable(
+        {
+            "content": [
+                _Dumpable({"type": "output_text", "text": "visible content"}),
+            ],
+            "tool_calls": None,
+        }
+    )
+    resp = _mk_resp(content=None)
+    resp.choices[0].message = message
+    client = AsyncMock()
+    client.chat.completions.create = AsyncMock(return_value=resp)
+    monkeypatch.setattr(p, "_client_or_raise", lambda: client)
+
+    out = await p.complete(req)
+
+    assert out.content == "visible content"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- preserve OpenAI-compatible content when SDK/Pydantic objects expose fields through model_dump()/dict()
- recurse through dumped content parts so nested output_text/text fields are not dropped
- use the same safe accessor for OpenAI tool_calls
- refresh DocOps counts for the added regression test

## Coherence Delta
- Organ touched: `dharma_swarm/providers.py` OpenAI/OpenAI-compatible response parsing, provider parser regression tests, and the generated DocOps counters.
- Declared-vs-actual gap closed: OpenAIProvider now preserves content exposed only through SDK/Pydantic dump APIs, including nested `output_text`/`text` content parts that previously collapsed to empty output.
- Proof that re-reads the map: GitNexus upstream blast-radius check on `OpenAIProvider`, `pytest -q tests/test_providers_quality_track.py tests/test_providers.py tests/test_base_provider.py`, and `python3 scripts/docops/check_docops_integrity.py --report-json reports/docops/check.json`.
- New drift introduced: No intended API/schema drift; parser/accessor behavior is widened for OpenAI-compatible SDK objects and DocOps count drift is refreshed.

## Impact
- Hot path: OpenAIProvider / OpenAI-compatible response parsing
- Impact checked via GitNexus OpenAIProvider upstream blast-radius query; change kept to parser/accessor behavior and covered by provider tests

## Tests
- python3 scripts/docops/check_docops_integrity.py --report-json reports/docops/check.json
- pytest -q tests/test_providers_quality_track.py
- pytest -q tests/test_providers.py tests/test_base_provider.py
- pytest -q tests/test_providers_quality_track.py tests/test_providers.py tests/test_base_provider.py
