### PR TITLE
spine: route orchestrator dispatch through invoke_agent behind default-OFF flag (WS3)

### DIFF
--- a/dharma_swarm/orchestrator.py
+++ b/dharma_swarm/orchestrator.py
@@ -2161,6 +2161,80 @@ class Orchestrator:
 
         logger.info("Dispatched task %s -> agent %s", td.task_id, td.agent_id)
 
+    async def _run_task_via_spine(
+        self, runner: Any, task: Task, td: TaskDispatch, timeout_seconds: float
+    ) -> Any:
+        """WS3: execute ``runner.run_task(task)`` through the spine's one blessed
+        path (``invoke_agent``), emitting exactly one ``EvidenceReceipt`` per
+        dispatch. Mirrors ``a2a_bridge.submit_via_spine``: the real execution
+        runs inside the invoker, the result is captured for downstream use, and
+        any exception is re-raised so the caller's timeout/failure handling is
+        unchanged. Gated by ``DHARMA_SPINE_DISPATCH=1`` (default OFF)."""
+        from datetime import datetime, timezone
+        from dharma_swarm.spine.invoke import invoke_agent
+        from dharma_swarm.spine.receipt import EvidenceReceipt
+        from dharma_swarm.spine.routing import RoutingDecision
+
+        ident = td.metadata.get("execution_identity")
+        ident = ident if isinstance(ident, dict) else {}
+        routing = RoutingDecision(
+            agent_id=td.agent_id,
+            reason=f"orchestrator dispatch: {getattr(td.topology, 'value', 'dispatch')}",
+            router_name="orchestrator_dispatch",
+            context_id=str(ident.get("session_id", "") or ""),
+            task_id=td.task_id,
+        )
+        started = datetime.now(timezone.utc)
+        captured: dict[str, Any] = {}
+
+        async def _orch_invoker(
+            task: dict[str, Any], agent_id: str, context_id: str, routing: RoutingDecision
+        ) -> EvidenceReceipt:
+            status, err_source, err_detail = "ok", "none", None
+            try:
+                captured["result"] = await asyncio.wait_for(
+                    runner.run_task(captured["_task_obj"]), timeout=timeout_seconds
+                )
+            except asyncio.TimeoutError as exc:
+                captured["exc"] = exc
+                status, err_source, err_detail = "timeout", "timeout", "run_task timed out"
+            except Exception as exc:  # noqa: BLE001 — re-raised below; receipt records it
+                captured["exc"] = exc
+                status, err_source, err_detail = "failed", "internal_error", str(exc)
+            finished = datetime.now(timezone.utc)
+            return EvidenceReceipt(
+                trace_id=str(ident.get("trace_id", "") or ""),
+                context_id=context_id,
+                task_id=td.task_id,
+                agent_id=agent_id,
+                provider="orchestrator",
+                operation="invoke_agent",
+                provider_attempted=True,
+                status=status,
+                error_source=err_source,
+                error_detail=err_detail,
+                started_at=started,
+                finished_at=finished,
+                latency_ms=int((finished - started).total_seconds() * 1000),
+                routing_decision_id=routing.decision_id,
+                attributes={"router": "orchestrator_dispatch"},
+            )
+
+        captured["_task_obj"] = task
+        receipt = await invoke_agent(
+            task={"id": td.task_id, "agent_id": td.agent_id},
+            agent_id=td.agent_id,
+            context_id=routing.context_id,
+            routing=routing,
+            invoker=_orch_invoker,
+        )
+        # Observable for the verifier + downstream truth packets (no new store).
+        self._last_evidence_receipt = receipt
+        td.metadata["evidence_receipt_id"] = str(receipt.receipt_id)
+        if "exc" in captured:
+            raise captured["exc"]
+        return captured["result"]
+
     async def _execute_task(self, runner: Any, task: Task, td: TaskDispatch) -> None:
         """Run agent.run_task() in background, update board on completion/failure."""
         # Yield immediately so the dispatching coroutine can finish its loop
@@ -2209,10 +2283,17 @@ class Orchestrator:
                 task=task,
                 status="running",
             )
-            result = await asyncio.wait_for(
-                runner.run_task(task),
-                timeout=timeout_seconds,
-            )
+            if os.environ.get("DHARMA_SPINE_DISPATCH") == "1":
+                # WS3: route execution through the Runtime Truth Spine's one
+                # blessed path (invoke_agent), emitting exactly one EvidenceReceipt.
+                # Default OFF: when unset, the direct call below is byte-identical
+                # to prior behavior. Preserves timeout + exception semantics.
+                result = await self._run_task_via_spine(runner, task, td, timeout_seconds)
+            else:
+                result = await asyncio.wait_for(
+                    runner.run_task(task),
+                    timeout=timeout_seconds,
+                )
             try:
                 from dharma_swarm.mission_contract import (
                     honors_checkpoint_passed,

--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -8,9 +8,9 @@ Do not hand-edit the generated block.
 |---|---:|
 | Dharma Python modules | 674 |
 | Top-level Dharma Python modules | 391 |
-| Dharma Python LOC | 285,850 |
-| Test files | 646 |
-| Test function occurrences | 11,091 |
+| Dharma Python LOC | 285,931 |
+| Test files | 647 |
+| Test function occurrences | 11,094 |
 | Markdown files | 870 |
 | Markdown total lines | 216,421 |
 | Bridge files | 24 |

--- a/docs/governance/SOVEREIGN_MANIFEST.md
+++ b/docs/governance/SOVEREIGN_MANIFEST.md
@@ -156,8 +156,8 @@ These are the ground-truth metrics. All other documents citing different numbers
 | Total Python modules | **674** | find dharma_swarm -name "*.py" -type f |
 | Top-level (flat) modules | **391 (58.7%)** | find dharma_swarm -maxdepth 1 -name "*.py" -type f |
 | Total Python LOC | **285,830** | wc -l across dharma_swarm Python modules |
-| Test files | **646** | find tests -name "*.py" -type f |
-| Test functions | **11,091 `def test_` occurrences under tests/** | rg "def test_" tests |
+| Test files | **647** | find tests -name "*.py" -type f |
+| Test functions | **11,094 `def test_` occurrences under tests/** | rg "def test_" tests |
 | Tests collected (pytest) | **Needs write-permitted refresh** | not run during this DocOps count pass |
 | Collection errors | **Historical: 16 on 2026-04-04** | refresh before relying on this count |
 | Markdown files | **870** | find . -name "*.md" -type f |

--- a/tests/test_orchestrator_spine_dispatch.py
+++ b/tests/test_orchestrator_spine_dispatch.py
@@ -1,0 +1,88 @@
+"""WS3 verifier: orchestrator dispatch routes execution through the spine's
+invoke_agent path, emitting exactly one EvidenceReceipt per dispatch, while
+preserving run_task's result (success) and exception (failure) semantics.
+
+Tests _run_task_via_spine in isolation (unbound method on a stub self) so we
+don't need to stand up the full Orchestrator + pool + bus.
+"""
+from __future__ import annotations
+
+import asyncio
+import types
+
+from dharma_swarm.orchestrator import Orchestrator
+from dharma_swarm.spine.receipt import EvidenceReceipt
+
+
+def _stub_self():
+    return types.SimpleNamespace()
+
+
+def _stub_td(agent="agent-1", task_id="t-123"):
+    return types.SimpleNamespace(
+        agent_id=agent,
+        task_id=task_id,
+        metadata={"execution_identity": {"trace_id": "trace-xyz", "session_id": "sess-1"}},
+        topology=types.SimpleNamespace(value="dispatch"),
+    )
+
+
+def test_spine_dispatch_success_emits_one_receipt_and_returns_result():
+    calls = {"n": 0}
+
+    class Runner:
+        async def run_task(self, task):
+            calls["n"] += 1
+            return "RUN_RESULT"
+
+    me = _stub_self()
+    td = _stub_td()
+    result = asyncio.run(
+        Orchestrator._run_task_via_spine(me, Runner(), object(), td, 5.0)
+    )
+    assert result == "RUN_RESULT"
+    assert calls["n"] == 1, "run_task must be invoked exactly once"
+    receipt = me._last_evidence_receipt
+    assert isinstance(receipt, EvidenceReceipt)
+    assert receipt.operation == "invoke_agent"
+    assert receipt.status == "ok"
+    assert receipt.agent_id == "agent-1"
+    assert receipt.task_id == "t-123"
+    assert receipt.trace_id == "trace-xyz"
+    assert td.metadata["evidence_receipt_id"] == str(receipt.receipt_id)
+
+
+def test_spine_dispatch_failure_reraises_and_records_failed_receipt():
+    class BoomRunner:
+        async def run_task(self, task):
+            raise RuntimeError("boom")
+
+    me = _stub_self()
+    td = _stub_td(task_id="t-fail")
+    raised = None
+    try:
+        asyncio.run(Orchestrator._run_task_via_spine(me, BoomRunner(), object(), td, 5.0))
+    except RuntimeError as exc:
+        raised = exc
+    assert raised is not None and str(raised) == "boom", "exception must propagate to caller"
+    receipt = me._last_evidence_receipt
+    assert isinstance(receipt, EvidenceReceipt)
+    assert receipt.status == "failed"
+    assert receipt.error_source == "internal_error"
+
+
+def test_spine_dispatch_timeout_reraises_and_records_timeout_receipt():
+    class SlowRunner:
+        async def run_task(self, task):
+            await asyncio.sleep(1.0)
+            return "late"
+
+    me = _stub_self()
+    td = _stub_td(task_id="t-slow")
+    raised = False
+    try:
+        asyncio.run(Orchestrator._run_task_via_spine(me, SlowRunner(), object(), td, 0.05))
+    except asyncio.TimeoutError:
+        raised = True
+    assert raised, "timeout must propagate"
+    assert me._last_evidence_receipt.status == "timeout"


### PR DESCRIPTION
Adopts the Runtime Truth Spine's blessed `invoke_agent` path for orchestrator dispatch, emitting exactly one EvidenceReceipt per dispatch, behind `DHARMA_SPINE_DISPATCH=1` (**default OFF → lands inert**).

## What
`orchestrator._execute_task`: when the flag is set, `runner.run_task()` is routed through new `_run_task_via_spine` (mirrors `a2a_bridge.submit_via_spine`) — result captured for downstream, one EvidenceReceipt emitted, exceptions re-raised to preserve timeout/failure/board semantics. Flag-OFF path is byte-identical.

## Verification
- `tests/test_orchestrator_spine_dispatch.py` — 3 pass (success→1 receipt+result, failure→re-raise+failed receipt, timeout→re-raise+timeout receipt)
- flag-OFF regression: `test_spine_adoption_dispatch` (8) + `test_orchestrator` (35) green
- **independent dual-audit: SHIP** (flag-OFF byte-identical, no swallowed exc, no KeyError, one-receipt invariant holds, no import cycle, fields valid)

## ⚠️ GATE 1 (do not skip before WS4)
This lands INERT. Before enabling the flag in any runtime, **independently confirm an EvidenceReceipt actually fires on the real `_assign_dispatch` chokepoint at runtime** (not just test-green, not just the a2a_bridge slice). WS4 (gate PEP) builds enforcement on this receipt — it must not be hollow.

## Coherence Delta
- Organ touched: `dharma_swarm/orchestrator.py` (`_execute_task` dispatch; routing/spine layer) + `tests/test_orchestrator_spine_dispatch.py`.
- Declared-vs-actual gap closed: orchestrator dispatch bypassed the spine (`invoke_agent`); now flag-gated onto it → one EvidenceReceipt per dispatch.
- Proof that re-reads the map: grounded in WS3 recon (a2a_bridge reference adapter, invoke_agent/EvidenceReceipt/RoutingDecision contracts) + the evolution-loop plan (~/.claude/plans/longrun-fix-evolution-loop-2026-06-09.md); cross-worktree drift acknowledged (only this checkout patched; default-OFF so siblings can't misbehave).
- New drift introduced: none — default-OFF, byte-identical OFF path, dual-audited SHIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)