### PR TITLE
chore(governance): refresh spine adoption metric [automated]

### DIFF
--- a/reports/governance/spine_adoption_metric.json
+++ b/reports/governance/spine_adoption_metric.json
@@ -1,5 +1,5 @@
 {
-  "audit_sha": "4b86b8aef52f8df90707e0dbc13efa4b0f2f9ded",
+  "audit_sha": "9362e4efe24278c95ebe9b5a6c50775385acd67c",
   "classification_rule": "joined requires all joined evidence patterns; adapter-ready requires all adapter evidence patterns when joined is incomplete; quarantine and legacy require explicit source markers; missing means no tracked surface or insufficient evidence.",
   "classification_vocabulary": [
     "joined",
@@ -1776,5 +1776,5 @@
       "status": "legacy"
     }
   ],
-  "tracked_file_count": 2924
+  "tracked_file_count": 2925
 }


### PR DESCRIPTION
## Spine Adoption Metric Refresh

Automated governance report: refreshed `reports/governance/spine_adoption_metric.json` with the latest snapshot.

### Summary

| Field | Value |
|-------|-------|
| **adoption_pct** | **93.8%** (target: 95%) |
| joined_count | 11 / 16 |
| adapter_ready_count | 4 |
| missing_count | 0 |
| quarantine_count | 0 |
| legacy_count | 1 |
| tracked_file_count | 2925 (was 2924) |

### What changed
- `audit_sha` updated to `9362e4efe24278c95ebe9b5a6c50775385acd67c`
- `tracked_file_count`: 2924 → 2925
- Adoption percentage unchanged at **93.8%**

### Top saturation targets (remaining 1.2pp gap to 95%)
1. `ontology_action_tollbooth` (ontology.py) — missing: `RuntimeStateStore` import
2. `tool_registry_dispatch` (tool_registry.py) — missing: `try_begin_idempotent_side_effect`
3. `self_modification_loop` (diff_applier.py) — missing: `try_begin_idempotent_side_effect`
4. `mcp_tool_access` (mcp_server.py, dharma_context_mcp.py) — missing all 3 spine patterns

> **Note:** PR #552 (`chore/governance-spine-adoption-metric-refresh`) covers the same metric update with older data (tracked_file_count: 2924). This PR supersedes it — operator may close #552.

---
_Conversation: https://app.warp.dev/conversation/ebb9c238-5b2f-4f26-9c9e-8154227b311b_
_Run: https://oz.warp.dev/runs/019ea487-7960-7ca0-a92c-671cc7b65ce6_
_This PR was generated with [Oz](https://warp.dev/oz)._
