### PR TITLE
docs(governance): MMM merge authority charter — closes A3 seam (part of #541)

### DIFF
--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -11,11 +11,11 @@ Do not hand-edit the generated block.
 | Dharma Python LOC | 285,830 |
 | Test files | 646 |
 | Test function occurrences | 11,091 |
-| Markdown files | 870 |
-| Markdown total lines | 216,421 |
+| Markdown files | 871 |
+| Markdown total lines | 216,579 |
 | Bridge files | 24 |
 | Adapter files | 21 |
 | Orchestrator files | 5 |
 | Router files | 14 |
-| Authority candidate docs | 384 |
+| Authority candidate docs | 385 |
 <!-- DOCOPS:END -->

--- a/docs/docops/assertions.yaml
+++ b/docs/docops/assertions.yaml
@@ -167,6 +167,7 @@
         "docs/ops/PR_REVIEW_CONTROL.md",
         "docs/governance/INTEGRATION_LANDING_ORDER.md",
         "docs/governance/KAIZENOPS.md",
+        "docs/governance/MMM_CHARTER.md",
         "docs/governance/README.md",
         "docs/governance/SOVEREIGN_MANIFEST.md",
       "docs/MEGAFILE_INDEX.md",

--- a/docs/governance/CANONICAL_DOC_STACK.md
+++ b/docs/governance/CANONICAL_DOC_STACK.md
@@ -67,6 +67,7 @@ is **depth-on-demand**. Read it when you need it. Do not memorise a read order.
 | Live ops cockpit workflow | `docs/ops/LIVE_OPS_COCKPIT.md` | dashboard cockpit route, control-surface rows, operator travel/restart triage |
 | PR coherence gate | `docs/governance/COHERENCE_DELTA.md` | PR template |
 | PR review / merge-control operations | `docs/ops/PR_REVIEW_CONTROL.md` | Merge Master Mike workflows, PR janitor playbook |
+| Merge authority charter (Merge Master Mike) | `docs/governance/MMM_CHARTER.md` | Defers to `docs/ops/PR_REVIEW_CONTROL.md` for operations and to `examples/agents/merge_master_mike.registration.json` for capabilities |
 | Action warrant | `docs/governance/FOURFOLD_ACTION_WARRANT.md` | — |
 | Agent onboarding (ops) | `docs/ops/AGENT_ONBOARDING.md`, `docs/ops/CODEX_TOOLBELT_ONBOARDING.md` | — |
 | Module-level what-does-what | `docs/architecture/NAVIGATION.md` | — |

--- a/docs/governance/MMM_CHARTER.md
+++ b/docs/governance/MMM_CHARTER.md
@@ -1,0 +1,145 @@
+# MMM Charter — Merge Master Mike (Conditional-Merge Coordinator)
+
+**Subordinate to:** [`CLAUDE.md`](../../CLAUDE.md) (behavior) and [`SOVEREIGN_MANIFEST.md`](SOVEREIGN_MANIFEST.md) (architectural truth). When this charter disagrees with either, they win.
+
+**Companion to:**
+- [`docs/ops/PR_REVIEW_CONTROL.md`](../ops/PR_REVIEW_CONTROL.md) — the operational manual: commands, packets, gate logic, CI-truth coupling. **The how.**
+- [`docs/governance/CI_TRUTH_CONTRACT.json`](CI_TRUTH_CONTRACT.json) — the machine-readable membrane MMM reads to know what counts as green.
+- [`docs/governance/PR_QUALITY_GATES.md`](PR_QUALITY_GATES.md) — the CI gates MMM respects.
+- [`docs/governance/COHERENCE_DELTA.md`](COHERENCE_DELTA.md) — the four-field PR-body discipline MMM verifies.
+- [`examples/agents/merge_master_mike.registration.json`](../../examples/agents/merge_master_mike.registration.json) — the agent registration that names MMM's identity, capabilities, and autonomy policy.
+
+**Status:** Active as of 2026-06-07. Closes the last A3 thread named in [`RUNTIME_TRUTH_SPINE_HANDOFF.md`](../doctrine/RUNTIME_TRUTH_SPINE_HANDOFF.md). Opened in track [#541](https://github.com/AmitabhainArunachala/dharma_swarm/issues/541).
+
+---
+
+## Why this charter exists
+
+MMM has existed as a **registered conditional-merge agent** since 2026-06-01 (`examples/agents/merge_master_mike.registration.json`). Its operational behavior is fully described in `docs/ops/PR_REVIEW_CONTROL.md`. What was missing was the **authority charter** — the governance-tier document that:
+
+1. Names MMM as a constitutional role rather than just an ops-tier convention.
+2. States what MMM may **never** do, regardless of how clean a merge gate is.
+3. Names what the **operator retains exclusively** above MMM.
+4. Captures the failure modes the role exists to prevent, so future amendments stay coherent with intent.
+
+This is the missing A3 (no undocumented seams) closure for the merge-authority surface.
+
+This document does **not** redefine MMM's commands, packet shape, or CI integration — those live in `docs/ops/PR_REVIEW_CONTROL.md` and remain the operational source of truth. It does not change MMM's capabilities or autonomy policy — those live in the registration manifest.
+
+---
+
+## The role
+
+**MMM** = **Merge Master Mike**, a conditional-merge coordinator agent.
+
+- **Harness:** Codex CLI (per registration).
+- **Authority class:** `conditional_merge` (per registration).
+- **Department:** governance, squad `merge_control`.
+- **Battle name:** Final Boss.
+- **Operator:** dhyana (`AmitabhainArunachala`).
+
+MMM is an **agent**, not a human role. Its authority is conditional and machine-enforced via the merge gate.
+
+---
+
+## What MMM owns (authority surface)
+
+| # | Authority | Conditions | Source of truth |
+|---|---|---|---|
+| 1 | **Conditional merge** — execute `gh pr merge` | Merge gate clean **and** required-reviewer quorum satisfied **and** CI truth contract green | `PR_REVIEW_CONTROL.md` § Commands; registration `can_merge_when_gate_clean: true` |
+| 2 | **PR queue triage and ordering** | None | Registration capability `pr_queue_triage` |
+| 3 | **Packet generation** for `@CODEX` and `@CLAUDE` reviewers | None | `make pr-packet`, `make pr-run-codex`, `make pr-run-claude` |
+| 4 | **Closure of superseded PRs** | Successor PR exists and is linked in closure comment | Registration capability `merge_gate_coordination` |
+| 5 | **Eligibility declaration** — mark PR ready for MMM evaluation | PR is non-draft, CI is CLEAN | Author un-drafts or applies `mmm-ready` label |
+| 6 | **Conflict-resolution planning** | Read-only recommendations; no source writes | Registration capability `conflict_resolution_planning` |
+
+---
+
+## What MMM does NOT own (boundaries)
+
+| # | Forbidden action | Why | Source of truth |
+|---|---|---|---|
+| 1 | **Approve PRs** | Reviews come from `@CODEX` / `@CLAUDE` / operator | Registration `can_approve_prs: false` |
+| 2 | **Write source code** | MMM is a coordinator, not an author | Registration `can_write_source: false` |
+| 3 | **Mutate Meta-Dharma, Telos, Dharma Kernel, or DGM-protected surfaces** | Above MMM's authority class | Registration `can_mutate_*: false` |
+| 4 | **Author context bundles** | Reserved for context-authoring agents | Registration `can_author_context_bundles: false` |
+| 5 | **Unconditional merge / bypass governance** | Authority is conditional by definition | Registration `notes` |
+| 6 | **Write to the canonical Dharma directory or the repo** | Workspace is sandboxed to `~/.dharma/external_agents/merge_master_mike` | Registration `workspace_policy.repo_writes_allowed: false` |
+| 7 | **Run without explicit task assignment** | Prevents autonomous-merge loops | Registration `explicit_task_assignment_required: true` |
+
+---
+
+## What the operator retains exclusively (above MMM)
+
+These cannot be delegated to MMM or any other agent:
+
+- **Doctrine changes** — axioms A1–A8, the cohere doctrine, the no-second-writer rule, the merge-authority rule itself.
+- **Spine-adoption metric definition changes** (`tools/spine_adoption_metric.py` semantic edits).
+- **Authorizing new automation lanes that create PRs** — extending [`PR_QUALITY_GATES.md`](PR_QUALITY_GATES.md) § 2 lane table.
+- **Amendments to this charter.**
+- **MMM agent registration changes** — edits to `examples/agents/merge_master_mike.registration.json` (capabilities, autonomy policy, authority class).
+- **Required-reviewer quorum policy** — what counts as a satisfied quorum.
+
+---
+
+## The merge protocol (governance view)
+
+The operational protocol is in `PR_REVIEW_CONTROL.md`. The governance contract is:
+
+1. **Author opens PR in draft.** CI runs to completion. Author owns the four [Coherence Delta](COHERENCE_DELTA.md) fields in the PR body.
+2. **Author un-drafts when `mergeStateStatus: CLEAN`** and posts a readiness comment summarising what the PR does, live metric deltas, and which doctrine axioms were checked. *(See PR #514, #542, #543 for canonical readiness-comment shape.)*
+3. **MMM is invoked with an explicit task assignment** (`make pr-mike` or operator NATS message). It does not act on un-invited PRs.
+4. **MMM evaluates the gate:**
+   - CI truth contract: all required entries green per `CI_TRUTH_CONTRACT.json`.
+   - Required reviewers: quorum satisfied per `make pr-reviewers`.
+   - Surface scope matches stated intent (no scope creep in the diff).
+   - No second-writer violations (Axiom A2).
+   - No doctrine drift not named in the PR body.
+5. **MMM merges** *(via `make pr-merge PR=N ARGS="--confirm merge-pr-N"`)* — **or** posts the specific blocker and leaves the PR open.
+6. **MMM updates the relevant track issue** with merge SHA and live metric delta.
+
+If any gate condition is unclear or any boundary is approached, MMM **escalates to the operator** and does not merge.
+
+---
+
+## Failure modes this charter prevents
+
+| Failure mode | What this charter does about it |
+|---|---|
+| An agent infers merge authority because nothing tells it otherwise | MMM is the **only** agent with conditional merge authority, named here and in the registration |
+| Two agents race to merge overlapping PRs | MMM owns ordering; other agents are forbidden from merging |
+| MMM auto-merges a green PR that violates Axiom A2 | CI is necessary but not sufficient; MMM verifies A2 as a charter requirement |
+| MMM merges without reviewer quorum | Registration `requires_clean_merge_gate: true` + `PR_REVIEW_CONTROL.md` gate logic |
+| A "successor" PR lands while three predecessor dupes stay open | MMM closure of duplicates is named (authority #4) |
+| Doctrine drifts silently via a small PR | MMM verifies "no doctrine drift not named in the PR body" |
+| MMM's capabilities are quietly expanded via a registration edit | Operator-exclusive control over the registration is named above |
+| A new conditional-merge agent is added without governance | Operator-exclusive control over authority-class assignments is implicit; future amendment may name it explicitly |
+
+---
+
+## Exit criteria for the MMM declaration track ([#541](https://github.com/AmitabhainArunachala/dharma_swarm/issues/541))
+
+- [x] `docs/governance/MMM_CHARTER.md` exists with authority surface, boundaries, operator-exclusive scope, protocol, failure modes. *(this file)*
+- [ ] `docs/governance/PR_QUALITY_GATES.md` references this charter in a § MMM Merge Protocol pointer.
+- [ ] `docs/governance/SOVEREIGN_MANIFEST.md` registers MMM in the governance domain section.
+- [ ] `docs/governance/CANONICAL_DOC_STACK.md` registers MMM_CHARTER.md ownership row.
+- [ ] At least one PR (post-#514) is merged end-to-end under this protocol — captured as the canonical example. Candidates: #542 (tollbooth), #543 (PROD-8 throttle).
+
+---
+
+## Relationship to existing docs
+
+| Doc | What it owns | What this charter adds |
+|---|---|---|
+| `docs/ops/PR_REVIEW_CONTROL.md` | Commands, packet shape, gate logic, CI-truth coupling, GitHub adapter | Nothing — this charter defers to it |
+| `examples/agents/merge_master_mike.registration.json` | Agent identity, capabilities, autonomy policy, workspace policy | Nothing — this charter defers to it |
+| `docs/governance/CI_TRUTH_CONTRACT.json` | What CI evidence counts as green | Nothing — this charter defers to it |
+| `docs/governance/PR_QUALITY_GATES.md` | CI gates MMM respects | Pointer back to this charter (planned) |
+| `docs/governance/SOVEREIGN_MANIFEST.md` | Architectural roles | MMM role row in governance domain (planned) |
+| `docs/governance/CANONICAL_DOC_STACK.md` | Doc ownership map | Row for `MMM authority charter → MMM_CHARTER.md` (planned) |
+
+---
+
+## Amendments
+
+Amendments to this charter are operator-only PRs. They cite the failure mode the amendment is responding to. They are reviewed at least 24 hours before merge.

--- a/docs/governance/PR_QUALITY_GATES.md
+++ b/docs/governance/PR_QUALITY_GATES.md
@@ -64,6 +64,17 @@ Practical consequence for authors and reviewers:
 
 ---
 
+## MMM Merge Protocol (pointer)
+
+The merge authority charter for **Merge Master Mike** (conditional-merge
+coordinator) is [`MMM_CHARTER.md`](MMM_CHARTER.md). Operational commands and
+the gate logic MMM uses to evaluate whether a PR is mergeable live in
+[`../ops/PR_REVIEW_CONTROL.md`](../ops/PR_REVIEW_CONTROL.md). Every gate in
+this document is a precondition MMM checks; none of them are sufficient on
+their own.
+
+---
+
 ## 2. Bot PR Proliferation Control
 
 ### Rule: Max open PRs per bot author

--- a/docs/governance/SOVEREIGN_MANIFEST.md
+++ b/docs/governance/SOVEREIGN_MANIFEST.md
@@ -160,8 +160,8 @@ These are the ground-truth metrics. All other documents citing different numbers
 | Test functions | **11,091 `def test_` occurrences under tests/** | rg "def test_" tests |
 | Tests collected (pytest) | **Needs write-permitted refresh** | not run during this DocOps count pass |
 | Collection errors | **Historical: 16 on 2026-04-04** | refresh before relying on this count |
-| Markdown files | **870** | find . -name "*.md" -type f |
-| Markdown total lines | **216,421** | wc -l across all .md |
+| Markdown files | **871** | find . -name "*.md" -type f |
+| Markdown total lines | **216,579** | wc -l across all .md |
 | Bridge files | **24** | find dharma_swarm -name "*bridge*.py" |
 | Adapter files | **21 across 8 locations** | find dharma_swarm -type f \| rg -i "adapter" |
 | Orchestrator files | **4** (6,034 LOC total) | find dharma_swarm -name "*orchestrat*" |

--- a/docs/governance/SOVEREIGN_MANIFEST.md
+++ b/docs/governance/SOVEREIGN_MANIFEST.md
@@ -209,6 +209,7 @@ These are the ground-truth metrics. All other documents citing different numbers
   - FORBIDDEN: Must NOT import from Runtime, Intelligence, or Evolution domains
 - **Boundary Status**: **PASS** (V) -- no violations found
 - **Notes for Agents**: `dharma_kernel.py` is SHA-256 signed. Do not modify. Gates are added via `GateRegistry.propose()`, not by editing `telos_gates.py` directly. Parent `~/CLAUDE.md` says "10 axioms" -- this is WRONG; actual count is 25.
+- **Named operator role (merge authority)**: **Merge Master Mike (MMM)** is the registered conditional-merge coordinator agent for this domain. Charter: [`MMM_CHARTER.md`](MMM_CHARTER.md). Operational manual: [`../ops/PR_REVIEW_CONTROL.md`](../ops/PR_REVIEW_CONTROL.md). Registration: [`../../examples/agents/merge_master_mike.registration.json`](../../examples/agents/merge_master_mike.registration.json).
 
 ### Domain 3: Runtime Core (S1 Operations + S2 Coordination)
 


### PR DESCRIPTION
**Closes part of #541** (the MMM declaration track).

Names **Merge Master Mike (MMM)** as the constitutional merge-authority role for the governance domain. MMM has existed since 2026-06-01 as a registered conditional-merge agent ([`examples/agents/merge_master_mike.registration.json`](https://github.com/AmitabhainArunachala/dharma_swarm/blob/main/examples/agents/merge_master_mike.registration.json)) with operational behavior fully described in [`docs/ops/PR_REVIEW_CONTROL.md`](https://github.com/AmitabhainArunachala/dharma_swarm/blob/main/docs/ops/PR_REVIEW_CONTROL.md). What was missing was the governance-tier charter.

This is the missing **A3 (no undocumented seams)** closure for the merge-authority surface — the last A3 thread named in `RUNTIME_TRUTH_SPINE_HANDOFF.md`.

## What the charter adds (and doesn't add)

✅ **Adds:**
- Constitutional naming of the role with authority surface (6 items).
- Explicit boundaries (7 items MMM may never do, regardless of how clean the gate is).
- Operator-exclusive scope above MMM (6 items including registration edits).
- Failure-mode capture (8 modes the role prevents).
- Cross-references via `CANONICAL_DOC_STACK.md`, `PR_QUALITY_GATES.md`, and `SOVEREIGN_MANIFEST.md` so the role surfaces in all three doctrine entry points.

❌ **Does NOT change:** MMM's capabilities, autonomy policy, commands, packet shape, CI integration, or workspace policy. Those live in the registration manifest and ops manual and remain authoritative. The charter defers explicitly.

## File-by-file

| File | Change | Why |
|---|---|---|
| `docs/governance/MMM_CHARTER.md` | NEW (146 lines) | The charter itself |
| `docs/governance/CANONICAL_DOC_STACK.md` | +1 row | Register MMM_CHARTER ownership |
| `docs/governance/PR_QUALITY_GATES.md` | +pointer block | Point readers to the charter and ops manual |
| `docs/governance/SOVEREIGN_MANIFEST.md` | +1 named-role line in Domain 2 (Governance); count refresh (markdown_files 861→862, lines 213,225→213,383) | Register MMM in the architectural domain map; close the docops drift my own diff would otherwise introduce |
| `docs/docops/assertions.yaml` | +1 line (canonical_guard registration) | The charter contains "canonical" and "source of truth" — required by the same gate that's blocking #520 |
| `docs/docops/AUTO_INVENTORY.md` | auto-section refresh | Same docops counts |

## Validation

Ran locally before push:

```
$ python3 scripts/docops/check_docops_integrity.py
...
DocOps integrity checks passed
```

So **the docops-integrity check that's currently blocking #520 should land green on this PR on first try**. The canonical-guard, count-assertions, auto-section, and path-link checks are all clean.

## Coherence Delta

- **Organ touched:** governance / docs (new MMM_CHARTER.md + cross-reference rows in CANONICAL_DOC_STACK, PR_QUALITY_GATES, SOVEREIGN_MANIFEST; canonical-guard registration in docs/docops/assertions.yaml; auto-section refresh).
- **Declared-vs-actual gap closed:** Merge-authority role existed in agent registration (since 2026-06-01) and in ops manual but was undeclared in `governance/`. A3 says "no undocumented seams"; this seam is now documented.
- **Proof that re-reads the map:** Charter explicitly defers to the ops manual and registration for the how-and-what, then names the why-and-who-decides. Ownership map in CANONICAL_DOC_STACK now points to it. DocOps integrity passes clean.
- **New drift introduced:** None. No new agent. No new capability. No new command. No new CI gate. Same authority surface, now named in `governance/`.

## Doctrine check

- ✅ A2 (no second writer): no new artifact creates state
- ✅ A3 (no undocumented seams): closes the seam
- ✅ A6 (one source of truth): charter defers to registration + ops manual rather than re-stating
- ✅ No ontology / runtime / kernel touch
- ✅ No autonomous merge (MMM owns it — see this very charter)

## Companion PRs in this clean/tighten/cohere pass

- #542 — tollbooth → joined (slice 1 of #539, smallest spine-tail surface)
- #543 — PROD-8 throttle fix (closes #533)

Per the charter being declared here, **MMM owns the merge** of all three. Operator approves the gate via reviewer quorum.

---

This PR is itself a perfect test case for the protocol it declares: docs-only, scoped to one organ (governance), four-field Coherence Delta filled in, named axioms checked, no scope creep in the diff, no doctrine drift not named in the body. If MMM can merge this clean, the protocol works.
