### PR TITLE
chore(governance): refresh spine adoption metric [automated]

### DIFF
--- a/reports/governance/spine_adoption_metric.json
+++ b/reports/governance/spine_adoption_metric.json
@@ -1,5 +1,5 @@
 {
-  "audit_sha": "4b86b8aef52f8df90707e0dbc13efa4b0f2f9ded",
+  "audit_sha": "9362e4efe24278c95ebe9b5a6c50775385acd67c",
   "classification_rule": "joined requires all joined evidence patterns; adapter-ready requires all adapter evidence patterns when joined is incomplete; quarantine and legacy require explicit source markers; missing means no tracked surface or insufficient evidence.",
   "classification_vocabulary": [
     "joined",
@@ -1776,5 +1776,5 @@
       "status": "legacy"
     }
   ],
-  "tracked_file_count": 2924
+  "tracked_file_count": 2925
 }


### PR DESCRIPTION
## chore(governance): refresh spine adoption metric [automated]

Updates `reports/governance/spine_adoption_metric.json` with the latest spine adoption snapshot:

- `audit_sha`: refreshed to `9362e4efe24278c95ebe9b5a6c50775385acd67c`
- `tracked_file_count`: 2924 → 2925 (+1 new tracked file)
- All surface statuses and `adoption_pct` (93.8%) unchanged

---

_Conversation: https://app.warp.dev/conversation/4f2d5054-88b4-47cc-b493-2e37f2864921_
_Run: https://oz.warp.dev/runs/019ea71a-a792-7b82-9d49-74048c3a2792_
_This PR was generated with [Oz](https://warp.dev/oz)._
