### PR TITLE
[codex] add runtime-truth NATS transport

### DIFF
--- a/dharma_swarm/a2a/__init__.py
+++ b/dharma_swarm/a2a/__init__.py
@@ -43,6 +43,7 @@ from dharma_swarm.a2a.a2a_server import (
 )
 from dharma_swarm.a2a.a2a_client import A2AClient
 from dharma_swarm.a2a.a2a_bridge import A2ABridge
+from dharma_swarm.a2a.nats_transport import A2ANatsTransport, NatsTransportConfig
 from dharma_swarm.a2a.node_registry import NodeRegistry, RemoteNode
 from dharma_swarm.a2a.registry_hydrator import hydrate_from_receipts
 
@@ -62,6 +63,8 @@ __all__ = [
     "A2ATaskStatus",
     "A2AClient",
     "A2ABridge",
+    "A2ANatsTransport",
+    "NatsTransportConfig",
     "NodeRegistry",
     "RemoteNode",
     "hydrate_from_receipts",

--- a/dharma_swarm/a2a/nats_transport.py
+++ b/dharma_swarm/a2a/nats_transport.py
@@ -1,0 +1,500 @@
+"""NATS/JetStream transport adapter for A2A runtime truth.
+
+This module is import-safe when nats-py is absent. The real client is imported
+only by ``connect()``, while tests and local adapters can inject a JetStream-like
+object that exposes ``publish``.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, is_dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Protocol
+from uuid import uuid4
+
+from dharma_swarm.a2a.a2a_server import (
+    A2AArtifact,
+    A2AExtension,
+    A2AMessage,
+    A2APart,
+    A2APartType,
+    A2AServer,
+    A2ATask,
+    A2ATaskStatus,
+)
+from dharma_swarm.runtime_state import RuntimeStateStore
+from dharma_swarm.spine.identity import ExecutionIdentity, MissingExecutionIdentity
+
+
+class JetStreamLike(Protocol):
+    async def publish(
+        self,
+        subject: str,
+        payload: bytes,
+        *,
+        headers: dict[str, str] | None = None,
+        timeout: float | None = None,
+    ) -> Any:
+        ...
+
+
+class NatsMessageLike(Protocol):
+    subject: str
+    data: bytes
+
+    async def ack(self) -> Any:
+        ...
+
+    async def nak(self) -> Any:
+        ...
+
+
+@dataclass(frozen=True)
+class NatsTransportConfig:
+    endpoint: str = "nats://127.0.0.1:4222"
+    subject_prefix: str = "dharma.a2a"
+    stream_name: str = "DHARMA_A2A"
+    publish_timeout_s: float = 2.0
+    idempotency_stale_after_s: float | None = 300.0
+
+
+@dataclass(frozen=True)
+class NatsPublishAck:
+    task_id: str
+    subject: str
+    action: str
+    status: str
+    receipt_id: str
+    stream: str = ""
+    seq: int | None = None
+    duplicate: bool = False
+
+
+@dataclass(frozen=True)
+class NatsConsumeAck:
+    task_id: str
+    subject: str
+    action: str
+    status: str
+    receipt_id: str
+    duplicate: bool = False
+    error: str = ""
+
+
+class NatsTransportError(RuntimeError):
+    """Raised after a NATS adapter side effect records a nack receipt."""
+
+
+class A2ANatsTransport:
+    """Runtime-state-backed NATS/JetStream adapter for A2A tasks."""
+
+    def __init__(
+        self,
+        *,
+        runtime_state: RuntimeStateStore,
+        server: A2AServer | None = None,
+        jetstream: JetStreamLike | None = None,
+        config: NatsTransportConfig | None = None,
+        require_execution_identity: bool = True,
+    ) -> None:
+        self.runtime_state = runtime_state
+        self.server = server
+        self.jetstream = jetstream
+        self.config = config or NatsTransportConfig()
+        self.require_execution_identity = require_execution_identity
+        self._nats_connection: Any | None = None
+
+    async def connect(self) -> None:
+        """Connect to a real NATS server and bind ``self.jetstream``.
+
+        This is the only method that imports nats-py. Importing this module,
+        constructing the adapter, and running offline tests do not need the
+        optional dependency.
+        """
+
+        if self.jetstream is not None:
+            return
+        import nats
+
+        self._nats_connection = await nats.connect(
+            servers=[self.config.endpoint],
+            allow_reconnect=False,
+            max_reconnect_attempts=0,
+        )
+        self.jetstream = self._nats_connection.jetstream()
+
+    async def close(self) -> None:
+        if self._nats_connection is not None:
+            await self._nats_connection.close()
+            self._nats_connection = None
+
+    async def publish_task(
+        self,
+        task: A2ATask,
+        *,
+        identity: ExecutionIdentity | None = None,
+        subject: str | None = None,
+    ) -> NatsPublishAck:
+        resolved_identity = self._resolve_identity(task, identity=identity)
+        resolved_subject = subject or self.subject_for_task(task)
+        side_effect_key = f"nats_publish:{resolved_subject}:{task.id}"
+        metadata = {
+            "surface": "a2a.nats_transport.publish",
+            "subject": resolved_subject,
+            "external_a2a_task_id": task.id,
+            "operation_hash": _operation_hash(
+                resolved_subject,
+                task.id,
+                resolved_identity.correlation_id,
+            ),
+        }
+        await self.runtime_state.record_execution_identity(
+            resolved_identity,
+            source="a2a.nats_transport.publish",
+            metadata=metadata,
+        )
+        if not await self.runtime_state.try_begin_idempotent_side_effect(
+            resolved_identity,
+            side_effect_key,
+            metadata=metadata,
+            stale_after_seconds=self.config.idempotency_stale_after_s,
+        ):
+            receipt = await self.runtime_state.record_receipt_for_identity(
+                resolved_identity,
+                receipt_type="nats_publish",
+                status="duplicate",
+                side_effect_key=side_effect_key,
+                payload={**metadata, "action": "ack", "duplicate": True},
+            )
+            return NatsPublishAck(
+                task_id=task.id,
+                subject=resolved_subject,
+                action="ack",
+                status="duplicate",
+                receipt_id=receipt.receipt_id,
+                duplicate=True,
+            )
+
+        if self.jetstream is None:
+            await self.connect()
+        if self.jetstream is None:
+            raise NatsTransportError("JetStream client is unavailable after connect")
+
+        payload = _task_to_wire(task, resolved_identity)
+        encoded = json.dumps(payload, ensure_ascii=True, sort_keys=True).encode("utf-8")
+        headers = {
+            "Dharma-Trace-Id": resolved_identity.trace_id,
+            "Dharma-Correlation-Id": resolved_identity.correlation_id,
+            "Dharma-Run-Id": resolved_identity.run_id,
+            "Dharma-Task-Id": resolved_identity.task_id,
+            "Dharma-Idempotency-Key": resolved_identity.idempotency_key,
+        }
+        try:
+            pub_ack = await self.jetstream.publish(
+                resolved_subject,
+                encoded,
+                headers=headers,
+                timeout=self.config.publish_timeout_s,
+            )
+        except Exception as exc:
+            receipt = await self.runtime_state.record_receipt_for_identity(
+                resolved_identity,
+                receipt_type="nats_publish",
+                status="nack",
+                side_effect_key=side_effect_key,
+                payload={**metadata, "action": "nack", "error": str(exc)},
+            )
+            await self.runtime_state.complete_idempotent_side_effect(
+                resolved_identity,
+                side_effect_key,
+                status="failed",
+                result_receipt_id=receipt.receipt_id,
+                metadata={"error": str(exc), **metadata},
+            )
+            raise NatsTransportError(str(exc)) from exc
+
+        stream = str(getattr(pub_ack, "stream", "") or "")
+        seq = getattr(pub_ack, "seq", None)
+        receipt = await self.runtime_state.record_receipt_for_identity(
+            resolved_identity,
+            receipt_type="nats_publish",
+            status="ack",
+            side_effect_key=side_effect_key,
+            payload={
+                **metadata,
+                "action": "ack",
+                "stream": stream,
+                "seq": seq,
+                "ack_contract": "publish_ack",
+            },
+        )
+        await self.runtime_state.complete_idempotent_side_effect(
+            resolved_identity,
+            side_effect_key,
+            result_receipt_id=receipt.receipt_id,
+            metadata={"stream": stream, "seq": seq, **metadata},
+        )
+        return NatsPublishAck(
+            task_id=task.id,
+            subject=resolved_subject,
+            action="ack",
+            status="ack",
+            receipt_id=receipt.receipt_id,
+            stream=stream,
+            seq=int(seq) if isinstance(seq, int) else None,
+        )
+
+    async def consume_message(self, message: NatsMessageLike) -> NatsConsumeAck:
+        subject = str(message.subject)
+        try:
+            payload = json.loads(message.data.decode("utf-8"))
+            task = _task_from_wire(payload)
+            identity = ExecutionIdentity.from_metadata(
+                payload.get("execution_identity"),
+                require=True,
+            )
+            if identity is None:
+                raise MissingExecutionIdentity("NATS payload is missing ExecutionIdentity")
+        except Exception as exc:
+            await _nack(message)
+            raise NatsTransportError(f"invalid NATS A2A payload: {exc}") from exc
+
+        side_effect_key = f"nats_consume:{subject}:{task.id}"
+        metadata = {
+            "surface": "a2a.nats_transport.consume",
+            "subject": subject,
+            "external_a2a_task_id": task.id,
+            "operation_hash": _operation_hash(subject, task.id, identity.correlation_id),
+        }
+        await self.runtime_state.record_execution_identity(
+            identity,
+            source="a2a.nats_transport.consume",
+            metadata=metadata,
+        )
+        if not await self.runtime_state.try_begin_idempotent_side_effect(
+            identity,
+            side_effect_key,
+            metadata=metadata,
+            stale_after_seconds=self.config.idempotency_stale_after_s,
+        ):
+            await _ack(message)
+            receipt = await self.runtime_state.record_receipt_for_identity(
+                identity,
+                receipt_type="nats_consume",
+                status="duplicate",
+                side_effect_key=side_effect_key,
+                payload={**metadata, "action": "ack", "duplicate": True},
+            )
+            return NatsConsumeAck(
+                task_id=task.id,
+                subject=subject,
+                action="ack",
+                status="duplicate",
+                receipt_id=receipt.receipt_id,
+                duplicate=True,
+            )
+
+        try:
+            result = self.server.submit(task) if self.server is not None else task
+            if result.status in {
+                A2ATaskStatus.FAILED,
+                A2ATaskStatus.REJECTED,
+                A2ATaskStatus.CANCELLED,
+            }:
+                raise NatsTransportError(result.error or f"A2A task ended {result.status.value}")
+            await _ack(message)
+            receipt = await self.runtime_state.record_receipt_for_identity(
+                identity,
+                receipt_type="nats_consume",
+                status="ack",
+                side_effect_key=side_effect_key,
+                payload={
+                    **metadata,
+                    "action": "ack",
+                    "a2a_status": result.status.value,
+                    "ack_contract": "consumer_ack",
+                },
+            )
+            await self.runtime_state.complete_idempotent_side_effect(
+                identity,
+                side_effect_key,
+                result_receipt_id=receipt.receipt_id,
+                metadata={"a2a_status": result.status.value, **metadata},
+            )
+            return NatsConsumeAck(
+                task_id=task.id,
+                subject=subject,
+                action="ack",
+                status="ack",
+                receipt_id=receipt.receipt_id,
+            )
+        except Exception as exc:
+            await _nack(message)
+            receipt = await self.runtime_state.record_receipt_for_identity(
+                identity,
+                receipt_type="nats_consume",
+                status="nack",
+                side_effect_key=side_effect_key,
+                payload={**metadata, "action": "nack", "error": str(exc)},
+            )
+            await self.runtime_state.complete_idempotent_side_effect(
+                identity,
+                side_effect_key,
+                status="failed",
+                result_receipt_id=receipt.receipt_id,
+                metadata={"error": str(exc), **metadata},
+            )
+            raise NatsTransportError(str(exc)) from exc
+
+    def subject_for_task(self, task: A2ATask) -> str:
+        target = _subject_token(task.to_agent or "unassigned")
+        capability = _subject_token(task.capability or "default")
+        return f"{self.config.subject_prefix}.task.{target}.{capability}"
+
+    def _resolve_identity(
+        self,
+        task: A2ATask,
+        *,
+        identity: ExecutionIdentity | None,
+    ) -> ExecutionIdentity:
+        if identity is None:
+            identity = ExecutionIdentity.from_metadata(
+                task.metadata,
+                task_id=task.dharma_task_id or task.id,
+                agent_id=task.to_agent,
+                session_id=str((task.metadata or {}).get("session_id") or ""),
+                require=self.require_execution_identity,
+            )
+        if identity is None:
+            raise MissingExecutionIdentity("NATS A2A transport requires ExecutionIdentity")
+        identity = identity.with_updates(external_a2a_task_id=task.id)
+        task.trace_id = identity.trace_id
+        task.dharma_task_id = task.dharma_task_id or identity.task_id
+        task.metadata.update(
+            {
+                "execution_identity": identity.to_dict(),
+                "trace_id": identity.trace_id,
+                "correlation_id": identity.correlation_id,
+                "run_id": identity.run_id,
+                "claim_id": identity.claim_id,
+                "idempotency_key": identity.idempotency_key,
+                "external_a2a_task_id": identity.external_a2a_task_id,
+            }
+        )
+        return identity.require_for_dispatch()
+
+
+def _task_to_wire(task: A2ATask, identity: ExecutionIdentity) -> dict[str, Any]:
+    return {
+        "schema": "dharma.a2a.nats_task.v1",
+        "sent_at": datetime.now(timezone.utc).isoformat(),
+        "execution_identity": identity.to_dict(),
+        "task": _json_ready(asdict(task)),
+    }
+
+
+def _task_from_wire(payload: dict[str, Any]) -> A2ATask:
+    raw = dict(payload.get("task") or {})
+    history = [_message_from_dict(item) for item in raw.get("history") or raw.get("messages") or []]
+    artifacts = [_artifact_from_dict(item) for item in raw.get("artifacts") or []]
+    extensions = [_extension_from_dict(item) for item in raw.get("extensions") or []]
+    metadata = dict(raw.get("metadata") or {})
+    identity = payload.get("execution_identity")
+    if isinstance(identity, dict):
+        metadata["execution_identity"] = identity
+    return A2ATask(
+        id=str(raw.get("id") or uuid4().hex[:16]),
+        context_id=str(raw.get("context_id") or ""),
+        from_agent=str(raw.get("from_agent") or ""),
+        to_agent=str(raw.get("to_agent") or ""),
+        status=A2ATaskStatus(str(raw.get("status") or A2ATaskStatus.SUBMITTED.value)),
+        history=history,
+        artifacts=artifacts,
+        capability=str(raw.get("capability") or ""),
+        dharma_task_id=str(raw.get("dharma_task_id") or ""),
+        created_at=str(raw.get("created_at") or datetime.now(timezone.utc).isoformat()),
+        updated_at=str(raw.get("updated_at") or datetime.now(timezone.utc).isoformat()),
+        result=str(raw.get("result") or ""),
+        error=str(raw.get("error") or ""),
+        trace_id=str(raw.get("trace_id") or ""),
+        extensions=extensions,
+        metadata=metadata,
+    )
+
+
+def _message_from_dict(raw: dict[str, Any]) -> A2AMessage:
+    return A2AMessage(
+        role=str(raw.get("role") or "user"),
+        parts=[_part_from_dict(item) for item in raw.get("parts") or []],
+        metadata=dict(raw.get("metadata") or {}),
+    )
+
+
+def _part_from_dict(raw: dict[str, Any]) -> A2APart:
+    return A2APart(
+        type=A2APartType(str(raw.get("type") or A2APartType.TEXT.value)),
+        content=str(raw.get("content") or ""),
+        media_type=str(raw.get("media_type") or ""),
+        filename=str(raw.get("filename") or ""),
+        metadata=dict(raw.get("metadata") or {}),
+        _skip_validation=not bool(raw.get("content")),
+    )
+
+
+def _artifact_from_dict(raw: dict[str, Any]) -> A2AArtifact:
+    return A2AArtifact(
+        id=str(raw.get("id") or uuid4().hex[:12]),
+        parts=[_part_from_dict(item) for item in raw.get("parts") or []],
+        name=str(raw.get("name") or ""),
+        description=str(raw.get("description") or ""),
+        extensions=[_extension_from_dict(item) for item in raw.get("extensions") or []],
+        metadata=dict(raw.get("metadata") or {}),
+    )
+
+
+def _extension_from_dict(raw: dict[str, Any]) -> A2AExtension:
+    return A2AExtension(
+        uri=str(raw.get("uri") or ""),
+        required=bool(raw.get("required")),
+        data=dict(raw.get("data") or {}),
+    )
+
+
+def _json_ready(value: Any) -> Any:
+    if isinstance(value, Enum):
+        return value.value
+    if is_dataclass(value):
+        return _json_ready(asdict(value))
+    if isinstance(value, dict):
+        return {str(key): _json_ready(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_json_ready(item) for item in value]
+    if isinstance(value, tuple):
+        return [_json_ready(item) for item in value]
+    return value
+
+
+def _subject_token(value: str) -> str:
+    cleaned = "".join(ch if ch.isalnum() or ch in ("_", "-") else "_" for ch in value.lower())
+    return cleaned.strip("._-") or "default"
+
+
+def _operation_hash(*parts: str) -> str:
+    import hashlib
+
+    return hashlib.sha256("|".join(parts).encode("utf-8")).hexdigest()
+
+
+async def _ack(message: NatsMessageLike) -> None:
+    await message.ack()
+
+
+async def _nack(message: NatsMessageLike) -> None:
+    if hasattr(message, "nak"):
+        await message.nak()
+    elif hasattr(message, "nack"):
+        await getattr(message, "nack")()
+    else:
+        raise AttributeError("NATS message has neither nak nor nack")

--- a/dharma_swarm/a2a/nats_transport.py
+++ b/dharma_swarm/a2a/nats_transport.py
@@ -279,7 +279,6 @@ class A2ANatsTransport:
             metadata=metadata,
             stale_after_seconds=self.config.idempotency_stale_after_s,
         ):
-            await _ack(message)
             receipt = await self.runtime_state.record_receipt_for_identity(
                 identity,
                 receipt_type="nats_consume",
@@ -287,6 +286,7 @@ class A2ANatsTransport:
                 side_effect_key=side_effect_key,
                 payload={**metadata, "action": "ack", "duplicate": True},
             )
+            await _ack(message)
             return NatsConsumeAck(
                 task_id=task.id,
                 subject=subject,
@@ -296,6 +296,7 @@ class A2ANatsTransport:
                 duplicate=True,
             )
 
+        broker_acked = False
         try:
             result = self.server.submit(task) if self.server is not None else task
             if result.status in {
@@ -304,7 +305,20 @@ class A2ANatsTransport:
                 A2ATaskStatus.CANCELLED,
             }:
                 raise NatsTransportError(result.error or f"A2A task ended {result.status.value}")
+            await self.runtime_state.record_receipt_for_identity(
+                identity,
+                receipt_type="nats_consume",
+                status="ack_intent",
+                side_effect_key=side_effect_key,
+                payload={
+                    **metadata,
+                    "action": "ack_intent",
+                    "a2a_status": result.status.value,
+                    "ack_contract": "consumer_ack_intent",
+                },
+            )
             await _ack(message)
+            broker_acked = True
             receipt = await self.runtime_state.record_receipt_for_identity(
                 identity,
                 receipt_type="nats_consume",
@@ -331,6 +345,17 @@ class A2ANatsTransport:
                 receipt_id=receipt.receipt_id,
             )
         except Exception as exc:
+            if broker_acked:
+                await self.runtime_state.record_receipt_for_identity(
+                    identity,
+                    receipt_type="nats_consume",
+                    status="ack_finalization_error",
+                    side_effect_key=side_effect_key,
+                    payload={**metadata, "action": "ack", "error": str(exc)},
+                )
+                raise NatsTransportError(
+                    f"NATS broker ack succeeded but runtime finalization failed: {exc}"
+                ) from exc
             await _nack(message)
             receipt = await self.runtime_state.record_receipt_for_identity(
                 identity,

--- a/dharma_swarm/durable_execution.py
+++ b/dharma_swarm/durable_execution.py
@@ -25,6 +25,9 @@ from enum import Enum
 from pathlib import Path
 from typing import Any
 
+from dharma_swarm.runtime_state import RuntimeStateStore
+from dharma_swarm.spine.identity import ExecutionIdentity
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_WORKFLOW_DIR = Path(
@@ -98,12 +101,16 @@ class DurableWorkflow:
         self,
         workflow_id: str,
         persist_dir: Path | None = None,
+        runtime_state: RuntimeStateStore | None = None,
+        execution_identity: ExecutionIdentity | None = None,
     ) -> None:
         self.workflow_id = workflow_id
         self._persist_dir = persist_dir or DEFAULT_WORKFLOW_DIR / workflow_id
         self._steps: dict[str, WorkflowStep] = {}
         self._order: list[str] = []  # insertion order for deterministic iteration
         self._created_at: str = _utc_now_iso()
+        self._runtime_state = runtime_state
+        self._execution_identity = execution_identity
 
     # -- Step registration ---------------------------------------------------
 
@@ -244,6 +251,14 @@ class DurableWorkflow:
             raise
 
         logger.debug("Checkpointed workflow %s to %s", self.workflow_id, target)
+        self._record_runtime_receipt(
+            "checkpointed",
+            {
+                "workflow_id": self.workflow_id,
+                "checkpoint_path": str(target),
+                "step_count": len(self._steps),
+            },
+        )
         return target
 
     @classmethod
@@ -305,6 +320,29 @@ class DurableWorkflow:
         for step in self._steps.values():
             counts[step.status.value] += 1
         return counts
+
+    def _record_runtime_receipt(self, status: str, payload: dict[str, Any]) -> None:
+        """Record checkpoint state in RuntimeStateStore when identity is provided."""
+        if self._runtime_state is None or self._execution_identity is None:
+            return
+        identity = self._execution_identity.require_for_dispatch()
+        side_effect_key = f"workflow_checkpoint:{self.workflow_id}"
+        try:
+            self._runtime_state.record_execution_identity_sync(
+                identity,
+                source="durable_execution.workflow",
+                metadata={"workflow_id": self.workflow_id},
+            )
+            receipt = self._runtime_state.build_runtime_receipt(
+                identity,
+                receipt_type="workflow_checkpoint",
+                status=status,
+                side_effect_key=side_effect_key,
+                payload=payload,
+            )
+            self._runtime_state.record_runtime_receipt_sync(receipt)
+        except Exception:
+            logger.debug("Runtime workflow checkpoint receipt failed", exc_info=True)
 
     @property
     def steps(self) -> list[WorkflowStep]:

--- a/dharma_swarm/opportunity_refill.py
+++ b/dharma_swarm/opportunity_refill.py
@@ -29,10 +29,11 @@ from pydantic import BaseModel, Field
 
 from dharma_swarm.opportunity_dispatcher import (
     OPPORTUNITY_STAGES,
-    DispatchResult,
     OpportunityDispatcher,
 )
 from dharma_swarm.daemon_config import dharma_state_dir
+from dharma_swarm.runtime_state import RuntimeStateStore, _new_id
+from dharma_swarm.spine.identity import ExecutionIdentity
 
 logger = logging.getLogger(__name__)
 
@@ -94,14 +95,19 @@ class OpportunityRefill:
         economic_engine: Any | None = None,
         telemetry_store: Any | None = None,
         output_dir: Path | None = None,
+        runtime_state: RuntimeStateStore | None = None,
     ) -> None:
         self._telic_seam = telic_seam
         self._economic_engine = economic_engine
         self._telemetry_store = telemetry_store
+        self._runtime_state = runtime_state
         self._dispatcher = dispatcher or OpportunityDispatcher(
+            state_store=runtime_state,
             telic_seam=telic_seam,
             economic_engine=economic_engine,
         )
+        if self._runtime_state is None:
+            self._runtime_state = getattr(self._dispatcher, "_store", None)
         self._output_dir = output_dir or (dharma_state_dir() / "revenue_packets")
         self._output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -115,7 +121,11 @@ class OpportunityRefill:
             opportunity_type=row.type,
         )
 
+        trace_id = str(row.metadata.get("trace_id") or _new_id("trace"))
+        correlation_id = str(row.metadata.get("correlation_id") or trace_id)
         opp_dict = row.model_dump()
+        opp_dict["trace_id"] = trace_id
+        opp_dict["correlation_id"] = correlation_id
         dispatch_results = self._dispatcher.dispatch_opportunity_sync(opp_dict)
 
         stage_results: list[StageResult] = []
@@ -149,6 +159,7 @@ class OpportunityRefill:
             total_cost += stage_cost
 
             self._record_economic_telemetry(sr, row)
+            self._record_runtime_stage_receipt(sr, row, trace_id=trace_id, correlation_id=correlation_id)
             stage_results.append(sr)
 
         result.stages = stage_results
@@ -187,7 +198,7 @@ class OpportunityRefill:
 
         try:
             from dharma_swarm.autoresearch_loop import AutoResearchLoop
-            loop = AutoResearchLoop()
+            AutoResearchLoop()
             sr.status = "completed"
             sr.completed_at = datetime.now(timezone.utc).isoformat()
         except Exception as exc:
@@ -246,6 +257,62 @@ class OpportunityRefill:
                 )
             except Exception:
                 logger.debug("Telemetry plane record failed", exc_info=True)
+
+    def _record_runtime_stage_receipt(
+        self,
+        sr: StageResult,
+        row: OpportunityRow,
+        *,
+        trace_id: str,
+        correlation_id: str,
+    ) -> None:
+        """Record the refill wrapper's own stage observation in runtime truth."""
+        if self._runtime_state is None or not sr.task_id or not sr.run_id or not sr.claim_id:
+            return
+        identity = ExecutionIdentity.new(
+            task_id=sr.task_id,
+            agent_id="opportunity_agent",
+            session_id=str(getattr(self._dispatcher, "_session_id", "") or ""),
+            trace_id=trace_id,
+            correlation_id=correlation_id,
+            causation_id=f"opportunity_refill:{row.id}:{sr.stage}",
+            run_id=sr.run_id,
+            claim_id=sr.claim_id,
+            idempotency_key=f"idem_{sr.run_id}",
+            proposal_id=sr.proposal_id,
+            metadata={
+                "source": "opportunity_refill",
+                "opportunity_id": row.id,
+                "opportunity_type": row.type,
+                "stage": sr.stage,
+            },
+        )
+        payload = {
+            "opportunity_id": row.id,
+            "opportunity_type": row.type,
+            "stage": sr.stage,
+            "status": sr.status,
+            "quarantined": sr.quarantined,
+            "provider_cost_usd": sr.provider_cost_usd,
+            "net_value_usd": sr.net_value_usd,
+            "artifact_path": sr.artifact_path,
+            "error": sr.error,
+        }
+        try:
+            self._runtime_state.record_execution_identity_sync(
+                identity,
+                source="opportunity_refill",
+                metadata=payload,
+            )
+            self._runtime_state.record_receipt_for_identity_sync(
+                identity,
+                receipt_type="opportunity_refill_stage",
+                status=sr.status,
+                side_effect_key=f"opportunity_refill:{row.id}:{sr.stage}",
+                payload=payload,
+            )
+        except Exception:
+            logger.debug("Runtime stage receipt record failed", exc_info=True)
 
     def _write_revenue_packet(
         self,

--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -6,11 +6,11 @@ Do not hand-edit the generated block.
 <!-- DOCOPS:START metric=repo_inventory -->
 | Metric | Value |
 |---|---:|
-| Dharma Python modules | 673 |
+| Dharma Python modules | 674 |
 | Top-level Dharma Python modules | 391 |
-| Dharma Python LOC | 285,116 |
-| Test files | 642 |
-| Test function occurrences | 11,045 |
+| Dharma Python LOC | 285,724 |
+| Test files | 644 |
+| Test function occurrences | 11,052 |
 | Markdown files | 861 |
 | Markdown total lines | 213,197 |
 | Bridge files | 24 |

--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -8,9 +8,9 @@ Do not hand-edit the generated block.
 |---|---:|
 | Dharma Python modules | 674 |
 | Top-level Dharma Python modules | 391 |
-| Dharma Python LOC | 285,724 |
+| Dharma Python LOC | 285,749 |
 | Test files | 644 |
-| Test function occurrences | 11,052 |
+| Test function occurrences | 11,053 |
 | Markdown files | 861 |
 | Markdown total lines | 213,197 |
 | Bridge files | 24 |

--- a/docs/governance/SOVEREIGN_MANIFEST.md
+++ b/docs/governance/SOVEREIGN_MANIFEST.md
@@ -117,11 +117,11 @@ These are the ground-truth metrics. All other documents citing different numbers
 
 | Metric | Value | Verification |
 |--------|-------|-------------|
-| Total Python modules | **673** | find dharma_swarm -name "*.py" -type f |
+| Total Python modules | **674** | find dharma_swarm -name "*.py" -type f |
 | Top-level (flat) modules | **391 (58.7%)** | find dharma_swarm -maxdepth 1 -name "*.py" -type f |
-| Total Python LOC | **283,300** | wc -l across dharma_swarm Python modules |
-| Test files | **642** | find tests -name "*.py" -type f |
-| Test functions | **11,045 `def test_` occurrences under tests/** | rg "def test_" tests |
+| Total Python LOC | **285,724** | wc -l across dharma_swarm Python modules |
+| Test files | **644** | find tests -name "*.py" -type f |
+| Test functions | **11,052 `def test_` occurrences under tests/** | rg "def test_" tests |
 | Tests collected (pytest) | **Needs write-permitted refresh** | not run during this DocOps count pass |
 | Collection errors | **Historical: 16 on 2026-04-04** | refresh before relying on this count |
 | Markdown files | **861** | find . -name "*.md" -type f |

--- a/docs/governance/SOVEREIGN_MANIFEST.md
+++ b/docs/governance/SOVEREIGN_MANIFEST.md
@@ -119,9 +119,9 @@ These are the ground-truth metrics. All other documents citing different numbers
 |--------|-------|-------------|
 | Total Python modules | **674** | find dharma_swarm -name "*.py" -type f |
 | Top-level (flat) modules | **391 (58.7%)** | find dharma_swarm -maxdepth 1 -name "*.py" -type f |
-| Total Python LOC | **285,724** | wc -l across dharma_swarm Python modules |
+| Total Python LOC | **285,749** | wc -l across dharma_swarm Python modules |
 | Test files | **644** | find tests -name "*.py" -type f |
-| Test functions | **11,052 `def test_` occurrences under tests/** | rg "def test_" tests |
+| Test functions | **11,053 `def test_` occurrences under tests/** | rg "def test_" tests |
 | Tests collected (pytest) | **Needs write-permitted refresh** | not run during this DocOps count pass |
 | Collection errors | **Historical: 16 on 2026-04-04** | refresh before relying on this count |
 | Markdown files | **861** | find . -name "*.md" -type f |

--- a/reports/governance/runtime_truth_nats_recovery_20260606.json
+++ b/reports/governance/runtime_truth_nats_recovery_20260606.json
@@ -1,0 +1,48 @@
+{
+  "receipt": "runtime_truth_nats_recovery_20260606",
+  "created_at": "2026-06-06T01:44:13.966041+00:00",
+  "base_ref": "origin/main",
+  "base_sha": "aa5a8e82b0c9c0a36b9c6e3585b9bcd16f6fb296",
+  "recovery_audit": {
+    "old_worktree_path": "/private/tmp/runtime-truth-projector-v1-20260605",
+    "old_worktree_present": false,
+    "reachable_commit_with_nats_transport": false,
+    "reachable_commit_with_test_nats_transport": false,
+    "stash_with_named_missing_files": false,
+    "conclusion": "Earlier runtime-projector PR landed, but the final NATS adapter files were not present on main or the remote branch. This branch reconstructs the missing slice from current origin/main."
+  },
+  "implemented_surfaces": [
+    "dharma_swarm/a2a/nats_transport.py",
+    "tests/test_nats_transport.py",
+    "dharma_swarm/opportunity_refill.py",
+    "dharma_swarm/durable_execution.py",
+    "tests/test_runtime_truth_spine_recovery.py",
+    "reports/governance/spine_adoption_metric.json"
+  ],
+  "claim_boundary": {
+    "runtime_truth_spine_adoption_pct": 93.8,
+    "joined_or_adapter_ready_surfaces": "15/16",
+    "only_non_adopted_surface": "legacy_no_identity_escape_hatch",
+    "production_adapter_contract": true,
+    "live_nats_ack_claimed": true
+  },
+  "live_nats_ack_evidence": {
+    "ack_verified": true,
+    "code": "NATS_LIVE",
+    "ack_tier": "DELIVERED_TO_CONSUMER",
+    "stream": "DHARMA_LIVE_PROBE_d83c04cf3d",
+    "seq": 1,
+    "verified_by": "nats_live_contact",
+    "endpoint": "nats://127.0.0.1:4222",
+    "rtt_ms": 96,
+    "reason": "JetStream DELIVERED_TO_CONSUMER ack verified: stream=DHARMA_LIVE_PROBE_d83c04cf3d seq=1 rtt=96ms"
+  },
+  "verification": [
+    "pytest -q tests/test_nats_transport.py tests/test_runtime_truth_spine_recovery.py tests/test_nats_live_contact.py tests/test_runtime_truth_spine_adoption.py tests/test_runtime_state_invariants.py tests/test_durable_execution.py tests/test_authority_revenue_loop.py tests/test_runtime_truth_spine_v2_evidence.py tests/test_runtime_truth_spine_v2_adapters.py tests/test_spine_adoption_dispatch.py tests/test_spine_mapping_receipts.py",
+    "ruff check dharma_swarm/a2a/nats_transport.py dharma_swarm/opportunity_refill.py dharma_swarm/durable_execution.py tests/test_nats_transport.py tests/test_runtime_truth_spine_recovery.py scripts/governance/spine_bypass_report.py scripts/docops/check_docops_integrity.py",
+    "make docops-integrity",
+    "python tools/spine_adoption_metric.py --output reports/governance/spine_adoption_metric.json --fail-below-adoption 90",
+    "python -m dharma_swarm.operator_core.nats_live_contact --write-receipt --timeout 2.0",
+    "git diff --check"
+  ]
+}

--- a/reports/governance/spine_adoption_metric.json
+++ b/reports/governance/spine_adoption_metric.json
@@ -1,5 +1,5 @@
 {
-  "audit_sha": "aa5a8e82b0c9c0a36b9c6e3585b9bcd16f6fb296",
+  "audit_sha": "25510113e0301f0923c3cfb8427c208e9438f3c6",
   "classification_rule": "joined requires all joined evidence patterns; adapter-ready requires all adapter evidence patterns when joined is incomplete; quarantine and legacy require explicit source markers; missing means no tracked surface or insufficient evidence.",
   "classification_vocabulary": [
     "joined",
@@ -13,17 +13,7 @@
   "missing_doc_anchors": [],
   "source_status": "dirty",
   "source_status_entries": [
-    " M dharma_swarm/a2a/__init__.py",
-    " A dharma_swarm/a2a/nats_transport.py",
-    " M dharma_swarm/durable_execution.py",
-    " M dharma_swarm/opportunity_refill.py",
-    " M docs/docops/AUTO_INVENTORY.md",
-    " M docs/governance/SOVEREIGN_MANIFEST.md",
-    " M reports/governance/spine_adoption_metric.json",
-    " M scripts/docops/check_docops_integrity.py",
-    " M scripts/governance/spine_bypass_report.py",
-    " A tests/test_nats_transport.py",
-    " A tests/test_runtime_truth_spine_recovery.py"
+    " M reports/governance/spine_adoption_metric.json"
   ],
   "summary": {
     "adapter_ready_count": 4,
@@ -1788,5 +1778,5 @@
       "status": "legacy"
     }
   ],
-  "tracked_file_count": 2923
+  "tracked_file_count": 2924
 }

--- a/reports/governance/spine_adoption_metric.json
+++ b/reports/governance/spine_adoption_metric.json
@@ -1,5 +1,5 @@
 {
-  "audit_sha": "b3dbf94f00a0e7a72e23d5985cc34256c275f686",
+  "audit_sha": "aa5a8e82b0c9c0a36b9c6e3585b9bcd16f6fb296",
   "classification_rule": "joined requires all joined evidence patterns; adapter-ready requires all adapter evidence patterns when joined is incomplete; quarantine and legacy require explicit source markers; missing means no tracked surface or insufficient evidence.",
   "classification_vocabulary": [
     "joined",
@@ -11,34 +11,43 @@
   "doc_anchor_status": "ok",
   "metric": "spine_adoption_metric",
   "missing_doc_anchors": [],
-  "source_status": "clean",
-  "source_status_entries": [],
+  "source_status": "dirty",
+  "source_status_entries": [
+    " M dharma_swarm/a2a/__init__.py",
+    " A dharma_swarm/a2a/nats_transport.py",
+    " M dharma_swarm/durable_execution.py",
+    " M dharma_swarm/opportunity_refill.py",
+    " M docs/docops/AUTO_INVENTORY.md",
+    " M docs/governance/SOVEREIGN_MANIFEST.md",
+    " M reports/governance/spine_adoption_metric.json",
+    " M scripts/docops/check_docops_integrity.py",
+    " M scripts/governance/spine_bypass_report.py",
+    " A tests/test_nats_transport.py",
+    " A tests/test_runtime_truth_spine_recovery.py"
+  ],
   "summary": {
     "adapter_ready_count": 4,
-    "adoption_pct": 75.0,
-    "joined_count": 8,
-    "joined_or_adapter_ready_count": 12,
-    "joined_or_adapter_ready_percent": 75.0,
-    "joined_percent": 50.0,
-    "legacy_count": 2,
-    "missing_count": 1,
+    "adoption_pct": 93.8,
+    "joined_count": 11,
+    "joined_or_adapter_ready_count": 15,
+    "joined_or_adapter_ready_percent": 93.8,
+    "joined_percent": 68.8,
+    "legacy_count": 1,
+    "missing_count": 0,
     "non_joined_surface_ids": [
       "tool_registry_dispatch",
       "ontology_action_tollbooth",
       "self_modification_loop",
-      "workflow_checkpoint_replay",
       "mcp_tool_access",
-      "nats_jetstream_transport",
-      "opportunity_refill_research_backend",
       "legacy_no_identity_escape_hatch"
     ],
-    "quarantine_count": 1,
+    "quarantine_count": 0,
     "status_counts": {
       "adapter-ready": 4,
-      "joined": 8,
-      "legacy": 2,
-      "missing": 1,
-      "quarantine": 1
+      "joined": 11,
+      "legacy": 1,
+      "missing": 0,
+      "quarantine": 0
     },
     "total_surfaces": 16
   },
@@ -121,7 +130,7 @@
           "description": "runtime store symbol is present",
           "hits": [
             {
-              "line": 1048,
+              "line": 1061,
               "path": "dharma_swarm/runtime_state.py",
               "text": "class RuntimeStateStore:"
             }
@@ -141,7 +150,7 @@
           "description": "RuntimeStateStore type exists",
           "hits": [
             {
-              "line": 1048,
+              "line": 1061,
               "path": "dharma_swarm/runtime_state.py",
               "text": "class RuntimeStateStore:"
             }
@@ -193,7 +202,7 @@
           "description": "run ledger query exists",
           "hits": [
             {
-              "line": 3263,
+              "line": 3466,
               "path": "dharma_swarm/runtime_state.py",
               "text": "async def get_run_ledger(self, run_id: str) -> dict[str, Any]:"
             }
@@ -209,7 +218,7 @@
           "description": "legacy identity bypass flag is present",
           "hits": [
             {
-              "line": 893,
+              "line": 906,
               "path": "dharma_swarm/runtime_state.py",
               "text": "\"legacy_no_identity_allowed\": True,"
             }
@@ -416,7 +425,7 @@
           "description": "orchestrator has lifecycle adapter seam",
           "hits": [
             {
-              "line": 115,
+              "line": 116,
               "path": "dharma_swarm/orchestrator.py",
               "text": "self._runtime_lifecycle = RuntimeLifecycle(self._ledger)"
             }
@@ -521,7 +530,7 @@
           "description": "required identity option exists",
           "hits": [
             {
-              "line": 126,
+              "line": 132,
               "path": "dharma_swarm/message_bus.py",
               "text": "require_identity: bool = False,"
             }
@@ -534,7 +543,7 @@
           "description": "idempotency is checked before send/emit side effects",
           "hits": [
             {
-              "line": 241,
+              "line": 247,
               "path": "dharma_swarm/message_bus.py",
               "text": "should_execute = await self._runtime_state.try_begin_idempotent_side_effect("
             }
@@ -547,7 +556,7 @@
           "description": "idempotency completion is recorded",
           "hits": [
             {
-              "line": 274,
+              "line": 293,
               "path": "dharma_swarm/message_bus.py",
               "text": "await self._runtime_state.complete_idempotent_side_effect("
             }
@@ -560,7 +569,7 @@
           "description": "message consumption receipt exists",
           "hits": [
             {
-              "line": 837,
+              "line": 852,
               "path": "dharma_swarm/message_bus.py",
               "text": "receipt_type=\"message_consumed\","
             }
@@ -920,7 +929,7 @@
           "description": "ActionDef declares typed actions",
           "hits": [
             {
-              "line": 161,
+              "line": 164,
               "path": "dharma_swarm/ontology.py",
               "text": "class ActionDef(BaseModel):"
             }
@@ -933,7 +942,7 @@
           "description": "typed action execution chokepoint exists",
           "hits": [
             {
-              "line": 763,
+              "line": 766,
               "path": "dharma_swarm/ontology.py",
               "text": "def execute_action("
             }
@@ -946,7 +955,7 @@
           "description": "modifies contract is declared",
           "hits": [
             {
-              "line": 172,
+              "line": 175,
               "path": "dharma_swarm/ontology.py",
               "text": "modifies: list[str] = Field(default_factory=list)"
             }
@@ -959,7 +968,7 @@
           "description": "approval contract is declared",
           "hits": [
             {
-              "line": 174,
+              "line": 177,
               "path": "dharma_swarm/ontology.py",
               "text": "requires_approval: bool = False"
             }
@@ -977,9 +986,15 @@
       "joined_evidence": [
         {
           "description": "ontology actions receive execution identity",
-          "hits": [],
+          "hits": [
+            {
+              "line": 42,
+              "path": "dharma_swarm/ontology.py",
+              "text": "from dharma_swarm.spine.identity import ExecutionIdentity, MissingExecutionIdentity"
+            }
+          ],
           "key": "identity_import",
-          "matched": false,
+          "matched": true,
           "regex": "ExecutionIdentity"
         },
         {
@@ -991,23 +1006,41 @@
         },
         {
           "description": "ontology action receipts are recorded",
-          "hits": [],
+          "hits": [
+            {
+              "line": 818,
+              "path": "dharma_swarm/ontology.py",
+              "text": "runtime_state.record_ontology_action_receipt_sync("
+            }
+          ],
           "key": "ontology_receipt",
-          "matched": false,
+          "matched": true,
           "regex": "record_ontology_action_receipt"
         },
         {
           "description": "ActionDef.modifies is read at execution time",
-          "hits": [],
+          "hits": [
+            {
+              "line": 826,
+              "path": "dharma_swarm/ontology.py",
+              "text": "\"modifies\": list(action_def.modifies),"
+            }
+          ],
           "key": "modifies_enforced",
-          "matched": false,
+          "matched": true,
           "regex": "action_def\\.modifies"
         },
         {
           "description": "requires_approval is read at execution time",
-          "hits": [],
+          "hits": [
+            {
+              "line": 828,
+              "path": "dharma_swarm/ontology.py",
+              "text": "\"requires_approval\": action_def.requires_approval,"
+            }
+          ],
           "key": "approval_enforced",
-          "matched": false,
+          "matched": true,
           "regex": "action_def\\.requires_approval"
         }
       ],
@@ -1015,29 +1048,9 @@
       "legacy_evidence": [],
       "missing_joined_patterns": [
         {
-          "description": "ontology actions receive execution identity",
-          "key": "identity_import",
-          "regex": "ExecutionIdentity"
-        },
-        {
           "description": "ontology actions write to runtime ledger",
           "key": "runtime_store",
           "regex": "RuntimeStateStore"
-        },
-        {
-          "description": "ontology action receipts are recorded",
-          "key": "ontology_receipt",
-          "regex": "record_ontology_action_receipt"
-        },
-        {
-          "description": "ActionDef.modifies is read at execution time",
-          "key": "modifies_enforced",
-          "regex": "action_def\\.modifies"
-        },
-        {
-          "description": "requires_approval is read at execution time",
-          "key": "approval_enforced",
-          "regex": "action_def\\.requires_approval"
         }
       ],
       "path_patterns": [
@@ -1079,7 +1092,7 @@
           "description": "apply/test phase exists",
           "hits": [
             {
-              "line": 273,
+              "line": 345,
               "path": "dharma_swarm/diff_applier.py",
               "text": "async def apply_and_test("
             },
@@ -1127,23 +1140,41 @@
       "joined_evidence": [
         {
           "description": "self-modification receives execution identity",
-          "hits": [],
+          "hits": [
+            {
+              "line": 20,
+              "path": "dharma_swarm/diff_applier.py",
+              "text": "from dharma_swarm.spine.identity import ExecutionIdentity, MissingExecutionIdentity"
+            }
+          ],
           "key": "identity_import",
-          "matched": false,
+          "matched": true,
           "regex": "ExecutionIdentity"
         },
         {
           "description": "self-modification writes to runtime ledger",
-          "hits": [],
+          "hits": [
+            {
+              "line": 19,
+              "path": "dharma_swarm/diff_applier.py",
+              "text": "from dharma_swarm.runtime_state import RuntimeStateStore"
+            }
+          ],
           "key": "runtime_store",
-          "matched": false,
+          "matched": true,
           "regex": "RuntimeStateStore"
         },
         {
           "description": "self-modification receipts are recorded",
-          "hits": [],
+          "hits": [
+            {
+              "line": 252,
+              "path": "dharma_swarm/diff_applier.py",
+              "text": "self._runtime_state.record_self_mod_receipt_sync("
+            }
+          ],
           "key": "self_mod_receipt",
-          "matched": false,
+          "matched": true,
           "regex": "record_self_mod_receipt"
         },
         {
@@ -1157,21 +1188,6 @@
       "label": "Self-modification propose/gate/apply/verify loop",
       "legacy_evidence": [],
       "missing_joined_patterns": [
-        {
-          "description": "self-modification receives execution identity",
-          "key": "identity_import",
-          "regex": "ExecutionIdentity"
-        },
-        {
-          "description": "self-modification writes to runtime ledger",
-          "key": "runtime_store",
-          "regex": "RuntimeStateStore"
-        },
-        {
-          "description": "self-modification receipts are recorded",
-          "key": "self_mod_receipt",
-          "regex": "record_self_mod_receipt"
-        },
         {
           "description": "apply path is idempotency-gated",
           "key": "begin_idempotent",
@@ -1193,7 +1209,7 @@
           "description": "workflow identity exists",
           "hits": [
             {
-              "line": 99,
+              "line": 102,
               "path": "dharma_swarm/durable_execution.py",
               "text": "workflow_id: str,"
             },
@@ -1260,23 +1276,41 @@
       "joined_evidence": [
         {
           "description": "workflow/checkpoint path receives execution identity",
-          "hits": [],
+          "hits": [
+            {
+              "line": 29,
+              "path": "dharma_swarm/durable_execution.py",
+              "text": "from dharma_swarm.spine.identity import ExecutionIdentity"
+            }
+          ],
           "key": "identity_import",
-          "matched": false,
+          "matched": true,
           "regex": "ExecutionIdentity"
         },
         {
           "description": "workflow/checkpoint path writes to runtime ledger",
-          "hits": [],
+          "hits": [
+            {
+              "line": 28,
+              "path": "dharma_swarm/durable_execution.py",
+              "text": "from dharma_swarm.runtime_state import RuntimeStateStore"
+            }
+          ],
           "key": "runtime_store",
-          "matched": false,
+          "matched": true,
           "regex": "RuntimeStateStore"
         },
         {
           "description": "workflow/checkpoint path is ledger-reconstructable",
-          "hits": [],
+          "hits": [
+            {
+              "line": 254,
+              "path": "dharma_swarm/durable_execution.py",
+              "text": "self._record_runtime_receipt("
+            }
+          ],
           "key": "runtime_receipt",
-          "matched": false,
+          "matched": true,
           "regex": "record_runtime_receipt|get_run_ledger"
         }
       ],
@@ -1291,7 +1325,7 @@
               "text": "3. **CheckpointStore** \u2014 filesystem-backed store for checkpoint data."
             },
             {
-              "line": 226,
+              "line": 233,
               "path": "dharma_swarm/durable_execution.py",
               "text": "target = self._persist_dir / \"state.json\""
             },
@@ -1319,23 +1353,7 @@
           "regex": "EventLog"
         }
       ],
-      "missing_joined_patterns": [
-        {
-          "description": "workflow/checkpoint path receives execution identity",
-          "key": "identity_import",
-          "regex": "ExecutionIdentity"
-        },
-        {
-          "description": "workflow/checkpoint path writes to runtime ledger",
-          "key": "runtime_store",
-          "regex": "RuntimeStateStore"
-        },
-        {
-          "description": "workflow/checkpoint path is ledger-reconstructable",
-          "key": "runtime_receipt",
-          "regex": "record_runtime_receipt|get_run_ledger"
-        }
-      ],
+      "missing_joined_patterns": [],
       "path_patterns": [
         "dharma_swarm/workflow.py",
         "dharma_swarm/checkpoint.py",
@@ -1344,7 +1362,7 @@
       ],
       "priority": 6,
       "quarantine_evidence": [],
-      "status": "legacy"
+      "status": "joined"
     },
     {
       "adapter_ready_evidence": [
@@ -1427,76 +1445,119 @@
       "adapter_ready_evidence": [
         {
           "description": "NATS terms are present",
-          "hits": [],
+          "hits": [
+            {
+              "line": 1,
+              "path": "dharma_swarm/a2a/nats_transport.py",
+              "text": "\"\"\"NATS/JetStream transport adapter for A2A runtime truth."
+            },
+            {
+              "line": 1,
+              "path": "dharma_swarm/operator_core/nats_live_contact.py",
+              "text": "\"\"\"Real JetStream live-contact verifier."
+            },
+            {
+              "line": 1,
+              "path": "dharma_swarm/operator_core/nats_substrate_status.py",
+              "text": "\"\"\"NATS substrate status projection for operator-facing readiness claims."
+            }
+          ],
           "key": "nats_name_seen",
-          "matched": false,
+          "matched": true,
           "regex": "NATS|JetStream|nats"
         }
       ],
       "category": "event",
-      "files": [],
+      "files": [
+        "dharma_swarm/a2a/nats_transport.py",
+        "dharma_swarm/operator_core/nats_live_contact.py",
+        "dharma_swarm/operator_core/nats_substrate_status.py"
+      ],
       "id": "nats_jetstream_transport",
       "joined_evidence": [
         {
           "description": "NATS/JetStream client code exists",
-          "hits": [],
+          "hits": [
+            {
+              "line": 1,
+              "path": "dharma_swarm/a2a/nats_transport.py",
+              "text": "\"\"\"NATS/JetStream transport adapter for A2A runtime truth."
+            },
+            {
+              "line": 1,
+              "path": "dharma_swarm/operator_core/nats_live_contact.py",
+              "text": "\"\"\"Real JetStream live-contact verifier."
+            },
+            {
+              "line": 6,
+              "path": "dharma_swarm/operator_core/nats_substrate_status.py",
+              "text": "``nats_live_contact`` verifier for a real JetStream publish/consumer ack \u2014 that"
+            }
+          ],
           "key": "nats_client",
-          "matched": false,
+          "matched": true,
           "regex": "\\bnats\\b|JetStream"
         },
         {
           "description": "NATS events carry execution identity",
-          "hits": [],
+          "hits": [
+            {
+              "line": 28,
+              "path": "dharma_swarm/a2a/nats_transport.py",
+              "text": "from dharma_swarm.spine.identity import ExecutionIdentity, MissingExecutionIdentity"
+            }
+          ],
           "key": "identity_import",
-          "matched": false,
+          "matched": true,
           "regex": "ExecutionIdentity"
         },
         {
           "description": "NATS receiver is idempotency-gated",
-          "hits": [],
+          "hits": [
+            {
+              "line": 158,
+              "path": "dharma_swarm/a2a/nats_transport.py",
+              "text": "if not await self.runtime_state.try_begin_idempotent_side_effect("
+            }
+          ],
           "key": "begin_idempotent",
-          "matched": false,
+          "matched": true,
           "regex": "try_begin_idempotent_side_effect"
         },
         {
           "description": "ack/nack contract is visible",
-          "hits": [],
+          "hits": [
+            {
+              "line": 47,
+              "path": "dharma_swarm/a2a/nats_transport.py",
+              "text": "async def ack(self) -> Any:"
+            },
+            {
+              "line": 4,
+              "path": "dharma_swarm/operator_core/nats_live_contact.py",
+              "text": "JetStream publish (and best-effort consumer ack) round-trip and only reports"
+            },
+            {
+              "line": 6,
+              "path": "dharma_swarm/operator_core/nats_substrate_status.py",
+              "text": "``nats_live_contact`` verifier for a real JetStream publish/consumer ack \u2014 that"
+            }
+          ],
           "key": "ack_contract",
-          "matched": false,
+          "matched": true,
           "regex": "\\back\\b|\\bnack\\b"
         }
       ],
       "label": "NATS/JetStream event transport",
       "legacy_evidence": [],
-      "missing_joined_patterns": [
-        {
-          "description": "NATS/JetStream client code exists",
-          "key": "nats_client",
-          "regex": "\\bnats\\b|JetStream"
-        },
-        {
-          "description": "NATS events carry execution identity",
-          "key": "identity_import",
-          "regex": "ExecutionIdentity"
-        },
-        {
-          "description": "NATS receiver is idempotency-gated",
-          "key": "begin_idempotent",
-          "regex": "try_begin_idempotent_side_effect"
-        },
-        {
-          "description": "ack/nack contract is visible",
-          "key": "ack_contract",
-          "regex": "\\back\\b|\\bnack\\b"
-        }
-      ],
+      "missing_joined_patterns": [],
       "path_patterns": [
         "dharma_swarm/nats*.py",
         "dharma_swarm/**/nats*.py"
       ],
       "priority": 8,
       "quarantine_evidence": [],
-      "status": "missing"
+      "status": "joined"
     },
     {
       "adapter_ready_evidence": [
@@ -1504,7 +1565,7 @@
           "description": "stage-result surface exists",
           "hits": [
             {
-              "line": 57,
+              "line": 58,
               "path": "dharma_swarm/opportunity_refill.py",
               "text": "class StageResult(BaseModel):"
             }
@@ -1522,9 +1583,15 @@
       "joined_evidence": [
         {
           "description": "opportunity refill carries execution identity",
-          "hits": [],
+          "hits": [
+            {
+              "line": 36,
+              "path": "dharma_swarm/opportunity_refill.py",
+              "text": "from dharma_swarm.spine.identity import ExecutionIdentity"
+            }
+          ],
           "key": "identity_import",
-          "matched": false,
+          "matched": true,
           "regex": "ExecutionIdentity"
         },
         {
@@ -1543,13 +1610,7 @@
       ],
       "label": "Opportunity refill research backend",
       "legacy_evidence": [],
-      "missing_joined_patterns": [
-        {
-          "description": "opportunity refill carries execution identity",
-          "key": "identity_import",
-          "regex": "ExecutionIdentity"
-        }
-      ],
+      "missing_joined_patterns": [],
       "path_patterns": [
         "dharma_swarm/opportunity_refill.py"
       ],
@@ -1572,7 +1633,7 @@
           "description": "backend can be forced into quarantine",
           "hits": [
             {
-              "line": 178,
+              "line": 189,
               "path": "dharma_swarm/opportunity_refill.py",
               "text": "sr.error = \"Research backend quarantined by operator (DHARMA_RESEARCH_BACKEND=quarantine)\""
             }
@@ -1582,7 +1643,7 @@
           "regex": "DHARMA_RESEARCH_BACKEND=quarantine"
         }
       ],
-      "status": "quarantine"
+      "status": "joined"
     },
     {
       "adapter_ready_evidence": [],
@@ -1599,7 +1660,7 @@
           "description": "legacy bypass must stay explicit",
           "hits": [
             {
-              "line": 893,
+              "line": 906,
               "path": "dharma_swarm/runtime_state.py",
               "text": "\"legacy_no_identity_allowed\": True,"
             },
@@ -1639,35 +1700,6 @@
   ],
   "top_saturation_targets": [
     {
-      "category": "event",
-      "files": [],
-      "id": "nats_jetstream_transport",
-      "label": "NATS/JetStream event transport",
-      "missing_joined_patterns": [
-        {
-          "description": "NATS/JetStream client code exists",
-          "key": "nats_client",
-          "regex": "\\bnats\\b|JetStream"
-        },
-        {
-          "description": "NATS events carry execution identity",
-          "key": "identity_import",
-          "regex": "ExecutionIdentity"
-        },
-        {
-          "description": "NATS receiver is idempotency-gated",
-          "key": "begin_idempotent",
-          "regex": "try_begin_idempotent_side_effect"
-        },
-        {
-          "description": "ack/nack contract is visible",
-          "key": "ack_contract",
-          "regex": "\\back\\b|\\bnack\\b"
-        }
-      ],
-      "status": "missing"
-    },
-    {
       "category": "ontology",
       "files": [
         "dharma_swarm/ontology.py"
@@ -1676,29 +1708,9 @@
       "label": "Ontology typed action tollbooth",
       "missing_joined_patterns": [
         {
-          "description": "ontology actions receive execution identity",
-          "key": "identity_import",
-          "regex": "ExecutionIdentity"
-        },
-        {
           "description": "ontology actions write to runtime ledger",
           "key": "runtime_store",
           "regex": "RuntimeStateStore"
-        },
-        {
-          "description": "ontology action receipts are recorded",
-          "key": "ontology_receipt",
-          "regex": "record_ontology_action_receipt"
-        },
-        {
-          "description": "ActionDef.modifies is read at execution time",
-          "key": "modifies_enforced",
-          "regex": "action_def\\.modifies"
-        },
-        {
-          "description": "requires_approval is read at execution time",
-          "key": "approval_enforced",
-          "regex": "action_def\\.requires_approval"
         }
       ],
       "status": "adapter-ready"
@@ -1729,21 +1741,6 @@
       "id": "self_modification_loop",
       "label": "Self-modification propose/gate/apply/verify loop",
       "missing_joined_patterns": [
-        {
-          "description": "self-modification receives execution identity",
-          "key": "identity_import",
-          "regex": "ExecutionIdentity"
-        },
-        {
-          "description": "self-modification writes to runtime ledger",
-          "key": "runtime_store",
-          "regex": "RuntimeStateStore"
-        },
-        {
-          "description": "self-modification receipts are recorded",
-          "key": "self_mod_receipt",
-          "regex": "record_self_mod_receipt"
-        },
         {
           "description": "apply path is idempotency-gated",
           "key": "begin_idempotent",
@@ -1778,7 +1775,18 @@
         }
       ],
       "status": "adapter-ready"
+    },
+    {
+      "category": "legacy",
+      "files": [
+        "dharma_swarm/runtime_state.py",
+        "tests/test_runtime_state_invariants.py"
+      ],
+      "id": "legacy_no_identity_escape_hatch",
+      "label": "Legacy no-identity escape hatch",
+      "missing_joined_patterns": [],
+      "status": "legacy"
     }
   ],
-  "tracked_file_count": 2761
+  "tracked_file_count": 2923
 }

--- a/reports/governance/spine_adoption_metric.json
+++ b/reports/governance/spine_adoption_metric.json
@@ -1,5 +1,5 @@
 {
-  "audit_sha": "25510113e0301f0923c3cfb8427c208e9438f3c6",
+  "audit_sha": "4b86b8aef52f8df90707e0dbc13efa4b0f2f9ded",
   "classification_rule": "joined requires all joined evidence patterns; adapter-ready requires all adapter evidence patterns when joined is incomplete; quarantine and legacy require explicit source markers; missing means no tracked surface or insufficient evidence.",
   "classification_vocabulary": [
     "joined",
@@ -11,10 +11,8 @@
   "doc_anchor_status": "ok",
   "metric": "spine_adoption_metric",
   "missing_doc_anchors": [],
-  "source_status": "dirty",
-  "source_status_entries": [
-    " M reports/governance/spine_adoption_metric.json"
-  ],
+  "source_status": "clean",
+  "source_status_entries": [],
   "summary": {
     "adapter_ready_count": 4,
     "adoption_pct": 93.8,

--- a/scripts/docops/check_docops_integrity.py
+++ b/scripts/docops/check_docops_integrity.py
@@ -111,12 +111,13 @@ def count_files(repo_root: Path, pattern: str) -> int:
 
 
 def count_paths_containing(repo_root: Path, pattern: str, needle: str) -> int:
+    needle_lower = needle.lower()
     return sum(
         1
         for path in repo_root.glob(pattern)
         if path.is_file()
         and not is_ignored(path, repo_root)
-        and needle.lower() in path.as_posix().lower()
+        and needle_lower in path.relative_to(repo_root).as_posix().lower()
     )
 
 

--- a/scripts/governance/spine_bypass_report.py
+++ b/scripts/governance/spine_bypass_report.py
@@ -60,6 +60,10 @@ _INTENTIONAL_BYPASS: dict[tuple[str, int], str] = {
         "_dispatch_local — in-process delegation, "
         "migration target after node_gateway"
     ),
+    ("dharma_swarm/a2a/nats_transport.py", 300): (
+        "consume_message — NATS ingress handoff after transport-level "
+        "ExecutionIdentity, idempotency, and ack/nack receipts"
+    ),
 }
 
 # Known non-production lines (docstring examples, etc.)

--- a/scripts/governance/spine_bypass_report.py
+++ b/scripts/governance/spine_bypass_report.py
@@ -60,7 +60,7 @@ _INTENTIONAL_BYPASS: dict[tuple[str, int], str] = {
         "_dispatch_local — in-process delegation, "
         "migration target after node_gateway"
     ),
-    ("dharma_swarm/a2a/nats_transport.py", 300): (
+    ("dharma_swarm/a2a/nats_transport.py", 301): (
         "consume_message — NATS ingress handoff after transport-level "
         "ExecutionIdentity, idempotency, and ack/nack receipts"
     ),

--- a/tests/test_nats_transport.py
+++ b/tests/test_nats_transport.py
@@ -74,6 +74,29 @@ class _FakeMessage:
         self.nacked += 1
 
 
+class _InspectingAckMessage(_FakeMessage):
+    def __init__(
+        self,
+        subject: str,
+        data: bytes,
+        *,
+        runtime: RuntimeStateStore,
+        run_id: str,
+    ) -> None:
+        super().__init__(subject, data)
+        self._runtime = runtime
+        self._run_id = run_id
+
+    async def ack(self) -> None:
+        ledger = await self._runtime.get_run_ledger(self._run_id)
+        assert any(
+            receipt.receipt_type == "nats_consume"
+            and receipt.status == "ack_intent"
+            for receipt in ledger["receipts"]
+        )
+        await super().ack()
+
+
 @pytest.mark.asyncio
 async def test_publish_task_records_identity_idempotency_and_ack_receipt(tmp_path: Path) -> None:
     runtime = RuntimeStateStore(tmp_path / "runtime.db")
@@ -141,7 +164,12 @@ async def test_consume_message_ack_records_receipt_and_dispatches(tmp_path: Path
     transport = A2ANatsTransport(runtime_state=runtime, server=server, jetstream=fake_js)
     task = _task(identity, task_id="a2a-consume")
     await transport.publish_task(task, identity=identity)
-    message = _FakeMessage("dharma.a2a.task.worker.probe", fake_js.published[0][1])
+    message = _InspectingAckMessage(
+        "dharma.a2a.task.worker.probe",
+        fake_js.published[0][1],
+        runtime=runtime,
+        run_id=identity.run_id,
+    )
 
     ack = await transport.consume_message(message)
 
@@ -151,6 +179,7 @@ async def test_consume_message_ack_records_receipt_and_dispatches(tmp_path: Path
     assert message.nacked == 0
     assert seen == ["a2a-consume"]
     ledger = await runtime.get_run_ledger(identity.run_id)
+    assert any(receipt.receipt_type == "nats_consume" and receipt.status == "ack_intent" for receipt in ledger["receipts"])
     assert any(receipt.receipt_type == "nats_consume" and receipt.status == "ack" for receipt in ledger["receipts"])
 
 
@@ -176,3 +205,36 @@ async def test_consume_message_nacks_when_handler_fails(tmp_path: Path) -> None:
     assert message.nacked == 1
     ledger = await runtime.get_run_ledger(identity.run_id)
     assert any(receipt.receipt_type == "nats_consume" and receipt.status == "nack" for receipt in ledger["receipts"])
+
+
+@pytest.mark.asyncio
+async def test_consume_message_does_not_nak_after_broker_ack(tmp_path: Path) -> None:
+    runtime = RuntimeStateStore(tmp_path / "runtime.db")
+    fake_js = _FakeJetStream()
+    identity = _identity(run_id="run-post-ack-error", idempotency_key="idem-post-ack-error")
+    server = A2AServer(runtime_state=runtime, persist=False, require_execution_identity=True)
+
+    def handler(task: A2ATask) -> A2ATask:
+        task.status = A2ATaskStatus.COMPLETED
+        return task
+
+    async def fail_complete(*args: object, **kwargs: object) -> object:
+        raise RuntimeError("runtime finalization failed")
+
+    server.register_handler("probe", handler)
+    transport = A2ANatsTransport(runtime_state=runtime, server=server, jetstream=fake_js)
+    await transport.publish_task(_task(identity, task_id="a2a-post-ack-error"), identity=identity)
+    transport.runtime_state.complete_idempotent_side_effect = fail_complete  # type: ignore[method-assign]
+    message = _FakeMessage("dharma.a2a.task.worker.probe", fake_js.published[0][1])
+
+    with pytest.raises(NatsTransportError, match="broker ack succeeded"):
+        await transport.consume_message(message)
+
+    assert message.acked == 1
+    assert message.nacked == 0
+    ledger = await runtime.get_run_ledger(identity.run_id)
+    assert any(
+        receipt.receipt_type == "nats_consume"
+        and receipt.status == "ack_finalization_error"
+        for receipt in ledger["receipts"]
+    )

--- a/tests/test_nats_transport.py
+++ b/tests/test_nats_transport.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from dharma_swarm.a2a.a2a_server import A2AMessage, A2AServer, A2ATask, A2ATaskStatus
+from dharma_swarm.a2a.nats_transport import A2ANatsTransport, NatsTransportError
+from dharma_swarm.runtime_state import RuntimeStateStore
+from dharma_swarm.spine.identity import ExecutionIdentity, MissingExecutionIdentity
+
+
+def _identity(**overrides: str) -> ExecutionIdentity:
+    payload = {
+        "task_id": "task-nats",
+        "agent_id": "agent-nats",
+        "session_id": "session-nats",
+        "trace_id": "trace-nats",
+        "correlation_id": "corr-nats",
+        "run_id": "run-nats",
+        "claim_id": "claim-nats",
+        "idempotency_key": "idem-nats",
+    }
+    payload.update(overrides)
+    return ExecutionIdentity.new(**payload)
+
+
+def _task(identity: ExecutionIdentity | None = None, *, task_id: str = "a2a-task") -> A2ATask:
+    metadata = identity.to_metadata() if identity else {}
+    return A2ATask(
+        id=task_id,
+        from_agent="operator",
+        to_agent="worker",
+        capability="probe",
+        history=[A2AMessage.text("run probe")],
+        metadata=metadata,
+    )
+
+
+@dataclass
+class _FakePubAck:
+    stream: str = "DHARMA_A2A"
+    seq: int = 1
+
+
+class _FakeJetStream:
+    def __init__(self) -> None:
+        self.published: list[tuple[str, bytes, dict[str, str] | None]] = []
+
+    async def publish(
+        self,
+        subject: str,
+        payload: bytes,
+        *,
+        headers: dict[str, str] | None = None,
+        timeout: float | None = None,
+    ) -> _FakePubAck:
+        self.published.append((subject, payload, headers))
+        return _FakePubAck(seq=len(self.published))
+
+
+class _FakeMessage:
+    def __init__(self, subject: str, data: bytes) -> None:
+        self.subject = subject
+        self.data = data
+        self.acked = 0
+        self.nacked = 0
+
+    async def ack(self) -> None:
+        self.acked += 1
+
+    async def nak(self) -> None:
+        self.nacked += 1
+
+
+@pytest.mark.asyncio
+async def test_publish_task_records_identity_idempotency_and_ack_receipt(tmp_path: Path) -> None:
+    runtime = RuntimeStateStore(tmp_path / "runtime.db")
+    fake_js = _FakeJetStream()
+    identity = _identity()
+    transport = A2ANatsTransport(runtime_state=runtime, jetstream=fake_js)
+
+    ack = await transport.publish_task(_task(identity), identity=identity)
+
+    assert ack.action == "ack"
+    assert ack.status == "ack"
+    assert ack.seq == 1
+    assert len(fake_js.published) == 1
+    assert fake_js.published[0][2]["Dharma-Correlation-Id"] == identity.correlation_id
+
+    ledger = await runtime.get_run_ledger(identity.run_id)
+    assert ledger["identity"] is not None
+    assert any(receipt.receipt_type == "nats_publish" and receipt.status == "ack" for receipt in ledger["receipts"])
+    assert any(record.side_effect_key.startswith("nats_publish:") for record in ledger["idempotency_records"])
+
+
+@pytest.mark.asyncio
+async def test_publish_duplicate_does_not_publish_again(tmp_path: Path) -> None:
+    runtime = RuntimeStateStore(tmp_path / "runtime.db")
+    fake_js = _FakeJetStream()
+    identity = _identity()
+    transport = A2ANatsTransport(runtime_state=runtime, jetstream=fake_js)
+    task = _task(identity)
+
+    first = await transport.publish_task(task, identity=identity)
+    second = await transport.publish_task(task, identity=identity)
+
+    assert first.status == "ack"
+    assert second.status == "duplicate"
+    assert second.duplicate is True
+    assert len(fake_js.published) == 1
+
+
+@pytest.mark.asyncio
+async def test_publish_requires_execution_identity_before_side_effect(tmp_path: Path) -> None:
+    runtime = RuntimeStateStore(tmp_path / "runtime.db")
+    fake_js = _FakeJetStream()
+    transport = A2ANatsTransport(runtime_state=runtime, jetstream=fake_js)
+
+    with pytest.raises(MissingExecutionIdentity):
+        await transport.publish_task(_task(None))
+
+    assert fake_js.published == []
+
+
+@pytest.mark.asyncio
+async def test_consume_message_ack_records_receipt_and_dispatches(tmp_path: Path) -> None:
+    runtime = RuntimeStateStore(tmp_path / "runtime.db")
+    fake_js = _FakeJetStream()
+    identity = _identity(run_id="run-consume", idempotency_key="idem-consume")
+    server = A2AServer(runtime_state=runtime, persist=False, require_execution_identity=True)
+    seen: list[str] = []
+
+    def handler(task: A2ATask) -> A2ATask:
+        seen.append(task.id)
+        task.status = A2ATaskStatus.COMPLETED
+        return task
+
+    server.register_handler("probe", handler)
+    transport = A2ANatsTransport(runtime_state=runtime, server=server, jetstream=fake_js)
+    task = _task(identity, task_id="a2a-consume")
+    await transport.publish_task(task, identity=identity)
+    message = _FakeMessage("dharma.a2a.task.worker.probe", fake_js.published[0][1])
+
+    ack = await transport.consume_message(message)
+
+    assert ack.action == "ack"
+    assert ack.status == "ack"
+    assert message.acked == 1
+    assert message.nacked == 0
+    assert seen == ["a2a-consume"]
+    ledger = await runtime.get_run_ledger(identity.run_id)
+    assert any(receipt.receipt_type == "nats_consume" and receipt.status == "ack" for receipt in ledger["receipts"])
+
+
+@pytest.mark.asyncio
+async def test_consume_message_nacks_when_handler_fails(tmp_path: Path) -> None:
+    runtime = RuntimeStateStore(tmp_path / "runtime.db")
+    fake_js = _FakeJetStream()
+    identity = _identity(run_id="run-nack", idempotency_key="idem-nack")
+    server = A2AServer(runtime_state=runtime, persist=False, require_execution_identity=True)
+
+    def handler(task: A2ATask) -> A2ATask:
+        raise RuntimeError("handler failed")
+
+    server.register_handler("probe", handler)
+    transport = A2ANatsTransport(runtime_state=runtime, server=server, jetstream=fake_js)
+    await transport.publish_task(_task(identity, task_id="a2a-nack"), identity=identity)
+    message = _FakeMessage("dharma.a2a.task.worker.probe", fake_js.published[0][1])
+
+    with pytest.raises(NatsTransportError):
+        await transport.consume_message(message)
+
+    assert message.acked == 0
+    assert message.nacked == 1
+    ledger = await runtime.get_run_ledger(identity.run_id)
+    assert any(receipt.receipt_type == "nats_consume" and receipt.status == "nack" for receipt in ledger["receipts"])

--- a/tests/test_runtime_truth_spine_recovery.py
+++ b/tests/test_runtime_truth_spine_recovery.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from dharma_swarm.durable_execution import DurableWorkflow
+from dharma_swarm.opportunity_refill import OpportunityRefill, OpportunityRow
+from dharma_swarm.runtime_state import RuntimeStateStore
+from dharma_swarm.spine.identity import ExecutionIdentity
+
+
+def _identity(**overrides: str) -> ExecutionIdentity:
+    payload = {
+        "task_id": "task-recovery",
+        "agent_id": "agent-recovery",
+        "session_id": "session-recovery",
+        "trace_id": "trace-recovery",
+        "correlation_id": "corr-recovery",
+        "run_id": "run-recovery",
+        "claim_id": "claim-recovery",
+        "idempotency_key": "idem-recovery",
+    }
+    payload.update(overrides)
+    return ExecutionIdentity.new(**payload)
+
+
+def test_opportunity_refill_records_runtime_stage_receipts(tmp_path: Path) -> None:
+    runtime = RuntimeStateStore(tmp_path / "runtime.db")
+    refill = OpportunityRefill(
+        output_dir=tmp_path / "packets",
+        runtime_state=runtime,
+    )
+    row = OpportunityRow(
+        id="opp-runtime",
+        title="Runtime opportunity",
+        estimated_value_usd=10,
+        metadata={"trace_id": "trace-opp", "correlation_id": "corr-opp"},
+    )
+
+    result = refill.refill(row)
+
+    assert result.success is True
+    stage = result.stages[0]
+    ledger = asyncio.run(runtime.get_run_ledger(stage.run_id))
+    assert ledger["identity"] is not None
+    assert any(
+        receipt.receipt_type == "opportunity_refill_stage"
+        and receipt.status == "completed"
+        for receipt in ledger["receipts"]
+    )
+
+
+def test_durable_workflow_records_checkpoint_receipt(tmp_path: Path) -> None:
+    runtime = RuntimeStateStore(tmp_path / "runtime.db")
+    identity = _identity()
+    workflow = DurableWorkflow(
+        "workflow-runtime",
+        persist_dir=tmp_path / "workflow",
+        runtime_state=runtime,
+        execution_identity=identity,
+    )
+
+    workflow.add_step("step-1", "first")
+    workflow.mark_running("step-1")
+
+    ledger = asyncio.run(runtime.get_run_ledger(identity.run_id))
+    assert ledger["identity"] is not None
+    assert any(
+        receipt.receipt_type == "workflow_checkpoint"
+        and receipt.status == "checkpointed"
+        for receipt in ledger["receipts"]
+    )


### PR DESCRIPTION
## Summary

- Reconstructs the missing runtime-truth NATS/JetStream A2A transport from current `main`.
- Adds RuntimeStateStore-backed ExecutionIdentity, idempotency, publish/consume ack-nack receipt coverage for the transport.
- Hardens consume ordering so `ack_intent` is persisted before broker ack and post-ack finalization errors do not emit false NAKs.
- Joins the remaining opportunity refill and durable workflow checkpoint surfaces into the runtime truth spine.
- Fixes a docops integrity path-count bug that misclassified adapter files when the worktree path contained `adapter`.
- Refreshes the spine adoption metric and docops inventory/manifest counts.

## Coherence Delta

- Organ touched: A2A transport, runtime truth state/receipt projection, opportunity refill, durable workflow checkpoints, and docops/governance inventory scripts.
- Declared-vs-actual gap closed: The earlier reported NATS transport slice was not present on `main`; this PR recreates it from current `origin/main` and records recovery evidence in `reports/governance/runtime_truth_nats_recovery_20260606.json`.
- Proof that re-reads the map: `python tools/spine_adoption_metric.py --output reports/governance/spine_adoption_metric.json --fail-below-adoption 90` passed with 15/16 joined-or-adapter-ready surfaces and 93.8% adoption.
- New drift introduced: None known. The only remaining non-adopted surface is the intentional `legacy_no_identity_escape_hatch`.

## Claim boundary

The earlier local-only completion claim was not present on `main`. Recovery did not find a surviving reachable commit, stash, or worktree containing the reported `dharma_swarm/a2a/nats_transport.py` and `tests/test_nats_transport.py` slice, so this PR recreates and hardens that slice from current `origin/main`.

This PR includes local live NATS proof via `dharma_swarm.operator_core.nats_live_contact`: JetStream `DELIVERED_TO_CONSUMER` ack verified on `nats://127.0.0.1:4222`. Latest rerun on this head verified stream `DHARMA_LIVE_PROBE_cf40a457c8`, seq `1`, RTT `228ms`. The adapter contract is implemented in code; production freshness remains represented by runtime truth projections.

## Verification

- `pytest -q tests/test_nats_transport.py tests/test_runtime_truth_spine_recovery.py tests/test_nats_live_contact.py tests/test_runtime_truth_spine_adoption.py tests/test_runtime_state_invariants.py tests/test_durable_execution.py tests/test_authority_revenue_loop.py tests/test_runtime_truth_spine_v2_evidence.py tests/test_runtime_truth_spine_v2_adapters.py tests/test_spine_adoption_dispatch.py tests/test_spine_mapping_receipts.py` -> 89 passed, 1 skipped
- `pytest -q tests/test_nats_transport.py` -> 6 passed
- `ruff check dharma_swarm/a2a/nats_transport.py dharma_swarm/opportunity_refill.py dharma_swarm/durable_execution.py tests/test_nats_transport.py tests/test_runtime_truth_spine_recovery.py scripts/governance/spine_bypass_report.py scripts/docops/check_docops_integrity.py` -> passed
- `make docops-integrity` -> passed
- `python tools/spine_adoption_metric.py --output reports/governance/spine_adoption_metric.json --fail-below-adoption 90` -> passed, 15/16 joined-or-adapter-ready, 93.8% adoption
- `python -m dharma_swarm.operator_core.nats_live_contact --write-receipt --timeout 2.0` -> passed, live JetStream delivered-to-consumer ack verified
- `python -m compileall -q dharma_swarm/a2a/nats_transport.py dharma_swarm/opportunity_refill.py dharma_swarm/durable_execution.py tests/test_nats_transport.py tests/test_runtime_truth_spine_recovery.py scripts/governance/spine_bypass_report.py scripts/docops/check_docops_integrity.py` -> passed
- `git diff --check` -> passed
- commit hooks passed, including docops integrity, manifest check, gitleaks, and warning-only semgrep
