### PR TITLE
docs(governance): document self-healing DocOps feeder in PR hygiene doctrine [impact-checked]

### DIFF
--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -12,7 +12,7 @@ Do not hand-edit the generated block.
 | Test files | 642 |
 | Test function occurrences | 11,045 |
 | Markdown files | 861 |
-| Markdown total lines | 213,197 |
+| Markdown total lines | 213,225 |
 | Bridge files | 24 |
 | Adapter files | 21 |
 | Orchestrator files | 5 |

--- a/docs/governance/PR_QUALITY_GATES.md
+++ b/docs/governance/PR_QUALITY_GATES.md
@@ -36,6 +36,32 @@ make gitleaks             # secret scanning
 make docops-integrity     # documentation invariants
 ```
 
+### Self-healing DocOps counts (why gate #3 rarely blocks anymore)
+
+Gate #3 (DocOps integrity) verifies that count-sensitive generated sections
+(file / test / module counts) match the filesystem. Historically *any* PR that
+added or removed a file invalidated those counts and the read-only gate failed,
+so nearly the entire queue sat blocked until someone hand-ran the repair. That
+failure mode produced the 57-PR jam of 2026-06-05.
+
+This is now self-healing. The `docops-autorefresh.yml` feeder runs on every
+same-repo PR (triggers on `pull_request` to `main`, `promote/**`,
+`governance/**`, plus `workflow_dispatch`). It reuses the existing writer
+`scripts/docops/check_docops_integrity.py --write-auto-sections`, refreshes the
+generated count sections, and commits them back to the PR head branch with
+`--force-with-lease`. It adds no new writer (Axiom A2), performs no merge
+(Merge Master Mike still owns merges), and skips forked-PR heads for safety.
+
+Practical consequence for authors and reviewers:
+
+- You do **not** need to hand-refresh counts before opening a PR. Push your
+  change; the feeder reconciles counts on the next CI run.
+- If gate #3 still fails after the feeder ran, the drift is *real* (a
+  hand-edited count section, or a count section the writer does not own) and
+  must be fixed by hand.
+- The feeder only runs for same-repo branches. Fork contributors must run
+  `make docops-integrity` and commit the refresh themselves.
+
 ---
 
 ## 2. Bot PR Proliferation Control
@@ -85,7 +111,9 @@ Every agent or contributor must:
 
 1. **Run `make onboard`** at session start to see the current operating
    reality (active track, live ops, broken register, PR hygiene summary)
-2. **Run `make governance-all`** before opening any PR
+2. **Run `make governance-all`** before opening any PR. You do not need to
+   hand-refresh DocOps counts — the `docops-autorefresh.yml` feeder reconciles
+   them on the first CI run (see §1, "Self-healing DocOps counts").
 3. **Check for existing open PRs** on the same topic before opening a new one:
    ```bash
    gh pr list --state open --search "<your topic keywords>"

--- a/docs/governance/SOVEREIGN_MANIFEST.md
+++ b/docs/governance/SOVEREIGN_MANIFEST.md
@@ -125,7 +125,7 @@ These are the ground-truth metrics. All other documents citing different numbers
 | Tests collected (pytest) | **Needs write-permitted refresh** | not run during this DocOps count pass |
 | Collection errors | **Historical: 16 on 2026-04-04** | refresh before relying on this count |
 | Markdown files | **861** | find . -name "*.md" -type f |
-| Markdown total lines | **213,197** | wc -l across all .md |
+| Markdown total lines | **213,225** | wc -l across all .md |
 | Bridge files | **24** | find dharma_swarm -name "*bridge*.py" |
 | Adapter files | **21 across 8 locations** | find dharma_swarm -type f \| rg -i "adapter" |
 | Orchestrator files | **4** (6,034 LOC total) | find dharma_swarm -name "*orchestrat*" |


### PR DESCRIPTION
## Summary

Documents the **self-healing DocOps feeder** in the canonical PR hygiene doctrine so
agents and contributors stop hand-refreshing counts and stop recreating the 57-PR
jam of 2026-06-05. The feeder (`docops-autorefresh.yml`, merged in #490) already
exists and runs; this PR closes the gap between behavior and doctrine. `[impact-checked]`

Changes:
- `docs/governance/PR_QUALITY_GATES.md`: new subsection under §1 — "Self-healing
  DocOps counts (why gate #3 rarely blocks anymore)" — plus an onboarding-rule note
  that authors no longer need to hand-refresh counts. States the A2 (no new writer)
  and merge-authority (MMM still owns merges) boundaries explicitly.
- `docs/governance/SOVEREIGN_MANIFEST.md`: manual update of the `Markdown total lines`
  ground-truth metric (213,197 → 213,225) — the legitimate "real drift" path the new
  subsection describes (a hand-maintained count the auto-writer does not own).
- `docs/docops/AUTO_INVENTORY.md`: auto-section refresh produced by
  `scripts/docops/check_docops_integrity.py --write-auto-sections` (no hand edits).

No code paths touched. No new files, no new top-level `.py`, no new authority surface.

## Coherence Delta

- **Organ touched**: governance doctrine — PR quality-gate documentation and the
  SOVEREIGN_MANIFEST ground-truth metric block.
- **Declared-vs-actual gap closed**: the DocOps feeder shipped in #490 and changed
  real author/reviewer behavior, but `PR_QUALITY_GATES.md` still described gate #3 as
  an unconditional hard-fail on count drift. Doctrine now matches the running system.
- **Proof that re-reads the map**: `python3 scripts/docops/check_docops_integrity.py`
  → "DocOps integrity checks passed" after the manifest line-count was reconciled by
  hand and the AUTO_INVENTORY auto-section was regenerated by the existing writer.
- **New drift introduced**: none. The manifest metric was reconciled to the current
  filesystem total (213,225) in the same change.
