### PR TITLE
fix(ci): resolve DocOps manual dispatch repo context

### DIFF
--- a/.github/workflows/docops-autorefresh.yml
+++ b/.github/workflows/docops-autorefresh.yml
@@ -71,8 +71,8 @@ jobs:
               echo "workflow_dispatch requires the pr input" >&2
               exit 1
             fi
-            head_repo="$(gh pr view "${INPUT_PR}" --json headRepository --jq '.headRepository.nameWithOwner')"
-            head_ref="$(gh pr view "${INPUT_PR}" --json headRefName --jq '.headRefName')"
+            head_repo="$(gh pr view "${INPUT_PR}" --repo "${REPOSITORY}" --json headRepository --jq '.headRepository.nameWithOwner')"
+            head_ref="$(gh pr view "${INPUT_PR}" --repo "${REPOSITORY}" --json headRefName --jq '.headRefName')"
           fi
 
           if [ "${head_repo}" != "${REPOSITORY}" ]; then


### PR DESCRIPTION
## Summary
- pass an explicit --repo value to gh pr view in docops-autorefresh manual dispatch
- preserves the pull_request path and same-repo fork guard

## Coherence Delta
- Organ touched: .github/workflows/docops-autorefresh.yml manual workflow_dispatch PR resolution path.
- Declared-vs-actual gap closed: manual DocOps refresh was declared usable for backlog cleanup, but gh pr view ran before checkout without repo context and failed with not a git repository.
- Proof that re-reads the map: python YAML parse, git diff --check, make docops-integrity, and commit hooks passed; failing run 27016922834 showed the exact pre-checkout gh context error this change resolves.
- New drift introduced: none expected; the pull_request path is unchanged and manual dispatch now resolves PR metadata against github.repository explicitly.

## Verification
- python YAML parse for .github/workflows/docops-autorefresh.yml
- git diff --check
- make docops-integrity
- commit hooks: test hygiene, contract tests, uplift guards, DocOps, gitleaks, YAML