### PR TITLE
fix(evolution): honest archive status, real gates_passed, lineage parent_id

### DIFF
--- a/dharma_swarm/archive.py
+++ b/dharma_swarm/archive.py
@@ -132,6 +132,19 @@ class FitnessScore(BaseModel):
         return sum(getattr(self, k, 0.0) * v for k, v in w.items())
 
 
+# Statuses emitted by DarwinEngine.archive_result for evaluated proposals.
+# Rows written before the honest-status change all say "applied"; rows after
+# it say what actually happened. Selection/analytics treat all of these as
+# fitness-bearing so honest recording does not change selection behavior.
+FITNESS_BEARING_STATUSES: tuple[str, ...] = (
+    "applied",
+    "evaluated",
+    "shadow",
+    "gated",
+    "rolled_back",
+)
+
+
 class ArchiveEntry(BaseModel):
     """Single evolution attempt stored in the archive."""
 
@@ -148,6 +161,7 @@ class ArchiveEntry(BaseModel):
 
     # Code changes
     diff: str = ""
+    shadow_diff: str = ""  # diff retained when shadow mode strips `diff`
     commit_hash: Optional[str] = None
 
     # Evaluation
@@ -407,7 +421,9 @@ class EvolutionArchive:
         """Change MAP-Elites granularity and rebuild from current applied entries."""
         self.grid = MAPElitesGrid(n_bins=n_bins)
         applied_entries = [
-            entry for entry in self._entries.values() if entry.status == "applied"
+            entry
+            for entry in self._entries.values()
+            if entry.status in FITNESS_BEARING_STATUSES
         ]
         self.grid.rebuild(applied_entries)
 
@@ -463,7 +479,7 @@ class EvolutionArchive:
         entries = list(self._entries.values())
         if component:
             entries = [e for e in entries if e.component == component]
-        entries = [e for e in entries if e.status == "applied"]
+        entries = [e for e in entries if e.status in FITNESS_BEARING_STATUSES]
         entries.sort(
             key=lambda e: e.fitness.weighted(weights=weights),
             reverse=True,
@@ -533,7 +549,7 @@ class EvolutionArchive:
         entries = list(self._entries.values())
         if len(entries) < min_age_entries:
             return 0
-        applied = [e for e in entries if e.status == "applied"]
+        applied = [e for e in entries if e.status in FITNESS_BEARING_STATUSES]
         if not applied:
             return 0
         fitness_values = sorted(e.fitness.weighted() for e in applied)
@@ -547,7 +563,7 @@ class EvolutionArchive:
         old_entries = entries_by_time[:-min_age_entries] if len(entries_by_time) > min_age_entries else []
         composted = 0
         for e in old_entries:
-            if (e.status in ("applied", "proposed") and e.fitness.weighted() < threshold and e.id not in has_children):
+            if (e.status in FITNESS_BEARING_STATUSES + ("proposed",) and e.fitness.weighted() < threshold and e.id not in has_children):
                 e.status = "composted"
                 composted += 1
         if composted > 0:
@@ -563,7 +579,7 @@ class EvolutionArchive:
         entries = list(self._entries.values())
         if component:
             entries = [e for e in entries if e.component == component]
-        entries = [e for e in entries if e.status == "applied"]
+        entries = [e for e in entries if e.status in FITNESS_BEARING_STATUSES]
         entries.sort(key=lambda e: e.timestamp)
         return [
             (e.timestamp, e.fitness.weighted(weights=weights))
@@ -623,7 +639,7 @@ class EvolutionArchive:
             by_status[e.status] = by_status.get(e.status, 0) + 1
             if e.component:
                 by_component[e.component] = by_component.get(e.component, 0) + 1
-        applied = [e for e in entries if e.status == "applied"]
+        applied = [e for e in entries if e.status in FITNESS_BEARING_STATUSES]
         avg_fitness = (
             sum(e.fitness.weighted() for e in applied) / len(applied)
             if applied

--- a/dharma_swarm/dgm_loop.py
+++ b/dharma_swarm/dgm_loop.py
@@ -390,6 +390,7 @@ class DGMLoop:
                 shadow=self._shadow_mode,
                 timeout=timeout,
                 context=full_context,
+                parent_id=result.parent_id,
             )
 
             result.proposals_submitted = evo_result.proposals_submitted

--- a/dharma_swarm/evolution.py
+++ b/dharma_swarm/evolution.py
@@ -104,6 +104,7 @@ class Proposal(BaseModel):
     requirement_refs: list[str] = Field(default_factory=list)
     think_notes: str = ""
     diff: str = ""
+    shadow_diff: str = ""  # original diff retained when shadow mode strips `diff`
     status: EvolutionStatus = EvolutionStatus.PENDING
     predicted_fitness: float = 0.0
     actual_fitness: Optional[FitnessScore] = None
@@ -1425,6 +1426,19 @@ class DarwinEngine:
 
             proposal.gate_decision = result.decision.value
             proposal.gate_reason = result.reason
+            # Record per-gate verdicts so archive_result can report real
+            # gate outcomes instead of a fabricated "ALL".
+            proposal.metadata = {
+                **(proposal.metadata or {}),
+                "gate_results": {
+                    name: (
+                        getattr(verdict[0], "value", str(verdict[0]))
+                        if isinstance(verdict, (tuple, list)) and verdict
+                        else str(verdict)
+                    )
+                    for name, verdict in result.gate_results.items()
+                },
+            }
             proposal.reflection_attempts = outcome.attempts
             proposal.reflection_suggestions = list(outcome.suggestions)
             if outcome.reflection.strip():
@@ -1708,6 +1722,56 @@ class DarwinEngine:
 
     # -- archiving -----------------------------------------------------------
 
+    @staticmethod
+    def _derive_archive_status(proposal: Proposal) -> str:
+        """Derive an honest archive status from what the proposal records.
+
+        "applied" only when a diff apply actually happened and stuck;
+        "rolled_back" when an apply happened but was reverted;
+        "gated" when the gates blocked it; "shadow" when there was no
+        diff to apply (shadow mode strips diffs); "evaluated" otherwise.
+        """
+        if (
+            proposal.gate_decision == GateDecision.BLOCK.value
+            or proposal.status == EvolutionStatus.REJECTED
+        ):
+            return "gated"
+        if not proposal.diff.strip():
+            return "shadow"
+        rolled_back = proposal.test_results.get("rolled_back")
+        if rolled_back is None:
+            trial = proposal.test_results.get("runtime_field_trial")
+            if isinstance(trial, dict):
+                rolled_back = trial.get("rolled_back")
+        if rolled_back is True:
+            return "rolled_back"
+        if rolled_back is False:
+            return "applied"
+        return "evaluated"
+
+    @staticmethod
+    def _derive_gate_record(proposal: Proposal) -> tuple[list[str], list[str]]:
+        """Derive (gates_passed, gates_failed) from real gate results.
+
+        Uses per-gate verdicts recorded by ``gate_check`` when present;
+        otherwise falls back to the decision label. Never fabricates "ALL".
+        """
+        raw = (proposal.metadata or {}).get("gate_results")
+        if isinstance(raw, dict) and raw:
+            passed: list[str] = []
+            failed: list[str] = []
+            for name, verdict in raw.items():
+                if str(verdict) == GateResult.FAIL.value:
+                    failed.append(name)
+                else:
+                    passed.append(name)
+            return passed, failed
+        if proposal.gate_decision == GateDecision.BLOCK.value:
+            return [], [proposal.gate_reason or "unknown"]
+        if proposal.gate_decision:
+            return [proposal.gate_decision.upper()], []
+        return [], []
+
     async def archive_result(self, proposal: Proposal) -> str:
         """Store an evaluated proposal in the evolution archive.
 
@@ -1751,6 +1815,7 @@ class DarwinEngine:
                 weighted_fitness,
             )
 
+            gates_passed, gates_failed = self._derive_gate_record(proposal)
             entry = ArchiveEntry(
                 component=proposal.component,
                 change_type=proposal.change_type,
@@ -1758,6 +1823,7 @@ class DarwinEngine:
                 spec_ref=proposal.spec_ref,
                 requirement_refs=list(proposal.requirement_refs),
                 diff=proposal.diff,
+                shadow_diff=proposal.shadow_diff,
                 parent_id=proposal.parent_id,
                 fitness=fitness,
                 test_results=test_results,
@@ -1765,17 +1831,9 @@ class DarwinEngine:
                 execution_profile=proposal.execution_profile,
                 evidence_tier=proposal.evidence_tier,
                 promotion_state=proposal.promotion_state,
-                status="applied",
-                gates_passed=(
-                    ["ALL"]
-                    if proposal.gate_decision != GateDecision.BLOCK.value
-                    else []
-                ),
-                gates_failed=(
-                    [proposal.gate_reason or "unknown"]
-                    if proposal.gate_decision == GateDecision.BLOCK.value
-                    else []
-                ),
+                status=self._derive_archive_status(proposal),
+                gates_passed=gates_passed,
+                gates_failed=gates_failed,
             )
 
             # GAIA ecological fitness (non-fatal): blend ecological awareness
@@ -3084,6 +3142,7 @@ class DarwinEngine:
         context: str = "",
         router: Any | None = None,
         shadow: bool = False,
+        parent_id: str | None = None,
         on_progress: Callable[[str, dict[str, Any]], None] | None = None,
     ) -> CycleResult:
         """Autonomous evolution: LLM proposes improvements, engine evaluates them.
@@ -3109,6 +3168,8 @@ class DarwinEngine:
             context: Extra context to guide the LLM (focus areas, recent errors).
             router: Optional ModelRouter for multi-model roster selection.
             shadow: If True, do not apply diffs — evaluate proposals in dry-run mode.
+            parent_id: Optional archive entry id these proposals evolve from
+                (recorded on each proposal so lineage reaches the archive).
             on_progress: Optional callback ``(event_name, data)`` for real-time UX.
 
         Returns:
@@ -3193,10 +3254,15 @@ class DarwinEngine:
             logger.info("No proposals generated — nothing to evolve")
             return CycleResult(proposals_submitted=0)
 
+        if parent_id:
+            for p in proposals:
+                p.parent_id = p.parent_id or parent_id
+
         if shadow:
             # Shadow mode: gate and evaluate without applying diffs
             logger.info("Shadow mode: evaluating %d proposals (no diffs applied)", len(proposals))
             for p in proposals:
+                p.shadow_diff = p.diff  # Retain original diff for the archive
                 p.diff = ""  # Strip diffs so sandbox doesn't apply them
             result = await self.run_cycle(proposals)
         else:

--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -8,7 +8,7 @@ Do not hand-edit the generated block.
 |---|---:|
 | Dharma Python modules | 739 |
 | Top-level Dharma Python modules | 399 |
-| Dharma Python LOC | 305,811 |
+| Dharma Python LOC | 305,894 |
 | Test files | 702 |
 | Test function occurrences | 11,512 |
 | Markdown files | 1,011 |

--- a/tests/test_evolution.py
+++ b/tests/test_evolution.py
@@ -919,7 +919,9 @@ async def test_archive_result_stores_entry(engine):
     stored = await engine.archive.get_entry(entry_id)
     assert stored is not None
     assert stored.component == "module.py"
-    assert stored.status == "applied"
+    # No diff apply ran on this path — honest status is "evaluated",
+    # not "applied" (which is reserved for diffs that actually landed).
+    assert stored.status == "evaluated"
     assert stored.fitness.correctness == pytest.approx(0.8)
     assert stored.promotion_state == "candidate"
     assert stored.evidence_tier == "unvalidated"


### PR DESCRIPTION
## HOT-PATH: operator dual-audit required. Auto-merge OFF.

Touches `evolution.py` (hot path). Do not merge without operator review.

## Defects fixed (each verified on origin/main @ 906833f56 before editing)

### 1. `dharma_swarm/evolution.py:1768` — status hardcoded `"applied"`
Every proposal reaching `archive_result` was recorded as `status="applied"`, including shadow-mode (empty-diff), gated-blocked, rolled-back, and never-applied proposals. `dgm_loop.py:417-418` already expects `'applied'` / `'rolled_back'` statuses that the archive never emitted.

**Fix:** `DarwinEngine._derive_archive_status` — `"gated"` (gate BLOCK / REJECTED), `"shadow"` (no diff to apply), `"rolled_back"` / `"applied"` (from the `rolled_back` marker that `apply_diff_and_test` returns and `evaluate` stores on `proposal.test_results`), `"evaluated"` otherwise (diff present, no apply evidence). Field stays a plain string; existing ~11k rows parse unchanged.

**Read-side compatibility:** `archive.py` filters (`get_best`, `fitness_over_time`, `compact`, `reconfigure_grid`, `stats`) assumed every archived row says `"applied"`. New `FITNESS_BEARING_STATUSES` tuple keeps selection/analytics behavior identical across old and new rows — this PR changes recording honesty, not selection.

### 2. `evolution.py:1769-1773` — `gates_passed=["ALL"]` fabricated
Any non-BLOCK decision recorded the fabricated sentinel `["ALL"]`.

**Fix:** `gate_check` now records the real per-gate verdicts (`GateCheckResult.gate_results`: name → PASS/WARN/FAIL) onto `proposal.metadata["gate_results"]`; `archive_result` derives `gates_passed`/`gates_failed` from them. Fallback when per-gate verdicts are absent: the decision label (e.g. `["REVIEW"]`, `["ALLOW"]`) — never `"ALL"`.

### 3. `dgm_loop.py:387-393` — `auto_evolve(...)` drops `parent_id`
The parent is sampled at :325-330 and `evolution.py` ArchiveEntry already passes `proposal.parent_id` through, but the `auto_evolve` call never carried it, so lineage was 0% (0/11,095 rows with `parent_id`).

**Fix:** `auto_evolve` gains `parent_id: str | None = None` (default-safe for all existing callers), stamps it on generated proposals; `dgm_loop` passes `parent_id=result.parent_id`. The child-lookup in `dgm_loop` (matching `parent_id == result.parent_id`) now actually works.

### 4. `evolution.py:3196-3200` — shadow mode destroys the diff
`p.diff = ""` discarded the proposed change entirely.

**Fix (small additive):** `shadow_diff: str = ""` field added to `Proposal` and `ArchiveEntry` (pydantic defaults — old rows readable); shadow branch retains the original diff in `shadow_diff` before stripping `diff`; `archive_result` passes it through.

## Tests
- `pytest tests/ -k "evolution or dgm or archive" -q` → **477 passed, 1 failed, 3 skipped**. The 1 failure (`test_ginko_evolution.py::TestPromptTournament::test_mutate_prompt_no_api_key`) fails identically on an untouched origin/main checkout (env has API keys set) — pre-existing, unrelated.
- Adjacent consumer suites (`test_review_cycle`, `test_guardian_crew`, `test_telos_gates*`, `test_archive_merkle_integration`, `test_shakti_darwin_integration`) → **157 passed**.
- `tests/test_evolution.py::test_archive_result_stores_entry` updated: it asserted the false history (`status == "applied"` with no apply); now asserts `"evaluated"`.

## Noted, deliberately unchanged (follow-up candidates)
- `evolution.py record_fitness_observation` hardcodes `status="applied"` for lightweight agent-fitness observations (a different site; changing it would alter `get_fitness_trend` semantics).
- `review_cycle.py:56` and `guardian_crew.py:501` filter on literal `"applied"` — after this change they count only real applies, which is the honest reading; guardian's "0 applied" warning becomes a true alarm rather than noise.
- `docs/docops/AUTO_INVENTORY.md` regenerated by the pre-commit docops hook (mechanical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Coherence Delta
- Organ touched: evolution layer (hot path) — `dharma_swarm/evolution.py` (DarwinEngine archive recording: `_derive_archive_status`, gate-verdict capture, shadow_diff retention), `dharma_swarm/dgm_loop.py` (parent_id propagation), `dharma_swarm/archive.py` (FITNESS_BEARING_STATUSES read-side compatibility), plus `tests/test_evolution.py` updates. Layer: evolution/self-improvement (DarwinEngine per CLAUDE.md key abstractions).
- Declared-vs-actual gap closed: none registered — no BR/MM entry covers the archive-status fabrication; all four defects were verified live on origin/main @ 906833f56 before editing (status hardcoded "applied", gates_passed=["ALL"] fabricated, parent_id dropped → 0/11,095 lineage rows, shadow mode destroying diffs). This PR closes the declared-vs-actual gap between what the archive records and what actually happened; no new register entry needed since the fix lands in the same diff.
- Proof that re-reads the map: re-read the consumer surfaces before editing (`dgm_loop.py:417-418` expected statuses; `archive.py` filters `get_best`/`fitness_over_time`/`compact`/`reconfigure_grid`/`stats`; `review_cycle.py:56` and `guardian_crew.py:501` literal-"applied" filters); ran `pytest tests/ -k "evolution or dgm or archive" -q` (477 passed; 1 pre-existing failure reproduced on clean origin/main) plus adjacent consumer suites (157 passed); post-refresh re-ran `tests/test_evolution.py tests/test_evolution_runtime_fields.py` (102 passed) and `scripts/docops/check_docops_integrity.py` (passed).
- New drift introduced: none — archive rows stay plain-string/pydantic-default compatible (~11k existing rows parse unchanged); selection/analytics behavior pinned by FITNESS_BEARING_STATUSES; the two known literal-"applied" consumers are documented above as follow-up candidates, not silent breakage.
