### PR TITLE
chore(governance): refresh spine adoption metric [automated]

### DIFF
--- a/reports/governance/spine_adoption_metric.json
+++ b/reports/governance/spine_adoption_metric.json
@@ -1,5 +1,5 @@
 {
-  "audit_sha": "fc2200758ce608042fe5a68a54a08436b304a483",
+  "audit_sha": "e1b9f839e15a58f980dd54ac1bf8f83119dd2de4",
   "classification_rule": "joined requires all joined evidence patterns; adapter-ready requires all adapter evidence patterns when joined is incomplete; quarantine and legacy require explicit source markers; missing means no tracked surface or insufficient evidence.",
   "classification_vocabulary": [
     "joined",
@@ -11,10 +11,8 @@
   "doc_anchor_status": "ok",
   "metric": "spine_adoption_metric",
   "missing_doc_anchors": [],
-  "source_status": "dirty",
-  "source_status_entries": [
-    " M dharma_swarm/ontology.py"
-  ],
+  "source_status": "clean",
+  "source_status_entries": [],
   "summary": {
     "adapter_ready_count": 3,
     "adoption_pct": 93.8,
@@ -1761,5 +1759,5 @@
       "status": "legacy"
     }
   ],
-  "tracked_file_count": 2924
+  "tracked_file_count": 3022
 }


### PR DESCRIPTION
## chore(governance): refresh spine adoption metric [automated]

**What changed in the JSON:**
| Field | Before | After |
|---|---|---|
| `audit_sha` | `fc2200758c…` | `e1b9f839e1…` |
| `source_status` | `dirty` | `clean` |
| `source_status_entries` | `[" M dharma_swarm/ontology.py"]` | `[]` |
| `tracked_file_count` | 2924 | 3022 |

**Adoption snapshot (2026-06-11):**
- `adoption_pct`: **93.8%** (target 95% — gap: 1.2 pp / 1 surface)
- joined: 12 · adapter-ready: 3 · legacy: 1 · missing: 0 · quarantine: 0

No source-code changes — governance report only.

_Conversation: https://app.warp.dev/conversation/1f359a77-d611-4215-af0b-6d8473a67fbb_
_Run: https://oz.warp.dev/runs/019eb68d-bbbf-7278-bcb4-ade28592c966_
_This PR was generated with [Oz](https://warp.dev/oz)._
