### PR TITLE
evolution: single-writer flock on archive.py append (WS2)

### DIFF
--- a/dharma_swarm/archive.py
+++ b/dharma_swarm/archive.py
@@ -326,12 +326,32 @@ class EvolutionArchive:
                     continue
 
     async def _append_line(self, entry: ArchiveEntry) -> None:
-        """Append a single JSONL line to the archive file."""
-        import aiofiles
+        """Append a single JSONL line to the archive file.
+
+        Uses an exclusive OS advisory lock (fcntl.flock LOCK_EX) so concurrent
+        writers across processes — e.g. a DGM evolution run and the live
+        orchestrate-live daemon — cannot interleave and corrupt the JSONL.
+        asyncio/in-process locks do not protect across processes; flock does.
+        (WS2 single-writer hardening, 2026-06-09.)
+        """
+        import asyncio
+        import fcntl
+        import os
 
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        async with aiofiles.open(self.path, "a") as f:
-            await f.write(entry.model_dump_json() + "\n")
+        line = entry.model_dump_json() + "\n"
+
+        def _locked_append() -> None:
+            with open(self.path, "a", encoding="utf-8") as f:
+                fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+                try:
+                    f.write(line)
+                    f.flush()
+                    os.fsync(f.fileno())
+                finally:
+                    fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+
+        await asyncio.to_thread(_locked_append)
 
     async def _rewrite(self) -> None:
         """Rewrite the full archive (needed after in-place mutations)."""

--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -8,7 +8,7 @@ Do not hand-edit the generated block.
 |---|---:|
 | Dharma Python modules | 674 |
 | Top-level Dharma Python modules | 391 |
-| Dharma Python LOC | 285,830 |
+| Dharma Python LOC | 285,850 |
 | Test files | 646 |
 | Test function occurrences | 11,091 |
 | Markdown files | 870 |


### PR DESCRIPTION
evolution: single-writer flock on archive.py append (WS2)

The evolution archive (~/.dharma/evolution/archive.jsonl) is written by
both DGM evolution runs and the live orchestrate-live daemon. _append_line
used an unlocked aiofiles append, so concurrent cross-process writers could
interleave and corrupt the JSONL (prior audit observed a daemon PID racing
the archive with no lock).

Fix: _append_line now does an exclusive OS advisory lock (fcntl.flock LOCK_EX)
around the append (+flush+fsync), via asyncio.to_thread so the event loop is
not blocked. asyncio/in-process locks cannot protect across processes; flock
can. This is a prerequisite for safely running the DGM loop alongside the
daemon (the evolution-loop-closure work-stream WS2).

Verified: 8-process x 60-write contention -> 480/480 valid JSON lines, 0
corrupt; real EvolutionArchive.add_entry still round-trips a single entry.

## Coherence Delta
- Organ touched: `dharma_swarm/archive.py` (EvolutionArchive append path; evolution/DGM layer).
- Declared-vs-actual gap closed: the evolution archive had no cross-process write lock; concurrent DGM + orchestrate-live writers could corrupt archive.jsonl. Now serialized via fcntl.flock.
- Proof that re-reads the map: verified against the DGM-loop ground-truth (archive.jsonl single-writer race, prior audit PID-2031); prerequisite WS2 for the evolution-loop-closure plan (~/.claude/plans/longrun-fix-evolution-loop-2026-06-09.md).
- New drift introduced: none — additive locking on the existing append; verified 480/480 no-corruption + add_entry round-trip. Also regenerated docops AUTO_INVENTORY auto-section (pre-existing main drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)