### PR TITLE
feat(operator-core): add runtime truth projector

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,56 +21,48 @@ If this file disagrees with that output on anything live (track id, prereqs, rec
      Do not hand-edit. Run scripts/governance/render_active_track_includes.py
      after updating the YAML. -->
 
-**Active track:** Runtime Truth Spine — one invariant, one invocation path, one receipt
-**Track id:** `runtime-truth-spine-2026-06`
+**Active track:** Runtime Truth Reconciliation — operator-visible truth packets
+**Track id:** `runtime-truth-reconciliation-2026-06`
 **Status:** ACTIVE
-**Verified at:** 2026-05-28 (TTL 14 days)
+**Verified at:** 2026-06-04 (TTL 14 days)
 **Owner:** @AmitabhainArunachala
 
 **Description:**
 
-Define the Runtime Truth Spine before expanding agent fabric. Three audits
-(Perplexity, Codex, Devin) converged: dharma_swarm has accreted without a
-spine. The fix is one invariant chain (Task + Runner + Claim + Context +
-RoutingDecision + ProviderCall + EvidenceReceipt = safe execution path).
-Every dispatch produces exactly one receipt. No more generic dispatch_dropoff.
+The Runtime Truth Spine substrate is merged and shippable. This track moves
+from substrate existence to read-only reconciliation: operator-visible
+runtime truth packets that separate heartbeat, readiness, artifact progress,
+completion, authority, projection/cache, mutation, and external-gated proof.
 
-PR A.5 (governance convergence): the spine guard is fused into the existing
-uplift_guards composition (no parallel CI workflow), each closure layer's
-canonical receipt is declared in ACTIVE_SURFACE_MANIFEST.yaml under
-correlation_spine, and ANTI_SLOP Rule 2 is extended with role vocabulary
-so future receipts must declare their layer instead of growing a second
-truth surface.
+The track must not create a new truth store, daemon, receipt system, or
+authority surface. It projects from existing owners only:
+spine.EvidenceReceipt for in-flight dispatch proof, runtime_state.RuntimeReceipt
+for persisted runtime receipts, IdempotencyRecord for exactly-once substrate,
+and existing operator/onboard/control-surface rows for read-only rendering.
 
-Doctrine line that must hold across all closure layers:
-  Receipts may differ by closure layer. Correlation identity must not.
-
-Reference: docs/reports/CONVERGED_SEAM_AUDIT_RUNTIME_TRUTH_SPINE.md
-A2A anchor: dharma_swarm/a2a/README.md (three-layer receipt architecture)
+Doctrine line that must hold:
+  Read models project truth from owners; they do not become authority.
 
 **Next items on this track:**
 
-- [code] (blocker) Define spine types (EvidenceReceipt, RoutingDecision, invoke_agent) — zero behavior change.
-- [code] (blocker) Wire A2A into the spine (invoke_agent becomes the only invocation path for A2A delegation).
-- [code] Collapse 7 routers to 2 on the spine rail.
-- [code] Shard providers.py into per-provider files.
-- [code] Decompose agent_runner.py run_task onto spine boundary.
+- [code] (blocker) Define the smallest read-only RuntimeTruthPacket contract in the existing operator_core owner.
+- [code] (blocker) Render compact runtime truth in make onboard without making onboard an authority surface.
+- [test] Protect A2A single-persistence invariant while adding runtime truth projections.
 
 **Non-goals (do not work on these during this track):**
 
-- Do not decompose AgentRunner.run_task in this track (except where strictly necessary).
-- Do not split providers.py into per-provider files yet.
-- Do not rewrite SwarmManager.
-- Do not introduce Redis, gRPC, or a new daemon as part of THIS track. (NATS substrate scoped out of this track but no longer globally prohibited as of doctrine amendment 2026-05-31; runs as a concurrent scoped track when opened, with non-overlapping surfaces.)
-- Do not create a second event log or truth surface.
-- Do not add another spiritual/metaphoric naming layer.
-- Do not add a parallel spine-check CI workflow — the uplift_guards composition is the only entry point.
+- Do not create a new daemon, database, event log, truth store, or receipt system.
+- Do not mint a second RuntimeReceipt for A2A or paths with an inner runtime owner.
+- Do not mutate external systems, live processes, archive fitness, payments, or gateways.
+- Do not broadly refactor orchestrator.py, agent_runner.py, swarm.py, providers.py, or SwarmManager.
+- Do not build Verified Experiment Loop runtime in this track.
+- Do not create standalone BetCard, Experiment, SwarmRun, DecisionRecord, LineageRecord, WikiUpdate, or cost-tracker classes.
 
 **Recently closed tracks:**
 
-- `boardstore-facade-2026-05` — BoardStore Facade — unified task/state surface for multi-agent coordination (SHIPPED, closed 2026-05-20)
-- `cockpit-control-surface-2026-05` — Operator Cockpit v1 + Control-Surface contract hardening (SHIPPED, closed 2026-05-20)
-- `operator-brief-seam-2026-04` — Ontology-Native Operator Brief (first substrate-native seam) (SHIPPED, closed 2026-05-19)
+- `runtime-truth-spine-2026-06` — Runtime Truth Spine — one invariant, one invocation path, one receipt (SHIPPED, closed 2026-06-04)
+- `trace-identity-coverage-2026-05` — Trace Identity Coverage — native propagation and soft coverage findings (SUPERSEDED, closed 2026-05-28)
+- `trace-attractor-causal-spine-2026-05` — Trace Attractor Causal Spine — operator-visible trace packets (SHIPPED, closed 2026-05-21)
 
 For machine-readable status, see [`reports/governance/active_track_evidence.md`](reports/governance/active_track_evidence.md) (generated by `scripts/governance/check_track_status.py`).
 

--- a/dharma_swarm/operator_core/__init__.py
+++ b/dharma_swarm/operator_core/__init__.py
@@ -48,6 +48,12 @@ from .operating_facts import (
 )
 from .routing_payloads import build_agent_routes_payload, build_routing_decision_payload
 from .runtime_payloads import build_runtime_snapshot_payload
+from .runtime_truth import (
+    connect_runtime_db_read_only,
+    runtime_db_path_from_env,
+    runtime_truth_packets_from_runtime_db,
+    summarize_runtime_truth_packets,
+)
 from .workspace_payloads import build_workspace_snapshot_payload
 from .session_payloads import build_session_catalog_payload, build_session_detail_payload
 from .session_store import SessionStore, cwd_matches
@@ -71,6 +77,8 @@ from .contracts import (
     PermissionResolutionKind,
     PermissionRisk,
     RuntimeHealth,
+    RuntimeTruthPacket,
+    RuntimeTruthState,
     WorkflowExecutionMode,
 )
 
@@ -113,6 +121,12 @@ __all__ = [
     "PermissionResolutionKind",
     "PermissionRisk",
     "RuntimeHealth",
+    "RuntimeTruthPacket",
+    "RuntimeTruthState",
+    "connect_runtime_db_read_only",
+    "runtime_db_path_from_env",
+    "runtime_truth_packets_from_runtime_db",
+    "summarize_runtime_truth_packets",
     "SessionStore",
     "WorkflowExecutionMode",
     "build_session_catalog",

--- a/dharma_swarm/operator_core/contracts.py
+++ b/dharma_swarm/operator_core/contracts.py
@@ -7,8 +7,10 @@ terminal and dashboard can build against while the internals converge.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from collections.abc import Mapping
+from dataclasses import dataclass, field, fields
 from enum import StrEnum
+from types import MappingProxyType
 from typing import Any
 
 
@@ -17,6 +19,33 @@ class RuntimeHealth(StrEnum):
     DEGRADED = "degraded"
     CRITICAL = "critical"
     UNKNOWN = "unknown"
+
+
+class RuntimeTruthState(StrEnum):
+    UNKNOWN = "unknown"
+    OBSERVED = "observed"
+    MISSING = "missing"
+    SOURCE_OWNED = "source_owned"
+    PROJECTION_ONLY = "projection_only"
+    CACHE_ONLY = "cache_only"
+    READY_BY_PROBE = "ready_by_probe"
+    NOT_READY_BY_PROBE = "not_ready_by_probe"
+    UNKNOWN_BY_PROBE_ERROR = "unknown_by_probe_error"
+    DEGRADED_BY_PROBE_TIMEOUT = "degraded_by_probe_timeout"
+    RUNNING_BY_HEARTBEAT = "running_by_heartbeat"
+    PROGRESSING_BY_ARTIFACT = "progressing_by_artifact"
+    STALLED_BY_ARTIFACT_PROGRESS = "stalled_by_artifact_progress"
+    BLOCKED_BY_RECEIPT = "blocked_by_receipt"
+    COMPLETED_BY_RECEIPT = "completed_by_receipt"
+    EXTERNAL_GATED = "external_gated"
+    NO_MUTATION_OBSERVED = "no_mutation_observed"
+    MUTATION_OBSERVED = "mutation_observed"
+    DRY_RUN_ONLY = "dry_run_only"
+    RETRY_EQUIVALENT = "retry_equivalent"
+    RETRY_PARAMETER_MISMATCH = "retry_parameter_mismatch"
+    EVALUATOR_PASS = "evaluator_pass"
+    EVALUATOR_RETRY = "evaluator_retry"
+    EVALUATOR_BLOCKED = "evaluator_blocked"
 
 
 class PermissionRisk(StrEnum):
@@ -90,6 +119,99 @@ class EntityRef:
 class EntityBadge:
     label: str
     tone: RuntimeHealth = RuntimeHealth.UNKNOWN
+
+
+@dataclass(slots=True, frozen=True)
+class RuntimeTruthPacket:
+    """Read-only reconciliation packet projected from existing truth owners."""
+
+    surface_id: str
+    kind: str
+    observed_at: str
+    owner_surface: str
+    source_kind: str
+    run_id: str | None = None
+    mission_id: str | None = None
+    mission_id_missing: bool = False
+    correlation_id: str | None = None
+    correlation_id_inferred: bool = False
+    task_id: str | None = None
+    claim_id: str | None = None
+    runner_id: str | None = None
+    receipt_refs: list[str] = field(default_factory=list)
+    artifact_refs: list[str] = field(default_factory=list)
+    source_refs: list[str] = field(default_factory=list)
+    startup_state: RuntimeTruthState = RuntimeTruthState.UNKNOWN
+    heartbeat_state: RuntimeTruthState = RuntimeTruthState.UNKNOWN
+    readiness_state: RuntimeTruthState = RuntimeTruthState.UNKNOWN
+    progress_state: RuntimeTruthState = RuntimeTruthState.UNKNOWN
+    completion_state: RuntimeTruthState = RuntimeTruthState.UNKNOWN
+    authority_state: RuntimeTruthState = RuntimeTruthState.PROJECTION_ONLY
+    mutation_state: RuntimeTruthState = RuntimeTruthState.NO_MUTATION_OBSERVED
+    source_state: RuntimeTruthState = RuntimeTruthState.UNKNOWN
+    projection_state: RuntimeTruthState = RuntimeTruthState.PROJECTION_ONLY
+    external_state: RuntimeTruthState = RuntimeTruthState.UNKNOWN
+    retry_state: RuntimeTruthState = RuntimeTruthState.UNKNOWN
+    evaluator_state: RuntimeTruthState = RuntimeTruthState.UNKNOWN
+    probe_ok: bool | None = None
+    probe_error: str | None = None
+    stale_after: str | None = None
+    stale_reason: str | None = None
+    last_heartbeat_at: str | None = None
+    last_progress_at: str | None = None
+    last_receipt_at: str | None = None
+    loop_iteration: int | None = None
+    retry_intent_key: str | None = None
+    eval_refs: list[str] = field(default_factory=list)
+    stop_reason: str | None = None
+    missing_machine_fields: list[str] = field(default_factory=list)
+    is_authoritative: bool = False
+    is_projection: bool = True
+    projection_lag: str | None = None
+    projection_source_refs: list[str] = field(default_factory=list)
+    projection_rebuildable: bool = True
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.is_authoritative:
+            raise ValueError(
+                "RuntimeTruthPacket is a read model; authority lives in owner surfaces"
+            )
+        for name in (
+            "receipt_refs",
+            "artifact_refs",
+            "source_refs",
+            "eval_refs",
+            "missing_machine_fields",
+            "projection_source_refs",
+        ):
+            object.__setattr__(self, name, tuple(getattr(self, name)))
+        object.__setattr__(self, "metadata", _freeze_runtime_truth_value(self.metadata))
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-ready machine row without making this packet authority."""
+
+        def encode(value: Any) -> Any:
+            if isinstance(value, StrEnum):
+                return value.value
+            if isinstance(value, tuple | list):
+                return [encode(item) for item in value]
+            if isinstance(value, Mapping):
+                return {str(key): encode(item) for key, item in value.items()}
+            return value
+
+        return {item.name: encode(getattr(self, item.name)) for item in fields(self)}
+
+
+def _freeze_runtime_truth_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return MappingProxyType({
+            str(key): _freeze_runtime_truth_value(item)
+            for key, item in value.items()
+        })
+    if isinstance(value, tuple | list):
+        return tuple(_freeze_runtime_truth_value(item) for item in value)
+    return value
 
 
 @dataclass(slots=True)

--- a/dharma_swarm/operator_core/control_surface.py
+++ b/dharma_swarm/operator_core/control_surface.py
@@ -774,8 +774,11 @@ def _broken_register_rows(repo_root: Path | None = None) -> list[ControlSurfaceR
 # K) Runtime state adapter
 # ---------------------------------------------------------------------------
 
-def _runtime_state_row(repo_root: Path | None = None) -> ControlSurfaceRow | None:
-    db_path = Path.home() / ".dharma" / "state" / "runtime.db"
+def _runtime_state_row(
+    repo_root: Path | None = None,
+    runtime_db: Path | None = None,
+) -> ControlSurfaceRow | None:
+    db_path = runtime_db or Path.home() / ".dharma" / "state" / "runtime.db"
     if not db_path.exists():
         row = ControlSurfaceRow(
             id="runtime.state_db",
@@ -822,8 +825,9 @@ def _runtime_state_row(repo_root: Path | None = None) -> ControlSurfaceRow | Non
     row.add_source_ref("file", "dharma_swarm/runtime_state.py", exists=True)
 
     try:
-        import sqlite3
-        with sqlite3.connect(str(db_path)) as conn:
+        from dharma_swarm.operator_core.runtime_truth import connect_runtime_db_read_only
+
+        with connect_runtime_db_read_only(db_path) as conn:
             tables = [r[0] for r in conn.execute(
                 "SELECT name FROM sqlite_master WHERE type='table'"
             ).fetchall()]
@@ -839,6 +843,39 @@ def _runtime_state_row(repo_root: Path | None = None) -> ControlSurfaceRow | Non
                 status="present",
                 provenance_chain=["runtime_state", "table_count_query"],
             )
+            from dharma_swarm.operator_core.runtime_truth import (
+                runtime_truth_packets_from_runtime_db,
+                summarize_runtime_truth_packets,
+            )
+
+            packets = runtime_truth_packets_from_runtime_db(db_path)
+            packet_summary = summarize_runtime_truth_packets(packets)
+            row.raw["runtime_truth_packets"] = [packet.to_dict() for packet in packets]
+            row.raw["runtime_truth_summary"] = packet_summary
+            latest_receipt = packet_summary.get("latest_receipt")
+            if latest_receipt:
+                row.add_evidence(
+                    "db_probe",
+                    str(latest_receipt),
+                    status="present",
+                    provenance_chain=[
+                        "runtime_state",
+                        "sqlite_read_only_probe",
+                        "RuntimeTruthPacket",
+                    ],
+                )
+            else:
+                row.gap_codes.append("runtime_receipt_missing")
+                row.add_evidence(
+                    "db_probe",
+                    "latest runtime receipt missing",
+                    status="missing",
+                    provenance_chain=[
+                        "runtime_state",
+                        "sqlite_read_only_probe",
+                        "RuntimeTruthPacket",
+                    ],
+                )
     except Exception as exc:
         row.add_evidence(
             "db_probe", f"db query error: {exc}",
@@ -929,7 +966,7 @@ def build_control_surface_rows(
     rows.extend(_broken_register_rows(root))
 
     # K) Runtime state DB (observed)
-    rt_row = _runtime_state_row(root)
+    rt_row = _runtime_state_row(root, runtime_db=runtime_db)
     if rt_row is not None:
         rows.append(rt_row)
 

--- a/dharma_swarm/operator_core/runtime_truth.py
+++ b/dharma_swarm/operator_core/runtime_truth.py
@@ -1,0 +1,714 @@
+"""Read-only runtime truth projections over existing runtime owners.
+
+This module deliberately does not initialize or migrate runtime state. It
+opens runtime.db in SQLite read-only mode and projects what is already there
+into RuntimeTruthPacket rows.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from dataclasses import replace
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+from .contracts import RuntimeTruthPacket, RuntimeTruthState
+
+
+RUNTIME_DB_SOURCE = "dharma_swarm/runtime_state.py"
+REQUIRED_RUNTIME_TABLES = ("runtime_receipts", "idempotency_records")
+TERMINAL_SUCCESS_STATUSES = {"completed", "complete", "succeeded", "success", "ok"}
+TERMINAL_BLOCKED_STATUSES = {
+    "blocked",
+    "failed",
+    "failure",
+    "error",
+    "cancelled",
+    "canceled",
+}
+ACTIVE_RUN_STATUSES = {
+    "active",
+    "claimed",
+    "pending",
+    "queued",
+    "running",
+    "started",
+    "in_progress",
+}
+TERMINAL_RECEIPT_TYPES = {
+    "a2a_task",
+    "delegation_run",
+    "runtime_completion",
+    "task_completion",
+    "task_run",
+}
+
+
+def runtime_db_path_from_env() -> Path:
+    """Return the runtime DB path without creating it."""
+
+    state_dir = os.environ.get("DHARMA_STATE_DIR")
+    if state_dir:
+        return Path(state_dir).expanduser() / "runtime.db"
+    return Path.home() / ".dharma" / "state" / "runtime.db"
+
+
+def runtime_truth_packets_from_runtime_db(
+    db_path: Path | str | None = None,
+    *,
+    observed_at: str | None = None,
+) -> list[RuntimeTruthPacket]:
+    """Project existing runtime.db facts into read-only truth packets.
+
+    Missing or malformed local state is rendered as NOT_READY/UNKNOWN instead
+    of being repaired. That preserves the line between projection and authority.
+    """
+
+    path = Path(db_path).expanduser() if db_path is not None else runtime_db_path_from_env()
+    observed = observed_at or _now_iso()
+    if not path.exists():
+        return [_store_packet(path, observed, present=False)]
+
+    try:
+        with _connect_read_only(path) as conn:
+            conn.row_factory = sqlite3.Row
+            tables = _tables(conn)
+            counts = _table_counts(conn, tables)
+            store_packet = _store_packet(
+                path,
+                observed,
+                present=True,
+                tables=tables,
+                counts=counts,
+            )
+            latest = _latest_runtime_receipt(conn, tables)
+            if latest is None:
+                return [
+                    _with_missing(
+                        store_packet,
+                        [
+                            "latest_runtime_receipt",
+                            "run_id",
+                            "task_id",
+                            "correlation_id",
+                        ],
+                    )
+                ]
+            return [
+                store_packet,
+                _packet_from_latest_runtime_receipt(
+                    conn,
+                    tables,
+                    latest,
+                    path=path,
+                    observed_at=observed,
+                    counts=counts,
+                ),
+            ]
+    except Exception as exc:
+        return [
+            _store_packet(
+                path,
+                observed,
+                present=True,
+                probe_ok=False,
+                probe_error=f"{type(exc).__name__}: {exc}",
+            )
+        ]
+
+
+def summarize_runtime_truth_packets(
+    packets: list[RuntimeTruthPacket],
+) -> dict[str, Any]:
+    """Return a compact operator summary from packet rows."""
+
+    runtime_packets = [
+        packet for packet in packets if packet.surface_id.startswith("runtime_state.")
+    ]
+    latest = next(
+        (
+            packet
+            for packet in runtime_packets
+            if packet.surface_id == "runtime_state.latest_receipt"
+        ),
+        None,
+    )
+    store = next(
+        (
+            packet
+            for packet in runtime_packets
+            if packet.surface_id == "runtime_state.store"
+        ),
+        None,
+    )
+    if latest is not None:
+        return {
+            "runtime_db": (latest.metadata or {}).get("runtime_db"),
+            "readiness": latest.readiness_state.value,
+            "latest_receipt": (latest.receipt_refs or [""])[0],
+            "run_id": latest.run_id,
+            "task_id": latest.task_id,
+            "correlation_id": latest.correlation_id,
+            "heartbeat": latest.heartbeat_state.value,
+            "progress": latest.progress_state.value,
+            "completion": latest.completion_state.value,
+            "retry": latest.retry_state.value,
+            "missing": latest.missing_machine_fields,
+        }
+    if store is not None:
+        return {
+            "runtime_db": (store.metadata or {}).get("runtime_db"),
+            "readiness": store.readiness_state.value,
+            "latest_receipt": None,
+            "run_id": None,
+            "task_id": None,
+            "correlation_id": None,
+            "heartbeat": store.heartbeat_state.value,
+            "progress": store.progress_state.value,
+            "completion": store.completion_state.value,
+            "retry": store.retry_state.value,
+            "missing": store.missing_machine_fields,
+        }
+    return {"runtime_db": None, "readiness": "unknown", "missing": ["runtime_packet"]}
+
+
+def connect_runtime_db_read_only(path: Path | str) -> sqlite3.Connection:
+    """Open an existing runtime.db in read-only SQLite mode."""
+
+    return _connect_read_only(Path(path).expanduser())
+
+
+def _connect_read_only(path: Path) -> sqlite3.Connection:
+    uri = f"file:{quote(path.as_posix(), safe='/:')}?mode=ro"
+    return sqlite3.connect(uri, uri=True)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _tables(conn: sqlite3.Connection) -> set[str]:
+    rows = conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+    return {str(row[0]) for row in rows}
+
+
+def _table_counts(conn: sqlite3.Connection, tables: set[str]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for table in (
+        "runtime_receipts",
+        "idempotency_records",
+        "task_claims",
+        "delegation_runs",
+        "artifact_records",
+        "execution_identities",
+    ):
+        if table not in tables:
+            continue
+        counts[table] = int(
+            conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]  # noqa: S608
+        )
+    return counts
+
+
+def _latest_runtime_receipt(
+    conn: sqlite3.Connection,
+    tables: set[str],
+) -> sqlite3.Row | None:
+    if "runtime_receipts" not in tables:
+        return None
+    return conn.execute(
+        "SELECT receipt_id, receipt_type, run_id, task_id, trace_id,"
+        " correlation_id, causation_id, parent_run_id, agent_id,"
+        " idempotency_key, side_effect_key, status, payload_json, created_at"
+        " FROM runtime_receipts ORDER BY created_at DESC LIMIT 1"
+    ).fetchone()
+
+
+def _store_packet(
+    path: Path,
+    observed_at: str,
+    *,
+    present: bool,
+    tables: set[str] | None = None,
+    counts: dict[str, int] | None = None,
+    probe_ok: bool | None = None,
+    probe_error: str | None = None,
+) -> RuntimeTruthPacket:
+    table_set = tables or set()
+    missing = [] if present else ["runtime_db"]
+    missing_required_tables = [
+        table for table in REQUIRED_RUNTIME_TABLES if present and table not in table_set
+    ]
+    if probe_error is None:
+        missing.extend(f"{table}_table" for table in missing_required_tables)
+    ok = (
+        present and not missing_required_tables
+        if probe_ok is None
+        else probe_ok
+    )
+    readiness = RuntimeTruthState.READY_BY_PROBE
+    if probe_error:
+        readiness = RuntimeTruthState.UNKNOWN_BY_PROBE_ERROR
+    elif not present or missing_required_tables:
+        readiness = RuntimeTruthState.NOT_READY_BY_PROBE
+    return RuntimeTruthPacket(
+        surface_id="runtime_state.store",
+        kind="local_runtime_store_probe",
+        observed_at=observed_at,
+        owner_surface=RUNTIME_DB_SOURCE,
+        source_kind="sqlite_read_only_probe",
+        source_refs=[RUNTIME_DB_SOURCE, str(path)],
+        readiness_state=readiness,
+        heartbeat_state=RuntimeTruthState.UNKNOWN,
+        progress_state=RuntimeTruthState.UNKNOWN,
+        completion_state=RuntimeTruthState.UNKNOWN,
+        authority_state=RuntimeTruthState.PROJECTION_ONLY,
+        source_state=RuntimeTruthState.OBSERVED if present else RuntimeTruthState.MISSING,
+        probe_ok=ok,
+        probe_error=probe_error,
+        missing_machine_fields=missing,
+        metadata={
+            "runtime_db": str(path),
+            "tables": sorted(table_set),
+            "counts": counts or {},
+            "read_only_probe": True,
+        },
+    )
+
+
+def _packet_from_latest_runtime_receipt(
+    conn: sqlite3.Connection,
+    tables: set[str],
+    receipt: sqlite3.Row,
+    *,
+    path: Path,
+    observed_at: str,
+    counts: dict[str, int],
+) -> RuntimeTruthPacket:
+    run_id = _nonempty(receipt["run_id"])
+    task_id = _nonempty(receipt["task_id"])
+    trace_id = _nonempty(receipt["trace_id"])
+    correlation_id = _nonempty(receipt["correlation_id"])
+    idempotency_key = _nonempty(receipt["idempotency_key"])
+    side_effect_key = _nonempty(receipt["side_effect_key"])
+
+    identity = _identity_for_run(conn, tables, run_id) if run_id else None
+    run = _delegation_run(conn, tables, run_id, task_id)
+    claim = _task_claim(conn, tables, identity, run, task_id)
+    idem = _idempotency_record(
+        conn,
+        tables,
+        run_id=run_id,
+        idempotency_key=idempotency_key,
+        side_effect_key=side_effect_key,
+    )
+    artifacts = _artifacts(conn, tables, run_id=run_id, task_id=task_id, trace_id=trace_id)
+    receipt_payload = _json_map(receipt["payload_json"])
+
+    task_id = task_id or _field(identity, "task_id") or _field(run, "task_id")
+    run_id = run_id or _field(identity, "run_id") or _field(run, "run_id")
+    correlation_id = correlation_id or _field(identity, "correlation_id")
+    claim_id = _field(identity, "claim_id") or _field(run, "claim_id") or _field(claim, "claim_id")
+    runner_id = (
+        _field(identity, "agent_id")
+        or _field(run, "assigned_to")
+        or _field(claim, "agent_id")
+        or _nonempty(receipt["agent_id"])
+    )
+    mission_id = _first_metadata_value(
+        "mission_id",
+        receipt_payload,
+        _json_map(_field(identity, "metadata_json")),
+        _json_map(_field(run, "metadata_json")),
+        _json_map(_field(claim, "metadata_json")),
+    )
+
+    stale = _is_stale(_field(claim, "stale_after"))
+    latest_artifact_at = _field(artifacts[0], "created_at") if artifacts else ""
+    receipt_ref = f"runtime_receipts:{receipt['receipt_id']}"
+    artifact_refs = [
+        _artifact_ref(artifact)
+        for artifact in artifacts
+    ]
+    missing = _missing_fields(
+        run_id=run_id,
+        task_id=task_id,
+        correlation_id=correlation_id,
+        receipt_refs=[receipt_ref],
+        mission_id=mission_id,
+        idempotency=idem,
+        claim=claim,
+        run=run,
+        artifacts=artifacts,
+    )
+    return RuntimeTruthPacket(
+        surface_id="runtime_state.latest_receipt",
+        kind="runtime_state_reconciliation",
+        observed_at=observed_at,
+        owner_surface=RUNTIME_DB_SOURCE,
+        source_kind="sqlite_read_only_probe",
+        run_id=run_id,
+        mission_id=mission_id,
+        mission_id_missing=mission_id is None,
+        correlation_id=correlation_id,
+        correlation_id_inferred=False,
+        task_id=task_id,
+        claim_id=claim_id,
+        runner_id=runner_id,
+        receipt_refs=[receipt_ref],
+        artifact_refs=artifact_refs,
+        source_refs=[RUNTIME_DB_SOURCE, str(path)],
+        heartbeat_state=_heartbeat_state(claim, stale=stale),
+        readiness_state=RuntimeTruthState.READY_BY_PROBE,
+        progress_state=_progress_state(run, artifacts, stale=stale),
+        completion_state=_completion_state(receipt, run),
+        authority_state=RuntimeTruthState.PROJECTION_ONLY,
+        source_state=RuntimeTruthState.OBSERVED,
+        projection_state=RuntimeTruthState.PROJECTION_ONLY,
+        retry_state=_retry_state(idem),
+        probe_ok=True,
+        stale_after=_field(claim, "stale_after") or None,
+        stale_reason="task_claim_stale_after_elapsed" if stale else None,
+        last_heartbeat_at=_field(claim, "heartbeat_at") or None,
+        last_progress_at=latest_artifact_at or _field(run, "started_at") or None,
+        last_receipt_at=str(receipt["created_at"] or "") or None,
+        retry_intent_key=idempotency_key or None,
+        missing_machine_fields=missing,
+        metadata={
+            "runtime_db": str(path),
+            "runtime_table_counts": counts,
+            "receipt_id": str(receipt["receipt_id"]),
+            "receipt_type": str(receipt["receipt_type"]),
+            "receipt_status": str(receipt["status"]),
+            "idempotency_status": _field(idem, "status"),
+            "side_effect_key": side_effect_key,
+            "delegation_status": _field(run, "status"),
+            "task_claim_status": _field(claim, "status"),
+            "artifact_count_for_latest": len(artifacts),
+            "read_only_probe": True,
+        },
+    )
+
+
+def _identity_for_run(
+    conn: sqlite3.Connection,
+    tables: set[str],
+    run_id: str | None,
+) -> sqlite3.Row | None:
+    if not run_id or "execution_identities" not in tables:
+        return None
+    return conn.execute(
+        "SELECT run_id, trace_id, correlation_id, task_id, claim_id,"
+        " idempotency_key, causation_id, parent_run_id, agent_id,"
+        " session_id, external_a2a_task_id, message_id, event_id,"
+        " artifact_id, proposal_id, metadata_json"
+        " FROM execution_identities WHERE run_id = ?",
+        (run_id,),
+    ).fetchone()
+
+
+def _delegation_run(
+    conn: sqlite3.Connection,
+    tables: set[str],
+    run_id: str | None,
+    task_id: str | None,
+) -> sqlite3.Row | None:
+    if "delegation_runs" not in tables:
+        return None
+    if run_id:
+        row = conn.execute(
+            "SELECT run_id, session_id, task_id, claim_id, parent_run_id,"
+            " assigned_by, assigned_to, current_artifact_id, status,"
+            " started_at, completed_at, failure_code, metadata_json"
+            " FROM delegation_runs WHERE run_id = ?",
+            (run_id,),
+        ).fetchone()
+        if row is not None:
+            return row
+    if task_id:
+        return conn.execute(
+            "SELECT run_id, session_id, task_id, claim_id, parent_run_id,"
+            " assigned_by, assigned_to, current_artifact_id, status,"
+            " started_at, completed_at, failure_code, metadata_json"
+            " FROM delegation_runs WHERE task_id = ?"
+            " ORDER BY started_at DESC LIMIT 1",
+            (task_id,),
+        ).fetchone()
+    return None
+
+
+def _task_claim(
+    conn: sqlite3.Connection,
+    tables: set[str],
+    identity: sqlite3.Row | None,
+    run: sqlite3.Row | None,
+    task_id: str | None,
+) -> sqlite3.Row | None:
+    if "task_claims" not in tables:
+        return None
+    claim_id = _field(identity, "claim_id") or _field(run, "claim_id")
+    if claim_id:
+        row = conn.execute(
+            "SELECT claim_id, task_id, agent_id, status, session_id,"
+            " claimed_at, acked_at, heartbeat_at, stale_after, recovered_at,"
+            " retry_count, metadata_json, trace_id"
+            " FROM task_claims WHERE claim_id = ?",
+            (claim_id,),
+        ).fetchone()
+        if row is not None:
+            return row
+    if task_id:
+        return conn.execute(
+            "SELECT claim_id, task_id, agent_id, status, session_id,"
+            " claimed_at, acked_at, heartbeat_at, stale_after, recovered_at,"
+            " retry_count, metadata_json, trace_id"
+            " FROM task_claims WHERE task_id = ?"
+            " ORDER BY claimed_at DESC LIMIT 1",
+            (task_id,),
+        ).fetchone()
+    return None
+
+
+def _idempotency_record(
+    conn: sqlite3.Connection,
+    tables: set[str],
+    *,
+    run_id: str | None,
+    idempotency_key: str | None,
+    side_effect_key: str | None,
+) -> sqlite3.Row | None:
+    if "idempotency_records" not in tables:
+        return None
+    if idempotency_key and side_effect_key:
+        row = conn.execute(
+            "SELECT idempotency_key, side_effect_key, run_id, task_id,"
+            " trace_id, correlation_id, status, result_receipt_id,"
+            " metadata_json, created_at, updated_at"
+            " FROM idempotency_records"
+            " WHERE idempotency_key = ? AND side_effect_key = ?",
+            (idempotency_key, side_effect_key),
+        ).fetchone()
+        if row is not None:
+            return row
+    if run_id:
+        return conn.execute(
+            "SELECT idempotency_key, side_effect_key, run_id, task_id,"
+            " trace_id, correlation_id, status, result_receipt_id,"
+            " metadata_json, created_at, updated_at"
+            " FROM idempotency_records WHERE run_id = ?"
+            " ORDER BY updated_at DESC LIMIT 1",
+            (run_id,),
+        ).fetchone()
+    return None
+
+
+def _artifacts(
+    conn: sqlite3.Connection,
+    tables: set[str],
+    *,
+    run_id: str | None,
+    task_id: str | None,
+    trace_id: str | None,
+) -> list[sqlite3.Row]:
+    if "artifact_records" not in tables:
+        return []
+    clauses: list[str] = []
+    params: list[str] = []
+    for column, value in (
+        ("run_id", run_id),
+        ("task_id", task_id),
+        ("trace_id", trace_id),
+    ):
+        if value:
+            clauses.append(f"{column} = ?")
+            params.append(value)
+    if not clauses:
+        return []
+    return conn.execute(
+        "SELECT artifact_id, artifact_kind, session_id, task_id, run_id,"
+        " trace_id, manifest_path, payload_path, checksum, parent_artifact_id,"
+        " promotion_state, created_at, metadata_json"
+        f" FROM artifact_records WHERE {' OR '.join(clauses)}"
+        " ORDER BY created_at DESC LIMIT 20",
+        params,
+    ).fetchall()
+
+
+def _with_missing(
+    packet: RuntimeTruthPacket,
+    missing: list[str],
+) -> RuntimeTruthPacket:
+    return replace(
+        packet,
+        missing_machine_fields=[
+            *packet.missing_machine_fields,
+            *[field for field in missing if field not in packet.missing_machine_fields],
+        ],
+    )
+
+
+def _nonempty(value: Any) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _field(row: sqlite3.Row | None, name: str) -> str:
+    if row is None:
+        return ""
+    try:
+        return str(row[name] or "")
+    except (IndexError, KeyError):
+        return ""
+
+
+def _json_map(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    if not value:
+        return {}
+    try:
+        loaded = json.loads(str(value))
+    except json.JSONDecodeError:
+        return {}
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def _first_metadata_value(key: str, *maps: dict[str, Any]) -> str | None:
+    for item in maps:
+        value = item.get(key)
+        if value:
+            return str(value)
+    return None
+
+
+def _is_stale(stale_after: str) -> bool:
+    if not stale_after:
+        return False
+    parsed = _parse_datetime(stale_after)
+    return bool(parsed and parsed < datetime.now(timezone.utc))
+
+
+def _parse_datetime(value: str) -> datetime | None:
+    if not value:
+        return None
+    try:
+        if value.endswith("Z"):
+            value = f"{value[:-1]}+00:00"
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _heartbeat_state(
+    claim: sqlite3.Row | None,
+    *,
+    stale: bool,
+) -> RuntimeTruthState:
+    if claim is None:
+        return RuntimeTruthState.UNKNOWN
+    if stale:
+        return RuntimeTruthState.STALLED_BY_ARTIFACT_PROGRESS
+    if _field(claim, "heartbeat_at"):
+        return RuntimeTruthState.RUNNING_BY_HEARTBEAT
+    return RuntimeTruthState.OBSERVED
+
+
+def _progress_state(
+    run: sqlite3.Row | None,
+    artifacts: list[sqlite3.Row],
+    *,
+    stale: bool,
+) -> RuntimeTruthState:
+    if stale:
+        return RuntimeTruthState.STALLED_BY_ARTIFACT_PROGRESS
+    if artifacts or _field(run, "current_artifact_id"):
+        return RuntimeTruthState.PROGRESSING_BY_ARTIFACT
+    status = _field(run, "status").lower()
+    if status in {"blocked", "failed", "failure", "error"}:
+        return RuntimeTruthState.BLOCKED_BY_RECEIPT
+    return RuntimeTruthState.UNKNOWN
+
+
+def _completion_state(
+    receipt: sqlite3.Row,
+    run: sqlite3.Row | None,
+) -> RuntimeTruthState:
+    receipt_status = str(receipt["status"] or "").lower()
+    receipt_type = str(receipt["receipt_type"] or "").lower()
+    run_status = _field(run, "status").lower()
+    if run_status in TERMINAL_BLOCKED_STATUSES:
+        return RuntimeTruthState.BLOCKED_BY_RECEIPT
+    if run_status in TERMINAL_SUCCESS_STATUSES or _field(run, "completed_at"):
+        return RuntimeTruthState.COMPLETED_BY_RECEIPT
+    if run_status in ACTIVE_RUN_STATUSES:
+        return RuntimeTruthState.UNKNOWN
+    if (
+        receipt_type in TERMINAL_RECEIPT_TYPES
+        and receipt_status in TERMINAL_BLOCKED_STATUSES
+    ):
+        return RuntimeTruthState.BLOCKED_BY_RECEIPT
+    if (
+        receipt_type in TERMINAL_RECEIPT_TYPES
+        and receipt_status in TERMINAL_SUCCESS_STATUSES
+    ):
+        return RuntimeTruthState.COMPLETED_BY_RECEIPT
+    return RuntimeTruthState.UNKNOWN
+
+
+def _retry_state(record: sqlite3.Row | None) -> RuntimeTruthState:
+    status = _field(record, "status").lower()
+    if not status:
+        return RuntimeTruthState.UNKNOWN
+    if status in {"completed", "skipped"}:
+        return RuntimeTruthState.RETRY_EQUIVALENT
+    if status in {"parameter_mismatch", "conflict"}:
+        return RuntimeTruthState.RETRY_PARAMETER_MISMATCH
+    return RuntimeTruthState.OBSERVED
+
+
+def _artifact_ref(artifact: sqlite3.Row) -> str:
+    path = _field(artifact, "payload_path") or _field(artifact, "manifest_path")
+    if path:
+        return f"artifact_records:{artifact['artifact_id']}:{path}"
+    return f"artifact_records:{artifact['artifact_id']}"
+
+
+def _missing_fields(
+    *,
+    run_id: str | None,
+    task_id: str | None,
+    correlation_id: str | None,
+    receipt_refs: list[str],
+    mission_id: str | None,
+    idempotency: sqlite3.Row | None,
+    claim: sqlite3.Row | None,
+    run: sqlite3.Row | None,
+    artifacts: list[sqlite3.Row],
+) -> list[str]:
+    fields: list[str] = []
+    if not run_id:
+        fields.append("run_id")
+    if not task_id:
+        fields.append("task_id")
+    if not correlation_id:
+        fields.append("correlation_id")
+    if not receipt_refs:
+        fields.append("receipt_refs")
+    if not mission_id:
+        fields.append("mission_id")
+    if idempotency is None:
+        fields.append("idempotency_record")
+    if claim is None:
+        fields.append("task_claim")
+    if run is None:
+        fields.append("delegation_run")
+    if not artifacts:
+        fields.append("artifact_refs")
+    return fields

--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -6,16 +6,16 @@ Do not hand-edit the generated block.
 <!-- DOCOPS:START metric=repo_inventory -->
 | Metric | Value |
 |---|---:|
-| Dharma Python modules | 662 |
+| Dharma Python modules | 663 |
 | Top-level Dharma Python modules | 389 |
-| Dharma Python LOC | 281,387 |
+| Dharma Python LOC | 282,274 |
 | Test files | 625 |
-| Test function occurrences | 10,796 |
+| Test function occurrences | 10,804 |
 | Markdown files | 771 |
-| Markdown total lines | 193,218 |
+| Markdown total lines | 193,193 |
 | Bridge files | 24 |
 | Adapter files | 21 |
 | Orchestrator files | 4 |
 | Router files | 14 |
-| Authority candidate docs | 311 |
+| Authority candidate docs | 310 |
 <!-- DOCOPS:END -->

--- a/docs/governance/ACTIVE_TRACK.yaml
+++ b/docs/governance/ACTIVE_TRACK.yaml
@@ -26,140 +26,146 @@ schema_version: 1
 # Active track (exactly one block with status=ACTIVE at any time)
 # ---------------------------------------------------------------------------
 active_track:
-  id: runtime-truth-spine-2026-06
-  name: Runtime Truth Spine — one invariant, one invocation path, one receipt
+  id: runtime-truth-reconciliation-2026-06
+  name: Runtime Truth Reconciliation — operator-visible truth packets
   status: ACTIVE
-  opened_at: "2026-05-28"
-  verified_at: "2026-05-28"
+  opened_at: "2026-06-04"
+  verified_at: "2026-06-04"
   ttl_days: 14
   owner: "@AmitabhainArunachala"
 
   description: |
-    Define the Runtime Truth Spine before expanding agent fabric. Three audits
-    (Perplexity, Codex, Devin) converged: dharma_swarm has accreted without a
-    spine. The fix is one invariant chain (Task + Runner + Claim + Context +
-    RoutingDecision + ProviderCall + EvidenceReceipt = safe execution path).
-    Every dispatch produces exactly one receipt. No more generic dispatch_dropoff.
+    The Runtime Truth Spine substrate is merged and shippable. This track moves
+    from substrate existence to read-only reconciliation: operator-visible
+    runtime truth packets that separate heartbeat, readiness, artifact progress,
+    completion, authority, projection/cache, mutation, and external-gated proof.
 
-    PR A.5 (governance convergence): the spine guard is fused into the existing
-    uplift_guards composition (no parallel CI workflow), each closure layer's
-    canonical receipt is declared in ACTIVE_SURFACE_MANIFEST.yaml under
-    correlation_spine, and ANTI_SLOP Rule 2 is extended with role vocabulary
-    so future receipts must declare their layer instead of growing a second
-    truth surface.
+    The track must not create a new truth store, daemon, receipt system, or
+    authority surface. It projects from existing owners only:
+    spine.EvidenceReceipt for in-flight dispatch proof, runtime_state.RuntimeReceipt
+    for persisted runtime receipts, IdempotencyRecord for exactly-once substrate,
+    and existing operator/onboard/control-surface rows for read-only rendering.
 
-    Doctrine line that must hold across all closure layers:
-      Receipts may differ by closure layer. Correlation identity must not.
-
-    Reference: docs/reports/CONVERGED_SEAM_AUDIT_RUNTIME_TRUTH_SPINE.md
-    A2A anchor: dharma_swarm/a2a/README.md (three-layer receipt architecture)
+    Doctrine line that must hold:
+      Read models project truth from owners; they do not become authority.
 
   surfaces:
-    - dharma_swarm/spine/**
-    - dharma_swarm/orchestrator.py
-    - dharma_swarm/agent_runner.py
+    - dharma_swarm/operator_core/contracts.py
+    - dharma_swarm/operator_core/control_surface_models.py
+    - dharma_swarm/operator_core/control_surface.py
+    - scripts/governance/agent_onboard.py
     - dharma_swarm/runtime_state.py
-    - tests/test_dispatch_dropoff_sources.py
-    - scripts/uplift_guards/check_spine_ownership.py
-    - ACTIVE_SURFACE_MANIFEST.yaml
-    - .semgrep/dharma-anti-slop.yml
+    - dharma_swarm/a2a/a2a_bridge.py
+    - dharma_swarm/a2a/a2a_server.py
+    - tests/test_agent_onboard.py
+    - tests/test_operator_core_contracts.py
+    - tests/test_spine_persistence_invariant.py
+    - tests/test_spine_adoption_dispatch.py
 
   prerequisites:
-    - id: converged_doctrine_exists
+    - id: runtime_spine_package_exists
       kind: file_exists
-      file: docs/reports/CONVERGED_SEAM_AUDIT_RUNTIME_TRUTH_SPINE.md
-    - id: a2a_tier1_merged
-      kind: file_contains
-      file: dharma_swarm/a2a/a2a_server.py
-      pattern: "A2ATaskStatus"
+      file: dharma_swarm/spine/__init__.py
+    - id: receipt_equivalence_matrix_exists
+      kind: file_exists
+      file: docs/research/RECEIPT_AND_VEL_EQUIVALENCE_MATRIX.md
+    - id: a2a_persistence_invariant_tests_exist
+      kind: file_exists
+      file: tests/test_spine_persistence_invariant.py
 
   completion_criteria:
-    - id: spine_package_exists
+    - id: runtime_truth_packet_defined
+      kind: file_contains
+      file: dharma_swarm/operator_core/contracts.py
+      pattern: "class RuntimeTruthPacket"
+    - id: runtime_truth_axes_defined
+      kind: file_contains
+      file: dharma_swarm/operator_core/contracts.py
+      pattern: "class RuntimeTruthState"
+    - id: onboard_runtime_truth_render
+      kind: file_contains
+      file: scripts/governance/agent_onboard.py
+      pattern: "render_runtime_truth"
+    - id: onboard_runtime_truth_no_write_test
+      kind: file_contains
+      file: tests/test_agent_onboard.py
+      pattern: "test_runtime_truth_render_is_read_only"
+    - id: runtime_truth_packet_axis_test
+      kind: file_contains
+      file: tests/test_operator_core_contracts.py
+      pattern: "test_runtime_truth_packet_keeps_state_axes_separate"
+    - id: a2a_single_persistence_invariant
+      kind: file_contains
+      file: tests/test_spine_persistence_invariant.py
+      pattern: "test_submit_via_spine_retry_does_not_create_second_runtime_receipt"
+    - id: spine_bypass_report_exists
       kind: file_exists
-      file: dharma_swarm/spine/__init__.py
-    - id: evidence_receipt_defined
+      file: scripts/governance/spine_bypass_report.py
+    - id: receipt_json_projection_only_doc
       kind: file_contains
-      file: dharma_swarm/spine/receipt.py
-      pattern: "class EvidenceReceipt"
-    - id: routing_decision_defined
-      kind: file_contains
-      file: dharma_swarm/spine/routing.py
-      pattern: "class RoutingDecision"
-    - id: invoke_agent_defined
-      kind: file_contains
-      file: dharma_swarm/spine/invoke.py
-      pattern: "async def invoke_agent"
-    - id: spine_ownership_guard
-      kind: file_exists
-      file: scripts/uplift_guards/check_spine_ownership.py
-    - id: spine_guard_registered
-      kind: file_contains
-      file: scripts/uplift_guards/run_pre_commit.py
-      pattern: "check_spine_ownership"
-    - id: spine_doctrine_anchored
-      kind: file_contains
-      file: dharma_swarm/spine/__init__.py
-      pattern: "Correlation identity must not"
-    - id: correlation_spine_manifest_block
+      file: docs/research/RECEIPT_AND_VEL_EQUIVALENCE_MATRIX.md
+      pattern: "projection/cache only"
+    - id: correlation_spine_manifest_still_declared
       kind: file_contains
       file: ACTIVE_SURFACE_MANIFEST.yaml
       pattern: "correlation_spine:"
-    - id: correlation_id_alias_present
+    - id: evidence_receipt_still_defined
       kind: file_contains
       file: dharma_swarm/spine/receipt.py
-      pattern: "dharma.correlation_id"
-    - id: onboard_renders_spine
-      kind: file_contains
-      file: scripts/governance/agent_onboard.py
-      pattern: "render_spine_status"
-    - id: anti_slop_role_vocabulary
-      kind: file_contains
-      file: docs/governance/ANTI_SLOP_RULES.md
-      pattern: "canonical-store"
-    - id: runtime_state_receipt_field
+      pattern: "class EvidenceReceipt"
+    - id: runtime_receipt_still_defined
       kind: file_contains
       file: dharma_swarm/runtime_state.py
-      pattern: "receipt_json"
-    - id: dropoff_tests_pass
-      kind: file_contains
-      file: tests/test_dispatch_dropoff_sources.py
-      pattern: "test_provider_failure_not_confused_with_dropoff"
+      pattern: "class RuntimeReceipt"
 
   non_goals:
-    - Do not decompose AgentRunner.run_task in this track (except where strictly necessary).
-    - Do not split providers.py into per-provider files yet.
-    - Do not rewrite SwarmManager.
-    - Do not introduce Redis, gRPC, or a new daemon as part of THIS track. (NATS substrate scoped out of this track but no longer globally prohibited as of doctrine amendment 2026-05-31; runs as a concurrent scoped track when opened, with non-overlapping surfaces.)
-    - Do not create a second event log or truth surface.
-    - Do not add another spiritual/metaphoric naming layer.
-    - Do not add a parallel spine-check CI workflow — the uplift_guards composition is the only entry point.
+    - Do not create a new daemon, database, event log, truth store, or receipt system.
+    - Do not mint a second RuntimeReceipt for A2A or paths with an inner runtime owner.
+    - Do not mutate external systems, live processes, archive fitness, payments, or gateways.
+    - Do not broadly refactor orchestrator.py, agent_runner.py, swarm.py, providers.py, or SwarmManager.
+    - Do not build Verified Experiment Loop runtime in this track.
+    - Do not create standalone BetCard, Experiment, SwarmRun, DecisionRecord, LineageRecord, WikiUpdate, or cost-tracker classes.
 
   next_items:
     - id: 1
-      what: "Define spine types (EvidenceReceipt, RoutingDecision, invoke_agent) — zero behavior change."
+      what: "Define the smallest read-only RuntimeTruthPacket contract in the existing operator_core owner."
       kind: code
       blocker: true
     - id: 2
-      what: "Wire A2A into the spine (invoke_agent becomes the only invocation path for A2A delegation)."
+      what: "Render compact runtime truth in make onboard without making onboard an authority surface."
       kind: code
       blocker: true
     - id: 3
-      what: "Collapse 7 routers to 2 on the spine rail."
-      kind: code
-      blocker: false
-    - id: 4
-      what: "Shard providers.py into per-provider files."
-      kind: code
-      blocker: false
-    - id: 5
-      what: "Decompose agent_runner.py run_task onto spine boundary."
-      kind: code
+      what: "Protect A2A single-persistence invariant while adding runtime truth projections."
+      kind: test
       blocker: false
 
 # ---------------------------------------------------------------------------
 # Closed tracks (history, append-only; do not edit prior entries)
 # ---------------------------------------------------------------------------
 closed_tracks:
+  - id: runtime-truth-spine-2026-06
+    name: Runtime Truth Spine — one invariant, one invocation path, one receipt
+    status: SHIPPED
+    opened_at: "2026-05-28"
+    closed_at: "2026-06-04"
+    closed_by: "codex/runtime-truth-spine-e2e-20260604T143553Z"
+    evidence:
+      - "reports/governance/active_track_evidence.md — completion criteria 13/13, shippable YES"
+      - "dharma_swarm/spine/__init__.py — Runtime Truth Spine package present"
+      - "dharma_swarm/spine/receipt.py — EvidenceReceipt defined"
+      - "dharma_swarm/spine/invoke.py — invoke_agent defined"
+      - "tests/test_spine_persistence_invariant.py — A2A single-persistence invariant test surface present"
+      - "scripts/governance/spine_bypass_report.py — A2A bypass report surface present"
+    superseded_by: runtime-truth-reconciliation-2026-06
+    notes: |
+      Substrate track closed after PRs #471, #468, and #470 landed. The next
+      track moves from substrate existence to read-only runtime truth
+      reconciliation. Receipt doctrine remains binding: EvidenceReceipt is
+      in-flight dispatch proof, RuntimeReceipt is persisted runtime proof,
+      IdempotencyRecord is the exactly-once substrate, and receipt_json is
+      projection/cache only.
+
   - id: trace-identity-coverage-2026-05
     name: Trace Identity Coverage — native propagation and soft coverage findings
     status: SUPERSEDED

--- a/docs/governance/BUILD_SESSION_ENTRYPOINT.md
+++ b/docs/governance/BUILD_SESSION_ENTRYPOINT.md
@@ -48,56 +48,48 @@ The governing principle behind whatever track is active: **one seam, end-to-end,
      Do not hand-edit. Run scripts/governance/render_active_track_includes.py
      after updating the YAML. -->
 
-**Active track:** Runtime Truth Spine — one invariant, one invocation path, one receipt
-**Track id:** `runtime-truth-spine-2026-06`
+**Active track:** Runtime Truth Reconciliation — operator-visible truth packets
+**Track id:** `runtime-truth-reconciliation-2026-06`
 **Status:** ACTIVE
-**Verified at:** 2026-05-28 (TTL 14 days)
+**Verified at:** 2026-06-04 (TTL 14 days)
 **Owner:** @AmitabhainArunachala
 
 **Description:**
 
-Define the Runtime Truth Spine before expanding agent fabric. Three audits
-(Perplexity, Codex, Devin) converged: dharma_swarm has accreted without a
-spine. The fix is one invariant chain (Task + Runner + Claim + Context +
-RoutingDecision + ProviderCall + EvidenceReceipt = safe execution path).
-Every dispatch produces exactly one receipt. No more generic dispatch_dropoff.
+The Runtime Truth Spine substrate is merged and shippable. This track moves
+from substrate existence to read-only reconciliation: operator-visible
+runtime truth packets that separate heartbeat, readiness, artifact progress,
+completion, authority, projection/cache, mutation, and external-gated proof.
 
-PR A.5 (governance convergence): the spine guard is fused into the existing
-uplift_guards composition (no parallel CI workflow), each closure layer's
-canonical receipt is declared in ACTIVE_SURFACE_MANIFEST.yaml under
-correlation_spine, and ANTI_SLOP Rule 2 is extended with role vocabulary
-so future receipts must declare their layer instead of growing a second
-truth surface.
+The track must not create a new truth store, daemon, receipt system, or
+authority surface. It projects from existing owners only:
+spine.EvidenceReceipt for in-flight dispatch proof, runtime_state.RuntimeReceipt
+for persisted runtime receipts, IdempotencyRecord for exactly-once substrate,
+and existing operator/onboard/control-surface rows for read-only rendering.
 
-Doctrine line that must hold across all closure layers:
-  Receipts may differ by closure layer. Correlation identity must not.
-
-Reference: docs/reports/CONVERGED_SEAM_AUDIT_RUNTIME_TRUTH_SPINE.md
-A2A anchor: dharma_swarm/a2a/README.md (three-layer receipt architecture)
+Doctrine line that must hold:
+  Read models project truth from owners; they do not become authority.
 
 **Next items on this track:**
 
-- [code] (blocker) Define spine types (EvidenceReceipt, RoutingDecision, invoke_agent) — zero behavior change.
-- [code] (blocker) Wire A2A into the spine (invoke_agent becomes the only invocation path for A2A delegation).
-- [code] Collapse 7 routers to 2 on the spine rail.
-- [code] Shard providers.py into per-provider files.
-- [code] Decompose agent_runner.py run_task onto spine boundary.
+- [code] (blocker) Define the smallest read-only RuntimeTruthPacket contract in the existing operator_core owner.
+- [code] (blocker) Render compact runtime truth in make onboard without making onboard an authority surface.
+- [test] Protect A2A single-persistence invariant while adding runtime truth projections.
 
 **Non-goals (do not work on these during this track):**
 
-- Do not decompose AgentRunner.run_task in this track (except where strictly necessary).
-- Do not split providers.py into per-provider files yet.
-- Do not rewrite SwarmManager.
-- Do not introduce Redis, gRPC, or a new daemon as part of THIS track. (NATS substrate scoped out of this track but no longer globally prohibited as of doctrine amendment 2026-05-31; runs as a concurrent scoped track when opened, with non-overlapping surfaces.)
-- Do not create a second event log or truth surface.
-- Do not add another spiritual/metaphoric naming layer.
-- Do not add a parallel spine-check CI workflow — the uplift_guards composition is the only entry point.
+- Do not create a new daemon, database, event log, truth store, or receipt system.
+- Do not mint a second RuntimeReceipt for A2A or paths with an inner runtime owner.
+- Do not mutate external systems, live processes, archive fitness, payments, or gateways.
+- Do not broadly refactor orchestrator.py, agent_runner.py, swarm.py, providers.py, or SwarmManager.
+- Do not build Verified Experiment Loop runtime in this track.
+- Do not create standalone BetCard, Experiment, SwarmRun, DecisionRecord, LineageRecord, WikiUpdate, or cost-tracker classes.
 
 **Recently closed tracks:**
 
-- `boardstore-facade-2026-05` — BoardStore Facade — unified task/state surface for multi-agent coordination (SHIPPED, closed 2026-05-20)
-- `cockpit-control-surface-2026-05` — Operator Cockpit v1 + Control-Surface contract hardening (SHIPPED, closed 2026-05-20)
-- `operator-brief-seam-2026-04` — Ontology-Native Operator Brief (first substrate-native seam) (SHIPPED, closed 2026-05-19)
+- `runtime-truth-spine-2026-06` — Runtime Truth Spine — one invariant, one invocation path, one receipt (SHIPPED, closed 2026-06-04)
+- `trace-identity-coverage-2026-05` — Trace Identity Coverage — native propagation and soft coverage findings (SUPERSEDED, closed 2026-05-28)
+- `trace-attractor-causal-spine-2026-05` — Trace Attractor Causal Spine — operator-visible trace packets (SHIPPED, closed 2026-05-21)
 
 For machine-readable status, see [`reports/governance/active_track_evidence.md`](../../reports/governance/active_track_evidence.md) (generated by `scripts/governance/check_track_status.py`).
 

--- a/docs/governance/SOVEREIGN_MANIFEST.md
+++ b/docs/governance/SOVEREIGN_MANIFEST.md
@@ -18,56 +18,48 @@
      Do not hand-edit. Run scripts/governance/render_active_track_includes.py
      after updating the YAML. -->
 
-**Active track:** Runtime Truth Spine — one invariant, one invocation path, one receipt
-**Track id:** `runtime-truth-spine-2026-06`
+**Active track:** Runtime Truth Reconciliation — operator-visible truth packets
+**Track id:** `runtime-truth-reconciliation-2026-06`
 **Status:** ACTIVE
-**Verified at:** 2026-05-28 (TTL 14 days)
+**Verified at:** 2026-06-04 (TTL 14 days)
 **Owner:** @AmitabhainArunachala
 
 **Description:**
 
-Define the Runtime Truth Spine before expanding agent fabric. Three audits
-(Perplexity, Codex, Devin) converged: dharma_swarm has accreted without a
-spine. The fix is one invariant chain (Task + Runner + Claim + Context +
-RoutingDecision + ProviderCall + EvidenceReceipt = safe execution path).
-Every dispatch produces exactly one receipt. No more generic dispatch_dropoff.
+The Runtime Truth Spine substrate is merged and shippable. This track moves
+from substrate existence to read-only reconciliation: operator-visible
+runtime truth packets that separate heartbeat, readiness, artifact progress,
+completion, authority, projection/cache, mutation, and external-gated proof.
 
-PR A.5 (governance convergence): the spine guard is fused into the existing
-uplift_guards composition (no parallel CI workflow), each closure layer's
-canonical receipt is declared in ACTIVE_SURFACE_MANIFEST.yaml under
-correlation_spine, and ANTI_SLOP Rule 2 is extended with role vocabulary
-so future receipts must declare their layer instead of growing a second
-truth surface.
+The track must not create a new truth store, daemon, receipt system, or
+authority surface. It projects from existing owners only:
+spine.EvidenceReceipt for in-flight dispatch proof, runtime_state.RuntimeReceipt
+for persisted runtime receipts, IdempotencyRecord for exactly-once substrate,
+and existing operator/onboard/control-surface rows for read-only rendering.
 
-Doctrine line that must hold across all closure layers:
-  Receipts may differ by closure layer. Correlation identity must not.
-
-Reference: docs/reports/CONVERGED_SEAM_AUDIT_RUNTIME_TRUTH_SPINE.md
-A2A anchor: dharma_swarm/a2a/README.md (three-layer receipt architecture)
+Doctrine line that must hold:
+  Read models project truth from owners; they do not become authority.
 
 **Next items on this track:**
 
-- [code] (blocker) Define spine types (EvidenceReceipt, RoutingDecision, invoke_agent) — zero behavior change.
-- [code] (blocker) Wire A2A into the spine (invoke_agent becomes the only invocation path for A2A delegation).
-- [code] Collapse 7 routers to 2 on the spine rail.
-- [code] Shard providers.py into per-provider files.
-- [code] Decompose agent_runner.py run_task onto spine boundary.
+- [code] (blocker) Define the smallest read-only RuntimeTruthPacket contract in the existing operator_core owner.
+- [code] (blocker) Render compact runtime truth in make onboard without making onboard an authority surface.
+- [test] Protect A2A single-persistence invariant while adding runtime truth projections.
 
 **Non-goals (do not work on these during this track):**
 
-- Do not decompose AgentRunner.run_task in this track (except where strictly necessary).
-- Do not split providers.py into per-provider files yet.
-- Do not rewrite SwarmManager.
-- Do not introduce Redis, gRPC, or a new daemon as part of THIS track. (NATS substrate scoped out of this track but no longer globally prohibited as of doctrine amendment 2026-05-31; runs as a concurrent scoped track when opened, with non-overlapping surfaces.)
-- Do not create a second event log or truth surface.
-- Do not add another spiritual/metaphoric naming layer.
-- Do not add a parallel spine-check CI workflow — the uplift_guards composition is the only entry point.
+- Do not create a new daemon, database, event log, truth store, or receipt system.
+- Do not mint a second RuntimeReceipt for A2A or paths with an inner runtime owner.
+- Do not mutate external systems, live processes, archive fitness, payments, or gateways.
+- Do not broadly refactor orchestrator.py, agent_runner.py, swarm.py, providers.py, or SwarmManager.
+- Do not build Verified Experiment Loop runtime in this track.
+- Do not create standalone BetCard, Experiment, SwarmRun, DecisionRecord, LineageRecord, WikiUpdate, or cost-tracker classes.
 
 **Recently closed tracks:**
 
-- `boardstore-facade-2026-05` — BoardStore Facade — unified task/state surface for multi-agent coordination (SHIPPED, closed 2026-05-20)
-- `cockpit-control-surface-2026-05` — Operator Cockpit v1 + Control-Surface contract hardening (SHIPPED, closed 2026-05-20)
-- `operator-brief-seam-2026-04` — Ontology-Native Operator Brief (first substrate-native seam) (SHIPPED, closed 2026-05-19)
+- `runtime-truth-spine-2026-06` — Runtime Truth Spine — one invariant, one invocation path, one receipt (SHIPPED, closed 2026-06-04)
+- `trace-identity-coverage-2026-05` — Trace Identity Coverage — native propagation and soft coverage findings (SUPERSEDED, closed 2026-05-28)
+- `trace-attractor-causal-spine-2026-05` — Trace Attractor Causal Spine — operator-visible trace packets (SHIPPED, closed 2026-05-21)
 
 For machine-readable status, see [`reports/governance/active_track_evidence.md`](../../reports/governance/active_track_evidence.md) (generated by `scripts/governance/check_track_status.py`).
 
@@ -80,7 +72,7 @@ For machine-readable status, see [`reports/governance/active_track_evidence.md`]
 These are immutable engineering laws for this repository. Violation = architectural regression.
 
 ### A1: NO FLAT-PACKAGE GROWTH
-The `dharma_swarm/` package currently has **389 files at its top level (58.9% of 661 total Python modules)** (V). No new .py file may be added to the top level. New modules must go into an appropriate subdirectory. Existing top-level files will be organized over time.
+The `dharma_swarm/` package currently has **389 files at its top level (58.7% of 663 total Python modules)** (V). No new .py file may be added to the top level. New modules must go into an appropriate subdirectory. Existing top-level files will be organized over time.
 
 ### A2: NO DUPLICATE IMPLEMENTATIONS
 Before creating a new file for routing, bridging, adapting, or orchestrating, check if one already exists. The repo currently has **24 bridge files** (V), **3 model_routing copies** (2 are identical, 1 is different) (V), **4 orchestrators** (V), **21 adapter files across 8 locations** (V), and **14 router files** (V). Do not add more without deprecating an existing one.
@@ -104,7 +96,7 @@ No single file should exceed 3,000 lines. Current violations (V):
 **148 files exceed 500 lines; 39 exceed 1,000; 7 exceed 3,000** (V). These must be decomposed over time, not grown further.
 
 ### A6: DOCS DECAY -- CHECK BEFORE CITING
-All numerical claims in docs become stale within weeks. Before citing module counts, test counts, or line counts from any doc (including this one), verify against the actual filesystem. See `REPO_GOVERNANCE_AUDIT.md` for the current staleness log. The current DocOps inventory reports **279 Markdown files containing at least one reserved trust-language term** (V). Treat these as authority-scope review candidates, not confirmed repo-wide authority.
+All numerical claims in docs become stale within weeks. Before citing module counts, test counts, or line counts from any doc (including this one), verify against the actual filesystem. See `REPO_GOVERNANCE_AUDIT.md` for the current staleness log. The current DocOps inventory reports **310 Markdown files containing at least one reserved trust-language term** (V). Treat these as authority-scope review candidates, not confirmed repo-wide authority.
 
 ### A7: NO CIRCULAR IMPORTS
 The repo has **9 verified circular dependency chains** (V). The worst:
@@ -115,25 +107,25 @@ The repo has **9 verified circular dependency chains** (V). The worst:
 All 9 cycles were independently confirmed with exact import lines. Most are mitigated by lazy imports but remain architectural debt. **New code must not create circular imports.**
 
 ### A8: FRONTMATTER DISCIPLINE
-Do not inject machine-readable YAML frontmatter into governance or architecture docs unless explicitly requested. Current state: **215 of 709 Markdown files start with YAML frontmatter; 15 of 25 docs/architecture Markdown files do so** (V). Long frontmatter remains an authority/noise risk even when the prose is useful.
+Do not inject machine-readable YAML frontmatter into governance or architecture docs unless explicitly requested. Current state: **216 of 771 Markdown files start with YAML frontmatter; 15 of 43 docs/architecture Markdown files do so** (V). Long frontmatter remains an authority/noise risk even when the prose is useful.
 
 ---
 
-## VERIFIED NUMBERS (2026-06-04 COUNT REFRESH)
+## VERIFIED NUMBERS (2026-06-05 COUNT REFRESH)
 
 These are the ground-truth metrics. All other documents citing different numbers are stale.
 
 | Metric | Value | Verification |
 |--------|-------|-------------|
-| Total Python modules | **662** | find dharma_swarm -name "*.py" -type f |
-| Top-level (flat) modules | **389 (59.0%)** | find dharma_swarm -maxdepth 1 -name "*.py" -type f |
-| Total Python LOC | **281,387** | wc -l across dharma_swarm Python modules |
+| Total Python modules | **663** | find dharma_swarm -name "*.py" -type f |
+| Top-level (flat) modules | **389 (58.7%)** | find dharma_swarm -maxdepth 1 -name "*.py" -type f |
+| Total Python LOC | **282,274** | wc -l across dharma_swarm Python modules |
 | Test files | **625** | find tests -name "*.py" -type f |
-| Test functions | **10,796 `def test_` occurrences under tests/** | rg "def test_" tests |
+| Test functions | **10,804 `def test_` occurrences under tests/** | rg "def test_" tests |
 | Tests collected (pytest) | **Needs write-permitted refresh** | not run during this DocOps count pass |
 | Collection errors | **Historical: 16 on 2026-04-04** | refresh before relying on this count |
 | Markdown files | **771** | find . -name "*.md" -type f |
-| Markdown total lines | **193,218** | wc -l across all .md |
+| Markdown total lines | **193,193** | wc -l across all .md |
 | Bridge files | **24** | find dharma_swarm -name "*bridge*.py" |
 | Adapter files | **21 across 8 locations** | find dharma_swarm -type f \| rg -i "adapter" |
 | Orchestrator files | **4** (6,034 LOC total) | find dharma_swarm -name "*orchestrat*" |

--- a/reports/governance/active_track_evidence.json
+++ b/reports/governance/active_track_evidence.json
@@ -1,109 +1,103 @@
 {
-  "generated_at": "2026-06-01T21:50:17+08:00",
-  "active_track_id": "runtime-truth-spine-2026-06",
+  "generated_at": "2026-06-05T15:26:06+09:00",
+  "active_track_id": "runtime-truth-reconciliation-2026-06",
   "shippable": true,
   "prerequisites_ok": true,
   "completion_progress": {
-    "passed": 13,
-    "total": 13
+    "passed": 11,
+    "total": 11
   },
   "criteria": [
     {
-      "id": "converged_doctrine_exists",
-      "kind": "file_exists",
-      "passed": true,
-      "detail": "docs/reports/CONVERGED_SEAM_AUDIT_RUNTIME_TRUTH_SPINE.md present"
-    },
-    {
-      "id": "a2a_tier1_merged",
-      "kind": "file_contains",
-      "passed": true,
-      "detail": "pattern 'A2ATaskStatus' found in dharma_swarm/a2a/a2a_server.py"
-    },
-    {
-      "id": "spine_package_exists",
+      "id": "runtime_spine_package_exists",
       "kind": "file_exists",
       "passed": true,
       "detail": "dharma_swarm/spine/__init__.py present"
     },
     {
-      "id": "evidence_receipt_defined",
-      "kind": "file_contains",
-      "passed": true,
-      "detail": "pattern 'class EvidenceReceipt' found in dharma_swarm/spine/receipt.py"
-    },
-    {
-      "id": "routing_decision_defined",
-      "kind": "file_contains",
-      "passed": true,
-      "detail": "pattern 'class RoutingDecision' found in dharma_swarm/spine/routing.py"
-    },
-    {
-      "id": "invoke_agent_defined",
-      "kind": "file_contains",
-      "passed": true,
-      "detail": "pattern 'async def invoke_agent' found in dharma_swarm/spine/invoke.py"
-    },
-    {
-      "id": "spine_ownership_guard",
+      "id": "receipt_equivalence_matrix_exists",
       "kind": "file_exists",
       "passed": true,
-      "detail": "scripts/uplift_guards/check_spine_ownership.py present"
+      "detail": "docs/research/RECEIPT_AND_VEL_EQUIVALENCE_MATRIX.md present"
     },
     {
-      "id": "spine_guard_registered",
+      "id": "a2a_persistence_invariant_tests_exist",
+      "kind": "file_exists",
+      "passed": true,
+      "detail": "tests/test_spine_persistence_invariant.py present"
+    },
+    {
+      "id": "runtime_truth_packet_defined",
       "kind": "file_contains",
       "passed": true,
-      "detail": "pattern 'check_spine_ownership' found in scripts/uplift_guards/run_pre_commit.py"
+      "detail": "pattern 'class RuntimeTruthPacket' found in dharma_swarm/operator_core/contracts.py"
     },
     {
-      "id": "spine_doctrine_anchored",
+      "id": "runtime_truth_axes_defined",
       "kind": "file_contains",
       "passed": true,
-      "detail": "pattern 'Correlation identity must not' found in dharma_swarm/spine/__init__.py"
+      "detail": "pattern 'class RuntimeTruthState' found in dharma_swarm/operator_core/contracts.py"
     },
     {
-      "id": "correlation_spine_manifest_block",
+      "id": "onboard_runtime_truth_render",
+      "kind": "file_contains",
+      "passed": true,
+      "detail": "pattern 'render_runtime_truth' found in scripts/governance/agent_onboard.py"
+    },
+    {
+      "id": "onboard_runtime_truth_no_write_test",
+      "kind": "file_contains",
+      "passed": true,
+      "detail": "pattern 'test_runtime_truth_render_is_read_only' found in tests/test_agent_onboard.py"
+    },
+    {
+      "id": "runtime_truth_packet_axis_test",
+      "kind": "file_contains",
+      "passed": true,
+      "detail": "pattern 'test_runtime_truth_packet_keeps_state_axes_separate' found in tests/test_operator_core_contracts.py"
+    },
+    {
+      "id": "a2a_single_persistence_invariant",
+      "kind": "file_contains",
+      "passed": true,
+      "detail": "pattern 'test_submit_via_spine_retry_does_not_create_second_runtime_receipt' found in tests/test_spine_persistence_invariant.py"
+    },
+    {
+      "id": "spine_bypass_report_exists",
+      "kind": "file_exists",
+      "passed": true,
+      "detail": "scripts/governance/spine_bypass_report.py present"
+    },
+    {
+      "id": "receipt_json_projection_only_doc",
+      "kind": "file_contains",
+      "passed": true,
+      "detail": "pattern 'projection/cache only' found in docs/research/RECEIPT_AND_VEL_EQUIVALENCE_MATRIX.md"
+    },
+    {
+      "id": "correlation_spine_manifest_still_declared",
       "kind": "file_contains",
       "passed": true,
       "detail": "pattern 'correlation_spine:' found in ACTIVE_SURFACE_MANIFEST.yaml"
     },
     {
-      "id": "correlation_id_alias_present",
+      "id": "evidence_receipt_still_defined",
       "kind": "file_contains",
       "passed": true,
-      "detail": "pattern 'dharma.correlation_id' found in dharma_swarm/spine/receipt.py"
+      "detail": "pattern 'class EvidenceReceipt' found in dharma_swarm/spine/receipt.py"
     },
     {
-      "id": "onboard_renders_spine",
+      "id": "runtime_receipt_still_defined",
       "kind": "file_contains",
       "passed": true,
-      "detail": "pattern 'render_spine_status' found in scripts/governance/agent_onboard.py"
-    },
-    {
-      "id": "anti_slop_role_vocabulary",
-      "kind": "file_contains",
-      "passed": true,
-      "detail": "pattern 'canonical-store' found in docs/governance/ANTI_SLOP_RULES.md"
-    },
-    {
-      "id": "runtime_state_receipt_field",
-      "kind": "file_contains",
-      "passed": true,
-      "detail": "pattern 'receipt_json' found in dharma_swarm/runtime_state.py"
-    },
-    {
-      "id": "dropoff_tests_pass",
-      "kind": "file_contains",
-      "passed": true,
-      "detail": "pattern 'test_provider_failure_not_confused_with_dropoff' found in tests/test_dispatch_dropoff_sources.py"
+      "detail": "pattern 'class RuntimeReceipt' found in dharma_swarm/runtime_state.py"
     }
   ],
   "findings": [
     {
       "severity": "INFO",
       "check": "track-shippable",
-      "message": "All 13 completion criteria pass. Track 'runtime-truth-spine-2026-06' is SHIPPABLE \u2014 close it and declare the next active track.",
+      "message": "All 11 completion criteria pass. Track 'runtime-truth-reconciliation-2026-06' is SHIPPABLE \u2014 close it and declare the next active track.",
       "criterion_id": null
     }
   ]

--- a/reports/governance/active_track_evidence.md
+++ b/reports/governance/active_track_evidence.md
@@ -1,29 +1,28 @@
 # Active Track Evidence
 
-Generated: 2026-06-01T21:50:17+08:00
-Track: `runtime-truth-spine-2026-06`
+Generated: 2026-06-05T15:26:06+09:00
+Track: `runtime-truth-reconciliation-2026-06`
 Prerequisites: **OK**
-Completion: **13/13**
+Completion: **11/11**
 Shippable: **YES**
 
 ## Criteria
 
-- ✓ `converged_doctrine_exists` (file_exists) — docs/reports/CONVERGED_SEAM_AUDIT_RUNTIME_TRUTH_SPINE.md present
-- ✓ `a2a_tier1_merged` (file_contains) — pattern 'A2ATaskStatus' found in dharma_swarm/a2a/a2a_server.py
-- ✓ `spine_package_exists` (file_exists) — dharma_swarm/spine/__init__.py present
-- ✓ `evidence_receipt_defined` (file_contains) — pattern 'class EvidenceReceipt' found in dharma_swarm/spine/receipt.py
-- ✓ `routing_decision_defined` (file_contains) — pattern 'class RoutingDecision' found in dharma_swarm/spine/routing.py
-- ✓ `invoke_agent_defined` (file_contains) — pattern 'async def invoke_agent' found in dharma_swarm/spine/invoke.py
-- ✓ `spine_ownership_guard` (file_exists) — scripts/uplift_guards/check_spine_ownership.py present
-- ✓ `spine_guard_registered` (file_contains) — pattern 'check_spine_ownership' found in scripts/uplift_guards/run_pre_commit.py
-- ✓ `spine_doctrine_anchored` (file_contains) — pattern 'Correlation identity must not' found in dharma_swarm/spine/__init__.py
-- ✓ `correlation_spine_manifest_block` (file_contains) — pattern 'correlation_spine:' found in ACTIVE_SURFACE_MANIFEST.yaml
-- ✓ `correlation_id_alias_present` (file_contains) — pattern 'dharma.correlation_id' found in dharma_swarm/spine/receipt.py
-- ✓ `onboard_renders_spine` (file_contains) — pattern 'render_spine_status' found in scripts/governance/agent_onboard.py
-- ✓ `anti_slop_role_vocabulary` (file_contains) — pattern 'canonical-store' found in docs/governance/ANTI_SLOP_RULES.md
-- ✓ `runtime_state_receipt_field` (file_contains) — pattern 'receipt_json' found in dharma_swarm/runtime_state.py
-- ✓ `dropoff_tests_pass` (file_contains) — pattern 'test_provider_failure_not_confused_with_dropoff' found in tests/test_dispatch_dropoff_sources.py
+- ✓ `runtime_spine_package_exists` (file_exists) — dharma_swarm/spine/__init__.py present
+- ✓ `receipt_equivalence_matrix_exists` (file_exists) — docs/research/RECEIPT_AND_VEL_EQUIVALENCE_MATRIX.md present
+- ✓ `a2a_persistence_invariant_tests_exist` (file_exists) — tests/test_spine_persistence_invariant.py present
+- ✓ `runtime_truth_packet_defined` (file_contains) — pattern 'class RuntimeTruthPacket' found in dharma_swarm/operator_core/contracts.py
+- ✓ `runtime_truth_axes_defined` (file_contains) — pattern 'class RuntimeTruthState' found in dharma_swarm/operator_core/contracts.py
+- ✓ `onboard_runtime_truth_render` (file_contains) — pattern 'render_runtime_truth' found in scripts/governance/agent_onboard.py
+- ✓ `onboard_runtime_truth_no_write_test` (file_contains) — pattern 'test_runtime_truth_render_is_read_only' found in tests/test_agent_onboard.py
+- ✓ `runtime_truth_packet_axis_test` (file_contains) — pattern 'test_runtime_truth_packet_keeps_state_axes_separate' found in tests/test_operator_core_contracts.py
+- ✓ `a2a_single_persistence_invariant` (file_contains) — pattern 'test_submit_via_spine_retry_does_not_create_second_runtime_receipt' found in tests/test_spine_persistence_invariant.py
+- ✓ `spine_bypass_report_exists` (file_exists) — scripts/governance/spine_bypass_report.py present
+- ✓ `receipt_json_projection_only_doc` (file_contains) — pattern 'projection/cache only' found in docs/research/RECEIPT_AND_VEL_EQUIVALENCE_MATRIX.md
+- ✓ `correlation_spine_manifest_still_declared` (file_contains) — pattern 'correlation_spine:' found in ACTIVE_SURFACE_MANIFEST.yaml
+- ✓ `evidence_receipt_still_defined` (file_contains) — pattern 'class EvidenceReceipt' found in dharma_swarm/spine/receipt.py
+- ✓ `runtime_receipt_still_defined` (file_contains) — pattern 'class RuntimeReceipt' found in dharma_swarm/runtime_state.py
 
 ## Findings
 
-- **INFO** `track-shippable`: All 13 completion criteria pass. Track 'runtime-truth-spine-2026-06' is SHIPPABLE — close it and declare the next active track.
+- **INFO** `track-shippable`: All 11 completion criteria pass. Track 'runtime-truth-reconciliation-2026-06' is SHIPPABLE — close it and declare the next active track.

--- a/scripts/governance/agent_onboard.py
+++ b/scripts/governance/agent_onboard.py
@@ -77,6 +77,10 @@ def _today() -> date:
     return datetime.now(tz=timezone.utc).date()
 
 
+def _now_iso() -> str:
+    return datetime.now(tz=timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
 def _doc_staleness(doc_rel: str) -> tuple[int, str]:
     """Return (days_since_last_touch, last_commit_subject) for a doc."""
     last = git("log", "-1", "--format=%cI|%s", "--", doc_rel)
@@ -358,8 +362,11 @@ def render_spine_status() -> None:
     db_path = Path.home() / ".dharma" / "state" / "runtime.db"
     if db_path.exists():
         try:
-            import sqlite3
-            conn = sqlite3.connect(str(db_path))
+            from dharma_swarm.operator_core.runtime_truth import (
+                connect_runtime_db_read_only,
+            )
+
+            conn = connect_runtime_db_read_only(db_path)
             try:
                 cur = conn.cursor()
                 cur.execute("SELECT COUNT(*) FROM delegation_runs")
@@ -379,6 +386,199 @@ def render_spine_status() -> None:
             print(f"  (live DB unavailable: {type(exc).__name__})")
     else:
         print("  (runtime.db not present — no live stats)")
+
+
+def _runtime_db_path() -> Path:
+    state_dir = os.environ.get("DHARMA_STATE_DIR")
+    if state_dir:
+        return Path(state_dir).expanduser() / "runtime.db"
+    return Path.home() / ".dharma" / "state" / "runtime.db"
+
+
+def _runtime_truth_packets(
+    evidence: dict[str, Any] | None,
+    track: dict[str, Any],
+) -> list[Any]:
+    from dharma_swarm.operator_core.contracts import RuntimeTruthPacket, RuntimeTruthState
+    from dharma_swarm.operator_core.runtime_truth import (
+        runtime_truth_packets_from_runtime_db,
+    )
+
+    observed_at = _now_iso()
+    block = (track or {}).get("active_track") or {}
+    progress = (evidence or {}).get("completion_progress") or {}
+    passed = int(progress.get("passed") or 0)
+    total = int(progress.get("total") or 0)
+    criteria = (evidence or {}).get("criteria") or []
+    failed_ids = [
+        str(item.get("id"))
+        for item in criteria
+        if isinstance(item, dict) and not item.get("passed") and item.get("id")
+    ]
+    shippable = bool(evidence and evidence.get("shippable"))
+    prereqs_ok = bool(evidence and evidence.get("prerequisites_ok"))
+    active_track_id = str((evidence or {}).get("active_track_id") or block.get("id") or "unknown")
+
+    packets: list[Any] = [
+        RuntimeTruthPacket(
+            surface_id="governance.active_track",
+            kind="governance_projection",
+            observed_at=observed_at,
+            owner_surface="docs/governance/ACTIVE_TRACK.yaml",
+            source_kind="generated_evidence",
+            artifact_refs=[
+                str(EVIDENCE_JSON.relative_to(REPO_ROOT)),
+                "reports/governance/active_track_evidence.md",
+            ],
+            source_refs=[str(ACTIVE_TRACK.relative_to(REPO_ROOT))],
+            readiness_state=(
+                RuntimeTruthState.READY_BY_PROBE
+                if prereqs_ok
+                else RuntimeTruthState.NOT_READY_BY_PROBE
+            ),
+            progress_state=(
+                RuntimeTruthState.PROGRESSING_BY_ARTIFACT
+                if total and passed < total
+                else RuntimeTruthState.COMPLETED_BY_RECEIPT
+                if total and passed >= total
+                else RuntimeTruthState.UNKNOWN
+            ),
+            completion_state=(
+                RuntimeTruthState.COMPLETED_BY_RECEIPT
+                if shippable
+                else RuntimeTruthState.UNKNOWN
+            ),
+            authority_state=RuntimeTruthState.PROJECTION_ONLY,
+            source_state=RuntimeTruthState.OBSERVED if evidence else RuntimeTruthState.MISSING,
+            missing_machine_fields=[
+                "run_id",
+                "mission_id",
+                "correlation_id",
+                *[f"failed_criterion:{item}" for item in failed_ids],
+            ],
+            metadata={
+                "active_track_id": active_track_id,
+                "criteria_passed": passed,
+                "criteria_total": total,
+            },
+        )
+    ]
+
+    manifest_text = ""
+    if SURFACE_MANIFEST.exists():
+        manifest_text = SURFACE_MANIFEST.read_text(encoding="utf-8", errors="replace")
+    correlation_declared = "correlation_spine:" in manifest_text
+    packets.append(
+        RuntimeTruthPacket(
+            surface_id="correlation_spine.manifest",
+            kind="owner_manifest",
+            observed_at=observed_at,
+            owner_surface="ACTIVE_SURFACE_MANIFEST.yaml",
+            source_kind="repo_file_probe",
+            source_refs=[str(SURFACE_MANIFEST.relative_to(REPO_ROOT))],
+            readiness_state=(
+                RuntimeTruthState.READY_BY_PROBE
+                if correlation_declared
+                else RuntimeTruthState.NOT_READY_BY_PROBE
+            ),
+            authority_state=RuntimeTruthState.PROJECTION_ONLY,
+            source_state=(
+                RuntimeTruthState.OBSERVED
+                if correlation_declared
+                else RuntimeTruthState.MISSING
+            ),
+            probe_ok=correlation_declared,
+            missing_machine_fields=[] if correlation_declared else ["correlation_spine"],
+        )
+    )
+
+    runtime_db = _runtime_db_path()
+    packets.extend(
+        runtime_truth_packets_from_runtime_db(runtime_db, observed_at=observed_at)
+    )
+
+    invariant_test = REPO_ROOT / "tests/test_spine_persistence_invariant.py"
+    invariant_present = invariant_test.exists()
+    packets.append(
+        RuntimeTruthPacket(
+            surface_id="a2a.persistence_invariant",
+            kind="test_contract",
+            observed_at=observed_at,
+            owner_surface="tests/test_spine_persistence_invariant.py",
+            source_kind="repo_test_contract",
+            source_refs=[
+                "tests/test_spine_persistence_invariant.py",
+                "dharma_swarm/a2a/a2a_server.py",
+                "dharma_swarm/a2a/a2a_bridge.py",
+            ],
+            readiness_state=(
+                RuntimeTruthState.READY_BY_PROBE
+                if invariant_present
+                else RuntimeTruthState.NOT_READY_BY_PROBE
+            ),
+            completion_state=RuntimeTruthState.UNKNOWN,
+            evaluator_state=RuntimeTruthState.UNKNOWN,
+            authority_state=RuntimeTruthState.PROJECTION_ONLY,
+            probe_ok=invariant_present,
+            missing_machine_fields=[
+                "latest_test_run",
+                "latest_ci_run",
+            ] if invariant_present else ["test_contract"],
+        )
+    )
+
+    packets.append(
+        RuntimeTruthPacket(
+            surface_id="external.keystone_merge",
+            kind="external_truth",
+            observed_at=observed_at,
+            owner_surface="external_operator_state",
+            source_kind="external_gated",
+            source_refs=["external:abduznik/instrumation#98"],
+            authority_state=RuntimeTruthState.PROJECTION_ONLY,
+            external_state=RuntimeTruthState.EXTERNAL_GATED,
+            mutation_state=RuntimeTruthState.NO_MUTATION_OBSERVED,
+            probe_ok=None,
+            missing_machine_fields=[
+                "external_api_probe_result",
+                "proof_json_path",
+                "operator_authority_to_probe_external_state",
+            ],
+            metadata={"no_external_probe_performed": True},
+        )
+    )
+    return packets
+
+
+def render_runtime_truth(
+    evidence: dict[str, Any] | None,
+    track: dict[str, Any],
+) -> list[dict[str, Any]]:
+    from dharma_swarm.operator_core.runtime_truth import summarize_runtime_truth_packets
+
+    section("RUNTIME TRUTH PACKETS — read-only projection")
+    packets = _runtime_truth_packets(evidence, track)
+    rows = [packet.to_dict() for packet in packets]
+    summary = summarize_runtime_truth_packets(packets)
+    print("  Doctrine: packets project existing owners; this section is not authority.")
+    print(
+        "  Compact: "
+        f"runtime_db={summary.get('runtime_db') or 'unknown'}; "
+        f"latest_receipt={summary.get('latest_receipt') or 'none'}; "
+        f"run_id={summary.get('run_id') or 'missing'}; "
+        f"task_id={summary.get('task_id') or 'missing'}; "
+        f"heartbeat={summary.get('heartbeat') or 'unknown'}; "
+        f"progress={summary.get('progress') or 'unknown'}; "
+        f"completion={summary.get('completion') or 'unknown'}; "
+        f"retry={summary.get('retry') or 'unknown'}"
+    )
+    missing = summary.get("missing") or []
+    if missing:
+        print(f"  Missing machine fields: {', '.join(str(item) for item in missing)}")
+    print("  Machine rows (JSONL):")
+    for row in rows:
+        print(f"    {json.dumps(row, sort_keys=True)}")
+    return rows
 
 
 def render_decay_watch() -> None:
@@ -545,6 +745,7 @@ def main() -> int:
     render_axioms()
     render_recent_activity(track)
     render_spine_status()
+    render_runtime_truth(evidence, track)
     render_decay_watch()
     render_tooling_first()
     render_enforcement_and_depth()

--- a/scripts/governance/render_active_track_includes.py
+++ b/scripts/governance/render_active_track_includes.py
@@ -89,7 +89,7 @@ def render_block(track: dict) -> str:
     if closed:
         lines.append("**Recently closed tracks:**")
         lines.append("")
-        for ct in closed[-3:]:  # last three
+        for ct in closed[:3]:  # newest three; closed_tracks is newest-first
             lines.append(
                 f"- `{ct.get('id')}` — {ct.get('name')} "
                 f"({ct.get('status')}, closed {ct.get('closed_at')})"

--- a/tests/test_agent_onboard.py
+++ b/tests/test_agent_onboard.py
@@ -7,6 +7,8 @@ These tests guard that contract.
 from __future__ import annotations
 
 import importlib.util
+import hashlib
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -169,3 +171,51 @@ def test_onboard_does_not_write_to_owners():
     after = {p: digest(p) for p in owner_files}
     for p in owner_files:
         assert before[p] == after[p], f"agent_onboard.py must not mutate owner file {p}"
+
+
+def test_runtime_truth_render_is_read_only(tmp_path, monkeypatch, capsys):
+    """Runtime truth rows are projections and must not mutate owner files."""
+    mod = _load_module()
+    monkeypatch.setenv("DHARMA_STATE_DIR", str(tmp_path / "state"))
+
+    owner_files = [
+        REPO_ROOT / "docs/governance/ACTIVE_TRACK.yaml",
+        REPO_ROOT / "ACTIVE_SURFACE_MANIFEST.yaml",
+        REPO_ROOT / "tests/test_spine_persistence_invariant.py",
+    ]
+
+    def digest(path: Path) -> str | None:
+        if not path.exists():
+            return None
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+
+    before = {path: digest(path) for path in owner_files}
+    rows = mod.render_runtime_truth(
+        {
+            "active_track_id": "runtime-truth-reconciliation-2026-06",
+            "prerequisites_ok": True,
+            "shippable": False,
+            "completion_progress": {"passed": 5, "total": 11},
+            "criteria": [
+                {"id": "runtime_truth_packet_defined", "passed": True},
+                {"id": "onboard_runtime_truth_render", "passed": False},
+            ],
+        },
+        {"active_track": {"id": "runtime-truth-reconciliation-2026-06"}},
+    )
+    after = {path: digest(path) for path in owner_files}
+    output = capsys.readouterr().out
+    json_lines = [
+        json.loads(line.strip())
+        for line in output.splitlines()
+        if line.strip().startswith("{")
+    ]
+
+    assert before == after
+    assert "RUNTIME TRUTH PACKETS" in output
+    assert "Compact:" in output
+    assert "Machine rows (JSONL):" in output
+    assert rows == json_lines
+    assert any(row["surface_id"] == "runtime_state.store" for row in rows)
+    assert all(row["is_authoritative"] is False for row in rows)
+    assert all(row["is_projection"] is True for row in rows)

--- a/tests/test_control_surface.py
+++ b/tests/test_control_surface.py
@@ -6,6 +6,8 @@ Observed reality comes from code, runtime, evidence adapters — not YAML.
 
 from __future__ import annotations
 
+import hashlib
+import sqlite3
 import textwrap
 from pathlib import Path
 
@@ -168,6 +170,80 @@ def tmp_broken_register(tmp_path: Path) -> Path:
     return tmp_path
 
 
+def _write_control_surface_runtime_db(db_path: Path) -> None:
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE runtime_receipts (
+                receipt_id TEXT PRIMARY KEY,
+                receipt_type TEXT NOT NULL,
+                run_id TEXT NOT NULL DEFAULT '',
+                task_id TEXT NOT NULL DEFAULT '',
+                trace_id TEXT NOT NULL DEFAULT '',
+                correlation_id TEXT NOT NULL DEFAULT '',
+                causation_id TEXT NOT NULL DEFAULT '',
+                parent_run_id TEXT NOT NULL DEFAULT '',
+                agent_id TEXT NOT NULL DEFAULT '',
+                idempotency_key TEXT NOT NULL DEFAULT '',
+                side_effect_key TEXT NOT NULL DEFAULT '',
+                status TEXT NOT NULL,
+                payload_json TEXT NOT NULL DEFAULT '{}',
+                created_at TEXT NOT NULL
+            );
+            CREATE TABLE idempotency_records (
+                idempotency_key TEXT NOT NULL,
+                side_effect_key TEXT NOT NULL,
+                run_id TEXT NOT NULL DEFAULT '',
+                task_id TEXT NOT NULL DEFAULT '',
+                trace_id TEXT NOT NULL DEFAULT '',
+                correlation_id TEXT NOT NULL DEFAULT '',
+                status TEXT NOT NULL,
+                result_receipt_id TEXT NOT NULL DEFAULT '',
+                metadata_json TEXT NOT NULL DEFAULT '{}',
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                PRIMARY KEY (idempotency_key, side_effect_key)
+            );
+            """
+        )
+        conn.execute(
+            "INSERT INTO runtime_receipts VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "receipt-control-1",
+                "a2a_task",
+                "run-control-1",
+                "task-control-1",
+                "trace-control-1",
+                "corr-control-1",
+                "",
+                "",
+                "agent-control-1",
+                "idem-control-1",
+                "a2a.submit",
+                "completed",
+                "{}",
+                "2026-06-04T01:04:00+00:00",
+            ),
+        )
+        conn.execute(
+            "INSERT INTO idempotency_records VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "idem-control-1",
+                "a2a.submit",
+                "run-control-1",
+                "task-control-1",
+                "trace-control-1",
+                "corr-control-1",
+                "completed",
+                "receipt-control-1",
+                "{}",
+                "2026-06-04T01:00:00+00:00",
+                "2026-06-04T01:04:00+00:00",
+            ),
+        )
+        conn.commit()
+
+
 # ---------------------------------------------------------------------------
 # Manifest loading
 # ---------------------------------------------------------------------------
@@ -264,6 +340,41 @@ class TestBrokenRegister:
         rows = _broken_register_rows(tmp_broken_register)
         br100 = [r for r in rows if "BR-100" in r.label][0]
         assert br100.priority == "p1"
+
+
+# ---------------------------------------------------------------------------
+# Runtime truth projection
+# ---------------------------------------------------------------------------
+
+
+class TestRuntimeTruthProjection:
+    def test_runtime_state_row_uses_explicit_runtime_db_projection(
+        self,
+        tmp_repo: Path,
+        tmp_path: Path,
+    ) -> None:
+        runtime_db = tmp_path / "runtime.db"
+        _write_control_surface_runtime_db(runtime_db)
+        before_hash = hashlib.sha256(runtime_db.read_bytes()).hexdigest()
+        before_sidecars = sorted(path.name for path in tmp_path.glob("runtime.db*"))
+
+        rows = build_control_surface_rows(repo_root=tmp_repo, runtime_db=runtime_db)
+        row = next(item for item in rows if item.id == "runtime.state_db")
+        after_hash = hashlib.sha256(runtime_db.read_bytes()).hexdigest()
+        after_sidecars = sorted(path.name for path in tmp_path.glob("runtime.db*"))
+
+        assert before_hash == after_hash
+        assert before_sidecars == after_sidecars == ["runtime.db"]
+        assert row.raw["runtime_truth_summary"]["latest_receipt"] == (
+            "runtime_receipts:receipt-control-1"
+        )
+        assert row.raw["runtime_truth_summary"]["run_id"] == "run-control-1"
+        assert any(
+            evidence.kind == "db_probe"
+            and evidence.source == "runtime_receipts:receipt-control-1"
+            and "RuntimeTruthPacket" in evidence.provenance_chain
+            for evidence in row.evidence
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_operator_core_contracts.py
+++ b/tests/test_operator_core_contracts.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import hashlib
+import sqlite3
+from pathlib import Path
+
 from dharma_swarm.operator_core import (
     CanonicalEntity,
     CanonicalEventEnvelope,
@@ -17,7 +21,11 @@ from dharma_swarm.operator_core import (
     PermissionDecisionKind,
     PermissionRisk,
     RuntimeHealth,
+    RuntimeTruthPacket,
+    RuntimeTruthState,
     WorkflowExecutionMode,
+    runtime_truth_packets_from_runtime_db,
+    summarize_runtime_truth_packets,
 )
 
 
@@ -112,3 +120,409 @@ def test_operator_core_contracts_hold_shell_neutral_shapes() -> None:
     assert runtime.health is RuntimeHealth.DEGRADED
     assert workflow.execution_mode is WorkflowExecutionMode.SERIAL_WRITE
     assert event.entity_refs[0].kind == "agent"
+
+
+def test_runtime_truth_packet_keeps_state_axes_separate() -> None:
+    packet = RuntimeTruthPacket(
+        surface_id="mission.demo",
+        kind="mission_projection",
+        observed_at="2026-06-04T00:00:00Z",
+        owner_surface="tests",
+        source_kind="fixture",
+        run_id="run-1",
+        mission_id="mission-1",
+        correlation_id="corr-1",
+        task_id="task-1",
+        receipt_refs=["receipts/mission-1.json"],
+        artifact_refs=["artifacts/mission-1/report.md"],
+        source_refs=["tests/fixtures/runtime_truth.json"],
+        heartbeat_state=RuntimeTruthState.RUNNING_BY_HEARTBEAT,
+        progress_state=RuntimeTruthState.STALLED_BY_ARTIFACT_PROGRESS,
+        completion_state=RuntimeTruthState.BLOCKED_BY_RECEIPT,
+        authority_state=RuntimeTruthState.PROJECTION_ONLY,
+        mutation_state=RuntimeTruthState.NO_MUTATION_OBSERVED,
+        external_state=RuntimeTruthState.EXTERNAL_GATED,
+        missing_machine_fields=["last_progress_at"],
+        metadata={"nested": {"refs": ["mutable-at-input"]}},
+    )
+
+    row = packet.to_dict()
+
+    assert row["heartbeat_state"] == "running_by_heartbeat"
+    assert row["progress_state"] == "stalled_by_artifact_progress"
+    assert row["completion_state"] == "blocked_by_receipt"
+    assert row["authority_state"] == "projection_only"
+    assert row["mutation_state"] == "no_mutation_observed"
+    assert row["external_state"] == "external_gated"
+    assert packet.heartbeat_state is not packet.progress_state
+    assert packet.is_projection is True
+    assert packet.is_authoritative is False
+    assert packet.receipt_refs == ("receipts/mission-1.json",)
+    assert row["receipt_refs"] == ["receipts/mission-1.json"]
+    assert row["missing_machine_fields"] == ["last_progress_at"]
+    assert row["metadata"] == {"nested": {"refs": ["mutable-at-input"]}}
+
+    try:
+        packet.receipt_refs.append("receipts/late-mutation.json")  # type: ignore[attr-defined]
+    except AttributeError:
+        pass
+    else:
+        raise AssertionError("RuntimeTruthPacket ref fields must be immutable")
+
+    try:
+        packet.metadata["late"] = "mutation"
+    except TypeError:
+        pass
+    else:
+        raise AssertionError("RuntimeTruthPacket metadata must be immutable")
+
+    try:
+        RuntimeTruthPacket(
+            surface_id="bad.authority",
+            kind="bad_projection",
+            observed_at="2026-06-04T00:00:00Z",
+            owner_surface="tests",
+            source_kind="fixture",
+            is_authoritative=True,
+        )
+    except ValueError as exc:
+        assert "authority lives in owner surfaces" in str(exc)
+    else:
+        raise AssertionError("RuntimeTruthPacket must reject authority claims")
+
+
+def _write_runtime_truth_fixture(
+    db_path: Path,
+    *,
+    receipt_type: str = "a2a_task",
+    receipt_status: str = "completed",
+    run_status: str = "completed",
+    completed_at: str | None = "2026-06-04T01:05:00+00:00",
+    stale_after: str = "2099-01-01T00:00:00+00:00",
+    current_artifact_id: str = "artifact-1",
+    include_artifact: bool = True,
+) -> None:
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE runtime_receipts (
+                receipt_id TEXT PRIMARY KEY,
+                receipt_type TEXT NOT NULL,
+                run_id TEXT NOT NULL DEFAULT '',
+                task_id TEXT NOT NULL DEFAULT '',
+                trace_id TEXT NOT NULL DEFAULT '',
+                correlation_id TEXT NOT NULL DEFAULT '',
+                causation_id TEXT NOT NULL DEFAULT '',
+                parent_run_id TEXT NOT NULL DEFAULT '',
+                agent_id TEXT NOT NULL DEFAULT '',
+                idempotency_key TEXT NOT NULL DEFAULT '',
+                side_effect_key TEXT NOT NULL DEFAULT '',
+                status TEXT NOT NULL,
+                payload_json TEXT NOT NULL DEFAULT '{}',
+                created_at TEXT NOT NULL
+            );
+            CREATE TABLE execution_identities (
+                run_id TEXT PRIMARY KEY,
+                trace_id TEXT NOT NULL,
+                correlation_id TEXT NOT NULL,
+                task_id TEXT NOT NULL,
+                claim_id TEXT NOT NULL DEFAULT '',
+                idempotency_key TEXT NOT NULL DEFAULT '',
+                causation_id TEXT NOT NULL DEFAULT '',
+                parent_run_id TEXT NOT NULL DEFAULT '',
+                agent_id TEXT NOT NULL DEFAULT '',
+                session_id TEXT NOT NULL DEFAULT '',
+                external_a2a_task_id TEXT NOT NULL DEFAULT '',
+                message_id TEXT NOT NULL DEFAULT '',
+                event_id TEXT NOT NULL DEFAULT '',
+                artifact_id TEXT NOT NULL DEFAULT '',
+                proposal_id TEXT NOT NULL DEFAULT '',
+                metadata_json TEXT NOT NULL DEFAULT '{}'
+            );
+            CREATE TABLE idempotency_records (
+                idempotency_key TEXT NOT NULL,
+                side_effect_key TEXT NOT NULL,
+                run_id TEXT NOT NULL DEFAULT '',
+                task_id TEXT NOT NULL DEFAULT '',
+                trace_id TEXT NOT NULL DEFAULT '',
+                correlation_id TEXT NOT NULL DEFAULT '',
+                status TEXT NOT NULL,
+                result_receipt_id TEXT NOT NULL DEFAULT '',
+                metadata_json TEXT NOT NULL DEFAULT '{}',
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                PRIMARY KEY (idempotency_key, side_effect_key)
+            );
+            CREATE TABLE task_claims (
+                claim_id TEXT PRIMARY KEY,
+                task_id TEXT NOT NULL,
+                session_id TEXT NOT NULL DEFAULT '',
+                agent_id TEXT NOT NULL,
+                status TEXT NOT NULL,
+                claimed_at TEXT NOT NULL,
+                acked_at TEXT,
+                heartbeat_at TEXT,
+                stale_after TEXT,
+                recovered_at TEXT,
+                retry_count INTEGER NOT NULL DEFAULT 0,
+                metadata_json TEXT NOT NULL DEFAULT '{}',
+                trace_id TEXT NOT NULL DEFAULT ''
+            );
+            CREATE TABLE delegation_runs (
+                run_id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL DEFAULT '',
+                task_id TEXT NOT NULL,
+                claim_id TEXT NOT NULL DEFAULT '',
+                parent_run_id TEXT NOT NULL DEFAULT '',
+                assigned_by TEXT NOT NULL DEFAULT '',
+                assigned_to TEXT NOT NULL,
+                current_artifact_id TEXT NOT NULL DEFAULT '',
+                status TEXT NOT NULL,
+                started_at TEXT NOT NULL,
+                completed_at TEXT,
+                failure_code TEXT NOT NULL DEFAULT '',
+                metadata_json TEXT NOT NULL DEFAULT '{}'
+            );
+            CREATE TABLE artifact_records (
+                artifact_id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL DEFAULT '',
+                task_id TEXT NOT NULL DEFAULT '',
+                run_id TEXT NOT NULL DEFAULT '',
+                trace_id TEXT NOT NULL DEFAULT '',
+                artifact_kind TEXT NOT NULL,
+                manifest_path TEXT NOT NULL DEFAULT '',
+                payload_path TEXT NOT NULL DEFAULT '',
+                checksum TEXT NOT NULL DEFAULT '',
+                parent_artifact_id TEXT NOT NULL DEFAULT '',
+                promotion_state TEXT NOT NULL DEFAULT 'ephemeral',
+                created_at TEXT NOT NULL,
+                metadata_json TEXT NOT NULL DEFAULT '{}'
+            );
+            """
+        )
+        conn.execute(
+            "INSERT INTO runtime_receipts VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "receipt-1",
+                receipt_type,
+                "run-1",
+                "task-1",
+                "trace-1",
+                "corr-1",
+                "",
+                "",
+                "agent-1",
+                "idem-1",
+                "a2a.submit",
+                receipt_status,
+                '{"mission_id": "mission-1"}',
+                "2026-06-04T01:04:00+00:00",
+            ),
+        )
+        conn.execute(
+            "INSERT INTO execution_identities VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "run-1",
+                "trace-1",
+                "corr-1",
+                "task-1",
+                "claim-1",
+                "idem-1",
+                "",
+                "",
+                "agent-1",
+                "session-1",
+                "",
+                "",
+                "",
+                "",
+                "",
+                '{"mission_id": "mission-1"}',
+            ),
+        )
+        conn.execute(
+            "INSERT INTO idempotency_records VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "idem-1",
+                "a2a.submit",
+                "run-1",
+                "task-1",
+                "trace-1",
+                "corr-1",
+                "completed",
+                "receipt-1",
+                "{}",
+                "2026-06-04T01:00:00+00:00",
+                "2026-06-04T01:04:00+00:00",
+            ),
+        )
+        conn.execute(
+            "INSERT INTO task_claims VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "claim-1",
+                "task-1",
+                "session-1",
+                "agent-1",
+                "claimed",
+                "2026-06-04T01:00:00+00:00",
+                "2026-06-04T01:00:10+00:00",
+                "2026-06-04T01:03:00+00:00",
+                stale_after,
+                None,
+                0,
+                "{}",
+                "trace-1",
+            ),
+        )
+        conn.execute(
+            "INSERT INTO delegation_runs VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "run-1",
+                "session-1",
+                "task-1",
+                "claim-1",
+                "",
+                "operator",
+                "agent-1",
+                current_artifact_id,
+                run_status,
+                "2026-06-04T01:00:00+00:00",
+                completed_at,
+                "",
+                "{}",
+            ),
+        )
+        if include_artifact:
+            conn.execute(
+                "INSERT INTO artifact_records VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    "artifact-1",
+                    "session-1",
+                    "task-1",
+                    "run-1",
+                    "trace-1",
+                    "handoff",
+                    "artifacts/run-1/manifest.json",
+                    "artifacts/run-1/result.md",
+                    "sha256:test",
+                    "",
+                    "ephemeral",
+                    "2026-06-04T01:05:00+00:00",
+                    "{}",
+                ),
+            )
+        conn.commit()
+
+
+def test_runtime_truth_projector_reads_runtime_db_without_writing(tmp_path: Path) -> None:
+    db_path = tmp_path / "runtime.db"
+    _write_runtime_truth_fixture(db_path)
+    before_hash = hashlib.sha256(db_path.read_bytes()).hexdigest()
+    before_sidecars = sorted(path.name for path in tmp_path.glob("runtime.db*"))
+
+    packets = runtime_truth_packets_from_runtime_db(
+        db_path,
+        observed_at="2026-06-04T01:06:00+00:00",
+    )
+
+    after_hash = hashlib.sha256(db_path.read_bytes()).hexdigest()
+    after_sidecars = sorted(path.name for path in tmp_path.glob("runtime.db*"))
+    latest = next(packet for packet in packets if packet.surface_id == "runtime_state.latest_receipt")
+    summary = summarize_runtime_truth_packets(packets)
+
+    assert before_hash == after_hash
+    assert before_sidecars == after_sidecars == ["runtime.db"]
+    assert latest.run_id == "run-1"
+    assert latest.task_id == "task-1"
+    assert latest.correlation_id == "corr-1"
+    assert latest.mission_id == "mission-1"
+    assert latest.receipt_refs == ("runtime_receipts:receipt-1",)
+    assert latest.artifact_refs == ("artifact_records:artifact-1:artifacts/run-1/result.md",)
+    assert latest.heartbeat_state is RuntimeTruthState.RUNNING_BY_HEARTBEAT
+    assert latest.progress_state is RuntimeTruthState.PROGRESSING_BY_ARTIFACT
+    assert latest.completion_state is RuntimeTruthState.COMPLETED_BY_RECEIPT
+    assert latest.retry_state is RuntimeTruthState.RETRY_EQUIVALENT
+    assert latest.is_authoritative is False
+    assert summary["latest_receipt"] == "runtime_receipts:receipt-1"
+
+
+def test_runtime_truth_projector_missing_db_does_not_create_file(tmp_path: Path) -> None:
+    db_path = tmp_path / "missing-runtime.db"
+
+    packets = runtime_truth_packets_from_runtime_db(
+        db_path,
+        observed_at="2026-06-04T01:06:00+00:00",
+    )
+
+    assert not db_path.exists()
+    assert len(packets) == 1
+    assert packets[0].surface_id == "runtime_state.store"
+    assert packets[0].readiness_state is RuntimeTruthState.NOT_READY_BY_PROBE
+    assert packets[0].missing_machine_fields == ("runtime_db",)
+
+
+def test_runtime_truth_projector_malformed_db_is_not_ready(tmp_path: Path) -> None:
+    db_path = tmp_path / "runtime.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE unrelated_state (id TEXT PRIMARY KEY)")
+        conn.commit()
+    before_hash = hashlib.sha256(db_path.read_bytes()).hexdigest()
+
+    packets = runtime_truth_packets_from_runtime_db(
+        db_path,
+        observed_at="2026-06-04T01:06:00+00:00",
+    )
+
+    after_hash = hashlib.sha256(db_path.read_bytes()).hexdigest()
+    store = packets[0]
+    assert before_hash == after_hash
+    assert store.surface_id == "runtime_state.store"
+    assert store.probe_ok is False
+    assert store.readiness_state is RuntimeTruthState.NOT_READY_BY_PROBE
+    assert "runtime_receipts_table" in store.missing_machine_fields
+    assert "idempotency_records_table" in store.missing_machine_fields
+
+
+def test_runtime_truth_projector_does_not_complete_from_nonterminal_receipt(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "runtime.db"
+    _write_runtime_truth_fixture(
+        db_path,
+        receipt_type="provider_call",
+        receipt_status="completed",
+        run_status="running",
+        completed_at=None,
+        current_artifact_id="",
+        include_artifact=False,
+    )
+
+    packets = runtime_truth_packets_from_runtime_db(
+        db_path,
+        observed_at="2026-06-04T01:06:00+00:00",
+    )
+
+    latest = next(packet for packet in packets if packet.surface_id == "runtime_state.latest_receipt")
+    assert latest.completion_state is RuntimeTruthState.UNKNOWN
+
+
+def test_runtime_truth_projector_stale_claim_dominates_artifact_progress(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "runtime.db"
+    _write_runtime_truth_fixture(
+        db_path,
+        run_status="running",
+        completed_at=None,
+        stale_after="2000-01-01T00:00:00+00:00",
+    )
+
+    packets = runtime_truth_packets_from_runtime_db(
+        db_path,
+        observed_at="2026-06-04T01:06:00+00:00",
+    )
+
+    latest = next(packet for packet in packets if packet.surface_id == "runtime_state.latest_receipt")
+    assert latest.heartbeat_state is RuntimeTruthState.STALLED_BY_ARTIFACT_PROGRESS
+    assert latest.progress_state is RuntimeTruthState.STALLED_BY_ARTIFACT_PROGRESS
+    assert latest.completion_state is RuntimeTruthState.UNKNOWN


### PR DESCRIPTION
## Summary
- add `RuntimeTruthPacket` projection support in `operator_core/runtime_truth.py`
- expose read-only runtime truth rendering through operator-core contracts/control surface and onboarding
- update active-track evidence and DocOps counts for the runtime truth reconciliation track
- add focused regression coverage for runtime truth contracts, onboarding rendering, and control-surface projection

## Coherence Delta
- Organ touched: `dharma_swarm/operator_core`, governance onboarding/rendering, runtime truth active-track evidence, and focused operator-core tests.
- Declared-vs-actual gap closed: Runtime truth can now be projected from the runtime state store as a read-only packet instead of remaining only as scattered database/runtime evidence.
- Proof that re-reads the map: `python3 scripts/governance/check_track_status.py`, `python3 scripts/docops/check_docops_integrity.py --report-json reports/docops/check.json`, and `pytest -q tests/test_operator_core_contracts.py tests/test_agent_onboard.py tests/test_control_surface.py` on the branch before and after merging current `main`.
- New drift introduced: No intended write-path drift; projector is read-only, merges current `main`, and keeps DocOps/active-track counts aligned.

## Tests
- `python3 scripts/governance/check_track_status.py`
- `python3 scripts/docops/check_docops_integrity.py --report-json reports/docops/check.json`
- `pytest -q tests/test_operator_core_contracts.py tests/test_agent_onboard.py tests/test_control_surface.py` -> `99 passed, 1 warning` before base merge
- `pytest -q tests/test_operator_core_contracts.py tests/test_agent_onboard.py tests/test_control_surface.py` -> `99 passed, 1 warning` after base merge
