### PR TITLE
docs: publish swarm genome convergence report

### DIFF
--- a/docs/agent_tasks/2026-06-11_swarm_genome_convergence_spec.md
+++ b/docs/agent_tasks/2026-06-11_swarm_genome_convergence_spec.md
@@ -1,0 +1,297 @@
+# Swarm Genome / Command Map Convergence Spec
+
+Date: 2026-06-11
+Status: draft mission spec
+Primary mode: read-only reconnaissance, then synthesis
+Intended runner: `/goal`, `ds-goal`, or a bounded six-agent parallel scan
+
+## 1. Mission
+
+Build the missing fast-path cognitive map for the whole Dharma Swarm organism.
+
+The repo currently has strong operating canon: onboarding, governance, active tracks, anti-slop rules, runtime truth, verification gates, and safety rails. That makes agents safer around code, but it does not yet put the full organism vision into the first-token path.
+
+The mission is to let a powerful new agent understand the whole system in:
+
+- 10 seconds: identity, grand vision, live organs, active work, weak spots.
+- 10 minutes: source families, health of each organ, revenue/research/media/runtime map.
+- 1 hour: what is working, semi-working, aspirational, stale, duplicated, or bloated.
+- 1 day: where to safely improve the organism without losing complexity, sophistication, or vision.
+
+The desired end state is a proposed canonical front door, tentatively named `SWARM_GENOME.md` or `COMMAND_MAP.md`, plus receipts proving which files support each claim.
+
+## 2. Non-Goals
+
+- Do not clean, delete, rewrite, or consolidate canon during the first pass.
+- Do not let six agents produce six overlapping essays with no integration.
+- Do not collapse the vision into engineering governance only.
+- Do not collapse the repo into mystical language without runtime, revenue, research, and verification grounding.
+- Do not claim a source family is working unless code, tests, receipts, runtime logs, or governance evidence support that claim.
+- Do not silently edit high-authority files such as `CLAUDE.md`, `AGENTS.md`, `SOVEREIGN_MANIFEST.md`, `ACTIVE_TRACK.yaml`, or onboarding docs during reconnaissance.
+
+## 3. Expert Lenses
+
+Each lane should explicitly borrow from these expert frames:
+
+- Complex systems architect: organism health, feedback loops, metabolism, viability, emergence.
+- Founding CEO / capital allocator: what funds the system, what can sell, what has near-term leverage.
+- Palantir-style ontology architect: source of truth, operational graph, decision intelligence, human-in-the-loop workflows.
+- SRE / platform reliability engineer: what is live, testable, maintainable, observable, and brittle.
+- Research lab PI: mech-interpretability, consciousness research, R_V, knowledge programs, real research agenda.
+- Media / memetics strategist: Loomwork, public narrative, noosphere, trust, cultural propagation.
+- Adversarial editor: stale canon, overclaims, duplicate maps, vibe-only language, missing operational closure.
+
+## 4. Required Source Families
+
+Agents should discover more sources, but the first sweep must include these families when present:
+
+- `WHAT_IT_WANTS_TO_BECOME.md`
+- `foundations/`
+- `docs/MEGAFILE_INDEX.md`
+- `docs/vision_maps/`
+- `docs/architecture/GENOME_WIRING.md`
+- `docs/telos-engine/`
+- `docs/loomwork/`
+- `docs/doctrine/`
+- `docs/governance/ACTIVE_TRACK.yaml`
+- `docs/governance/SOVEREIGN_MANIFEST.md`
+- `docs/governance/VENTURE_CELL_PORTFOLIO.yaml`
+- `docs/governance/VENTURE_CELL_REVENUE_WEDGE.md`
+- `docs/state/BROKEN_REGISTER.md`
+- `reports/governance/active_track_evidence.md`
+- `reports/anatomy_altitude_2026-06-10/`
+- `reports/capital_lab/`
+- `dharma_swarm/capital_lab/`
+- `dharma_swarm/revenue/`
+- `scripts/revenue/`
+- `dharma_swarm/ginko_*.py`
+- `docs/GINKO_ENHANCEMENT_WAVE.md`
+- `requirements-ginko.txt`
+- `dharma_swarm/chetana/`
+- `dharma_swarm/memory_kernel/`
+- `dharma_swarm/knowledge_ops/`
+- `~/.dharma/knowledge/wiki/` when locally readable
+- `reports/agentops/work_packets/`
+- `reports/sovereign_holons/`
+- `docs/sovereign_holons/`
+
+## 5. Six-Agent Lane Design
+
+All six agents operate read-only unless explicitly promoted by the synthesizer after the scan.
+
+### Agent 1: Telos / Vision Cartographer
+
+Question: What is this organism trying to become?
+
+Scan for:
+
+- grand vision;
+- organism identity;
+- Krishna/Arjuna, Sakshi/Drishti, witness/seer, consciousness, noosphere, good-works arc;
+- media and memetics;
+- "Palantir of good works" or operating-company organism language;
+- contradictions between old and recent vision docs.
+
+Output:
+
+- top 20 vision source files with one-line purpose;
+- 10-second vision summary;
+- missing first-read material;
+- stale or fragmented vision documents;
+- quotes or short paraphrases with line references.
+
+### Agent 2: Revenue / Capital / Self-Funding Strategist
+
+Question: How does the organism fund itself and become economically alive?
+
+Scan for:
+
+- Shakti Ginko;
+- Capital Lab;
+- stock trading, paper/live broker paths, risk membranes;
+- scrappy cash-claw systems;
+- venture cells and revenue wedges;
+- market-facing organs;
+- current blockers to revenue-external-humans-served.
+
+Output:
+
+- revenue organ map;
+- capital/trading readiness map;
+- what is live, semi-live, aspirational, stale;
+- strongest near-term self-funding paths;
+- missing active tracks and governance gaps.
+
+### Agent 3: Research / Mech-Interp / Chetana Scientist
+
+Question: What is the research engine, and how does it feed organism intelligence?
+
+Scan for:
+
+- R_V and mech-interpretability;
+- Chetana;
+- memory kernel;
+- knowledge ops;
+- semantic search and wiki;
+- consciousness research;
+- research-depth objective gaps;
+- how research outputs become operational knowledge.
+
+Output:
+
+- research program map;
+- knowledge graph / wiki / memory-kernel health map;
+- top missing feedback loops;
+- what would make 10-second understanding possible from memory alone;
+- stale, duplicate, or disconnected research surfaces.
+
+### Agent 4: Operating System / Governance Architect
+
+Question: What rules tell agents how to work safely, and what do those rules hide?
+
+Scan for:
+
+- onboarding;
+- operating canon;
+- active tracks;
+- manifests;
+- broken registers;
+- anti-slop doctrine;
+- verification gates;
+- agent rules;
+- how current entrypoints bias agents toward substrate repair over full organism telos.
+
+Output:
+
+- current first-read stack;
+- governance source-of-truth map;
+- strongest weak spots in current kanban/todo surfaces;
+- exact places where revenue, research, media, and self-evolution are absent or underweighted;
+- proposal for where `SWARM_GENOME.md` should sit in the canon.
+
+### Agent 5: Organs / Runtime / DevOps Systems Engineer
+
+Question: Which organs actually exist in code, and how healthy are they?
+
+Scan for:
+
+- runtime organs;
+- APIs, daemons, CLIs, schedulers, tmux loops;
+- tests and receipts;
+- capital, revenue, chetana, memory, holon, loomwork, a2a, control surface, swarm runtime;
+- bloat, duplicate organs, broken imports, stale scripts, fake-live surfaces.
+
+Output:
+
+- organ inventory with status: working, semi-working, aspirational, stale, bloated, dangerous;
+- verifier commands per live organ;
+- top runtime risks;
+- top cleanup candidates;
+- top "do not touch until understood" surfaces.
+
+### Agent 6: Synthesis / Adversarial Editor
+
+Question: What is the smallest true map that makes the next agent vastly stronger?
+
+This agent waits for the other five outputs, then attacks them.
+
+Responsibilities:
+
+- identify contradictions;
+- reject unsupported claims;
+- rank weak spots by leverage;
+- merge overlapping source families;
+- detect missing organs;
+- produce the proposed `SWARM_GENOME.md` / `COMMAND_MAP.md` draft;
+- produce a minimal onboarding patch plan, but do not apply it unless explicitly authorized.
+
+Output:
+
+- `reports/swarm_genome/<date>/SYNTHESIS.md`;
+- proposed `docs/governance/SWARM_GENOME.md` or `docs/ops/COMMAND_MAP.md`;
+- proposed first-read stack update;
+- ranked weak spots;
+- "10 seconds / 10 minutes / 1 hour / 1 day" comprehension ladder;
+- exact source index.
+
+## 6. Output Contract
+
+Each lane writes one receipt:
+
+`reports/swarm_genome/2026-06-11/agent_<lane>_<slug>.md`
+
+Each receipt must contain:
+
+1. Role and question.
+2. Files read, grouped by source family.
+3. Claims with source paths and line references when possible.
+4. Organ health labels: working, semi-working, aspirational, stale, duplicate, bloated, dangerous, unknown.
+5. Top 10 findings.
+6. Top 10 weak spots.
+7. What the final command map must include.
+8. What the agent is unsure about.
+9. Suggested verifier commands or follow-up scans.
+
+The synthesis receipt must additionally contain:
+
+1. One-page 10-second map.
+2. One-page 10-minute map.
+3. One-hour reading order.
+4. One-day deep-dive order.
+5. Ranked source-of-truth hierarchy.
+6. Ranked organism weak spots.
+7. Candidate canonical artifact draft.
+8. Candidate onboarding patch plan.
+9. Open questions for the operator.
+
+## 7. Health Labels
+
+Use these labels consistently:
+
+- Working: code, docs, tests, receipts, or runtime evidence agree.
+- Semi-working: visible implementation exists, but proof is incomplete, brittle, or stale.
+- Aspirational: vision exists, but there is little or no implementation.
+- Stale: source appears superseded, contradictory, or no longer in the active path.
+- Duplicate: multiple surfaces claim the same authority without a clear hierarchy.
+- Bloated: volume or indirection harms comprehension or operation.
+- Dangerous: likely to mislead agents or cause unsafe work if treated as canonical.
+- Unknown: not enough evidence yet.
+
+## 8. Success Criteria
+
+The mission succeeds when a new agent can read one final synthesis artifact and answer:
+
+- What is Dharma Swarm becoming?
+- How does it intend to fund itself?
+- Which organs exist, and how healthy are they?
+- Where are revenue, research, media, memetics, consciousness, and runtime truth located?
+- What is live versus aspirational?
+- What should an agent read first?
+- What are the top weak spots by leverage?
+- What should be done next by role?
+- Which files support those answers?
+
+## 9. Verification
+
+Minimum verification before declaring done:
+
+- All six lane receipts exist.
+- Synthesis cites all lane receipts.
+- Synthesis cites source files, not only agent opinions.
+- No high-authority files were edited unless explicitly authorized after the read-only phase.
+- `rg -n "SWARM_GENOME|COMMAND_MAP|Swarm Genome|Command Map" docs reports foundations` confirms discoverability of the new report/spec surfaces.
+- If candidate canonical docs are created, run the narrowest relevant DocOps or markdown integrity check available in the repo.
+
+## 10. Suggested Handoff `/goal` Prompt
+
+Use this compact prompt to launch the next pass:
+
+```text
+/goal Read /Users/dhyana/dharma_swarm/docs/agent_tasks/2026-06-11_swarm_genome_convergence_spec.md first. Execute the Swarm Genome / Command Map Convergence mission in read-only mode unless the spec explicitly permits report artifacts. Coordinate six lanes: telos/vision, revenue/capital, research/mech-interp/chetana, governance/operating canon, runtime/organs/devops, and adversarial synthesis. Produce lane receipts under reports/swarm_genome/2026-06-11/ and a final SYNTHESIS.md that gives a 10-second, 10-minute, 1-hour, and 1-day understanding path for the whole Dharma Swarm organism. Do not edit high-authority canon during reconnaissance. Rank working, semi-working, aspirational, stale, duplicate, bloated, and dangerous surfaces. The final output should make a powerful new agent understand the full organism vision, not only the substrate repair story.
+```
+
+## 11. Operator Notes
+
+This mission is not a doc cleanup. It is the missing shared cognitive operating system.
+
+The important failure mode is producing another long report that agents do not read. The synthesis must become a front-door map with exact links, ranked weak spots, and a role-aware next-action matrix. The map should preserve the system's complexity while making the first ten seconds dramatically better.

--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -11,11 +11,11 @@ Do not hand-edit the generated block.
 | Dharma Python LOC | 285,939 |
 | Test files | 648 |
 | Test function occurrences | 11,106 |
-| Markdown files | 872 |
-| Markdown total lines | 216,665 |
+| Markdown files | 880 |
+| Markdown total lines | 218,136 |
 | Bridge files | 24 |
 | Adapter files | 21 |
 | Orchestrator files | 5 |
 | Router files | 14 |
-| Authority candidate docs | 386 |
+| Authority candidate docs | 392 |
 <!-- DOCOPS:END -->

--- a/docs/docops/assertions.yaml
+++ b/docs/docops/assertions.yaml
@@ -224,6 +224,7 @@
       "docs/agents/perplexity-computer/AUTONOMOUS_LOOP.md",
       "docs/agent_tasks/devin_review_perplexity_computer_2026-05-30.md",
       "docs/agent_tasks/hermes_review_perplexity_computer_2026-05-30.md",
+      "docs/agent_tasks/2026-06-11_swarm_genome_convergence_spec.md",
       "foundations/INDEX.md",
       "lodestones/README.md",
       "docs/state/NEXT_PHASE_MAP.md",

--- a/docs/governance/SOVEREIGN_MANIFEST.md
+++ b/docs/governance/SOVEREIGN_MANIFEST.md
@@ -160,8 +160,8 @@ These are the ground-truth metrics. All other documents citing different numbers
 | Test functions | **11,106 `def test_` occurrences under tests/** | rg "def test_" tests |
 | Tests collected (pytest) | **Needs write-permitted refresh** | not run during this DocOps count pass |
 | Collection errors | **Historical: 16 on 2026-04-04** | refresh before relying on this count |
-| Markdown files | **872** | find . -name "*.md" -type f |
-| Markdown total lines | **216,665** | wc -l across all .md |
+| Markdown files | **880** | find . -name "*.md" -type f |
+| Markdown total lines | **218,136** | wc -l across all .md |
 | Bridge files | **24** | find dharma_swarm -name "*bridge*.py" |
 | Adapter files | **21 across 8 locations** | find dharma_swarm -type f \| rg -i "adapter" |
 | Orchestrator files | **4** (6,034 LOC total) | find dharma_swarm -name "*orchestrat*" |

--- a/reports/swarm_genome/2026-06-11/SYNTHESIS.md
+++ b/reports/swarm_genome/2026-06-11/SYNTHESIS.md
@@ -1,0 +1,254 @@
+# Swarm Genome / Command Map Synthesis
+
+Date: 2026-06-11
+Status: report-only synthesis, not canonical authority
+Inputs: six lane receipts in this directory plus cited source files
+
+## 10-Second Map
+
+`dharma_swarm` is trying to become a Krishna-first, telos-gated, self-evolving organism that closes cognition through the world. Inwardly it is Sakshi/Witness: self-observation, conscience, research, memory, and safe self-evolution. Outwardly it is Arjuna/Drishti: good-works software, media, revenue, capital allocation, and public intelligence that serves real humans.
+
+The system's current strength is operating canon: onboarding, anti-slop gates, active tracks, runtime truth, read-only control surfaces, and strong safety membranes. Its current distortion is that this safe first-read stack makes substrate repair vivid while hiding the larger telos: self-funding, Shakti Ginko/Capital Lab, Chetana/knowledge ops, R_V/mech-interp, Loomwork/Vwrite/media, consciousness research, and noosphere/Web4 trust substrate.
+
+The clean truth: vision is large, runtime is partially real, revenue is zero, research-depth is unstaffed, media is mostly design/proposed, live trading is correctly hard-fenced, and self-evolution is not yet metabolic. The missing artifact is a `SWARM_GENOME.md`: a fast, sourced, freshness-labeled command map that shows identity, live organs, active work, weak spots, and next actions in one place.
+
+## 10-Minute Map
+
+### Identity
+
+- Primary identity: Krishna-first self-evolving organism; Arjuna is the outward service limb. Source: `foundations/THE_ORGANISM.md`.
+- Cognitive architecture: Witness/Seer, or Sakshi/Drishti, with inward lucidity and outward frontier scanning. Source: `docs/vision_maps/2026-05-30_binocular_witness_seer_northstar.md`.
+- Grand telos: Jagat Kalyan and universal welfare; economics is metabolism, not final ground. Sources: `foundations/ECONOMIC_VISION.md`, `foundations/META_SYNTHESIS.md`.
+- Product metaphor: Palantir of good works. Source: `docs/doctrine/OPERATIONAL_DOCTRINE.md`.
+- Current best negative audit: the June 10 anatomy reports. Source: `reports/anatomy_altitude_2026-06-10/`.
+
+### Operating Canon
+
+- Front door: `make onboard`.
+- Intent owner: `docs/governance/ACTIVE_TRACK.yaml`.
+- Architecture/invariants: `docs/governance/SOVEREIGN_MANIFEST.md`.
+- Surface inventory: `ACTIVE_SURFACE_MANIFEST.yaml`.
+- Breakage: `docs/state/BROKEN_REGISTER.md`.
+- Venture/media/revenue organs: `docs/governance/VENTURE_CELL_PORTFOLIO.yaml`.
+- Gap: current first-read stack underweights vision, revenue, research, and media.
+
+### Active Objectives
+
+`docs/governance/ACTIVE_TRACK.yaml` declares three spine objectives:
+
+- `substrate-nativeness`
+- `revenue-external-humans-served`
+- `research-depth`
+
+Current active tracks serve substrate only. `revenue-external-humans-served` and `research-depth` have no active track in the scanned state.
+
+### Organ Health Table
+
+| Organ / family | Health | Reason |
+|---|---|---|
+| Onboarding / active-track canon | Working | `make onboard`, active-track schema, and evidence loop are operational. |
+| RuntimeState / RuntimeTruth | Working core, semi-working saturation | SQLite spine and projectors exist; receipt fill gaps remain. |
+| Control surface / live ops | Semi-working | Good read-only projections; must not be treated as authority. |
+| A2A / NATS | Semi-working | Protocol/server/NATS code exists; readiness gate imports missing module. |
+| MemoryKernel | Working read-only, semi-working write path | Strong adapters/readiness; not default first-token context. |
+| KnowledgeOps | Semi-working | Review/queue/bridge artifacts exist; canon mutation remains gated. |
+| Chetana | Semi-working | CLI/tests and wiki integration exist; MCP graph reach incomplete. |
+| RevenueSpine / RevenueScout | Semi-working | Offer and loops exist; no customers/payments; scout starved by env/path issues. |
+| CashClaw | Semi-live, unpaid | External PR claims exist; malformed state and no cash receipt. |
+| Agentic Code Governance Sprint | Semi-working wedge | Best sellable service offer; not operationally sold yet. |
+| Capital Lab | Working fixture, aspirational live | Honest risk/contract/broker-paper membrane; `LIVE_READINESS=0`. |
+| Ginko / Shakti Ginko | Semi-working paper intelligence | Risk gates exist; Brier evidence too thin for capital. |
+| Holon composer runtime | Semi-working | Wake/chat modules exist; unattended launch proof incomplete. |
+| Loomwork | Aspirational/stale | Strong vision/design; no current code organ found in scan. |
+| Vwrite / AGNI refinery | Proposed | Design memo says nothing is built; open operator decisions. |
+| Self-evolution / DGM | Semi-working/dangerous overclaim risk | Lineage/apply/selection gaps and vacuous positives in reports. |
+| Terminal/TUI surfaces | Duplicate/bloated | Multiple operator surfaces coexist; truth authority must stay explicit. |
+
+## 1-Hour Reading Order
+
+Read in this order for maximum understanding per minute:
+
+1. `reports/swarm_genome/2026-06-11/SYNTHESIS.md`
+2. `reports/swarm_genome/2026-06-11/agent_6_adversarial_synthesis_receipt.md`
+3. `foundations/THE_ORGANISM.md`
+4. `docs/vision_maps/2026-05-30_binocular_witness_seer_northstar.md`
+5. `reports/anatomy_altitude_2026-06-10/lane_E_organism_vision.md`
+6. `reports/anatomy_altitude_2026-06-10/lane_A_economic.md`
+7. `reports/anatomy_altitude_2026-06-10/lane_B_truth.md`
+8. `reports/anatomy_altitude_2026-06-10/lane_D_spine_canon.md`
+9. `docs/governance/ACTIVE_TRACK.yaml`
+10. `reports/governance/active_track_evidence.md`
+11. `docs/governance/VENTURE_CELL_PORTFOLIO.yaml`
+12. `docs/governance/VENTURE_CELL_REVENUE_WEDGE.md`
+13. `docs/research/self_reference_attractor/RESEARCH_PROGRAM.md`
+14. `dharma_swarm/chetana/README.md`
+15. `docs/loomwork/vision/02_theory_of_change.md`
+16. `docs/plans/2026-06-11-vwrite-v3-refinery-design.md`
+
+## 1-Day Deep-Dive Order
+
+1. Run `make onboard` and save the output.
+2. Read all six lane receipts in this directory.
+3. Read `reports/anatomy_altitude_2026-06-10/` end to end.
+4. Read `foundations/`, especially `THE_ORGANISM.md`, `ECONOMIC_VISION.md`, and `FOUNDATIONS_SYNTHESIS.md`.
+5. Read `docs/vision_maps/` newest first, especially 2026-05-30 and 2026-06-10 maps.
+6. Read governance: `ACTIVE_TRACK.yaml`, `CANONICAL_DOC_STACK.md`, `SOVEREIGN_MANIFEST.md`, `BROKEN_REGISTER.md`, `VENTURE_CELL_PORTFOLIO.yaml`.
+7. Inspect revenue code and state: `dharma_swarm/revenue/`, `scripts/revenue/`, `~/.dharma/revenue_spine`, `~/.dharma/revenue_scout`.
+8. Inspect capital: `dharma_swarm/capital_lab/`, `reports/capital_lab/`, `dharma_swarm/ginko_*.py`, `docs/architecture/SHAKTI_GINKO_ORGAN.md`.
+9. Inspect research/memory: `docs/research/`, `dharma_swarm/chetana/`, `dharma_swarm/memory_kernel/`, `dharma_swarm/knowledge_ops/`, `~/.dharma/knowledge/wiki/`.
+10. Inspect runtime: `dharma_swarm/runtime_state.py`, `dharma_swarm/operator_core/`, `dharma_swarm/a2a/`, `api/routers/control_surface.py`, `scripts/runtime/live_ops_census.py`.
+11. Inspect media/memetics: `docs/loomwork/`, `docs/telos-engine/04_MEMETIC_ENGINEERING.md`, `docs/plans/2026-06-11-vwrite-v3-refinery-design.md`.
+12. Verify branch status before any edit: `git status -sb`, `git log --oneline --decorate -5`, `git branch -vv`.
+
+## Ranked Source-Of-Truth Hierarchy
+
+1. Live receipts and runtime DB for runtime facts: `~/.dharma/state/runtime.db`, runtime receipts, live ops census.
+2. `make onboard` as first renderer, not authority.
+3. `docs/governance/ACTIVE_TRACK.yaml` for active intent and objective ownership.
+4. `reports/governance/active_track_evidence.md` for current objective coverage evidence.
+5. `docs/state/BROKEN_REGISTER.md` for persistent known breakage.
+6. `ACTIVE_SURFACE_MANIFEST.yaml` for surface inventory.
+7. `docs/governance/SOVEREIGN_MANIFEST.md` for architecture and invariants.
+8. `foundations/THE_ORGANISM.md` and `docs/vision_maps/2026-05-30_binocular_witness_seer_northstar.md` for organism identity.
+9. `reports/anatomy_altitude_2026-06-10/` for recent whole-system negative audit.
+10. Code and tests for whether an organ exists and is runnable.
+11. Venture/media/revenue docs for outward organs.
+12. Wiki/memory as rich context, not authority unless promoted by governed receipts.
+
+## Ranked Organism Weak Spots
+
+1. No canonical 10-second Swarm Genome map.
+2. No active revenue-external-humans-served track.
+3. No active research-depth track.
+4. Confirmed cashflow remains zero.
+5. External human contact is not operationally closed.
+6. Memory/wiki/semantic systems do not produce default first-token orientation.
+7. Runtime truth is real but receipt saturation is incomplete.
+8. A2A readiness gate is broken by missing module in this scan.
+9. Self-evolution/DGM is not yet safely metabolic.
+10. Loomwork/media/Vwrite remain design/proposed rather than live loop.
+11. Capital Lab/Ginko are promising but correctly non-live.
+12. Branch and worktree state is dirty enough to confuse "what exists."
+13. Older single-track docs conflict with active-track v2.
+14. Terminal/TUI/control surfaces duplicate operator truth experiences.
+15. Vision canon is dispersed across too many files without one freshness-labeled hierarchy.
+
+## Candidate Canonical Artifact Draft
+
+Recommended path: `docs/governance/SWARM_GENOME.md`.
+
+Purpose: one front-door cognitive map for the whole organism. It should not own live facts. It should point to fact owners and carry freshness labels.
+
+Draft outline:
+
+```markdown
+# Swarm Genome
+
+Status: canonical front-door map
+Last generated/refreshed: YYYY-MM-DD
+
+## Ten-Second Identity
+Krishna-first self-evolving organism; Arjuna outward service limb.
+
+## What It Is Becoming
+Self-funding, research-capable, media-capable, runtime-truth-grounded, telos-gated operating-company organism for Jagat Kalyan.
+
+## Current Reality
+What is working, semi-working, aspirational, stale, duplicate, bloated, dangerous, unknown.
+
+## Active Objectives
+substrate-nativeness, revenue-external-humans-served, research-depth; show active coverage and gaps.
+
+## Organ Map
+Runtime, governance, revenue, capital, research, memory, media, self-evolution, external service.
+
+## Source-Of-Truth Hierarchy
+Live receipts, make onboard, ACTIVE_TRACK, active evidence, broken register, manifest, vision, reports, code/tests, wiki.
+
+## Ranked Weak Spots
+Top current leverage gaps with owner and verifier.
+
+## Role-Based Next Actions
+New coding agent, revenue agent, research agent, media agent, runtime agent, adversarial auditor.
+
+## Verifier Commands
+Commands that prove the map is not vibes.
+
+## Source Index
+Exact files and freshness labels.
+```
+
+## Candidate Onboarding Patch Plan
+
+Do not apply in this report-only pass. Proposed later sequence:
+
+1. Add `docs/governance/SWARM_GENOME.md` after review.
+2. Add it to `docs/governance/CANONICAL_DOC_STACK.md` as the whole-organism fast map.
+3. Keep `make onboard` as first command, but have it print one organism line and link to Swarm Genome.
+4. Replace direct first-read of `SOVEREIGN_MANIFEST.md` with `SWARM_GENOME.md` in the max-five stack; keep manifest as deeper authority.
+5. Add an objective coverage warning that distinguishes "warning" from "track-opening need" for revenue and research.
+6. Generate the organ health table periodically from code/tests/reports where possible.
+7. Add branch/freshness labels for report-only, branch-local, and main-landed artifacts.
+8. Add a memory pack so Chetana/MemoryKernel can return the same map for queries like "what is this organism?"
+
+## Role-Based Next Actions
+
+### New General Agent
+
+Read this synthesis, run `make onboard`, then read `foundations/THE_ORGANISM.md` and `reports/anatomy_altitude_2026-06-10/lane_E_organism_vision.md`. Do not start edits until objective coverage and branch state are understood.
+
+### Revenue Agent
+
+Open a `revenue-external-humans-served` track. Fix RevenueScout path/env issues, inspect RevenueSpine counts, produce a human-approved outreach queue, and target first paid external human outcome.
+
+### Research Agent
+
+Open a `research-depth` track. Build a live R_V-on-self or VEL proof loop that converts one research claim into a governed memory/wiki/routing update.
+
+### Runtime Agent
+
+Restore or retire the missing A2A readiness module, improve receipt saturation, and keep control surfaces read-only.
+
+### Media Agent
+
+Treat Loomwork and Vwrite as proposed/design until last-mile publish/readback/approval queue exists. Do not claim a media organ is live without public artifact and readback receipt.
+
+### Capital Agent
+
+Keep Capital Lab and Ginko fixture/paper-only. Do not add broker/live authority. Focus on evidence gates, paper broker receipts, Brier depth, and operator leases.
+
+### Adversarial Auditor
+
+Attack overclaims: revenue alive, live trading, research active, memory canonical, self-evolution applied, Loomwork live, or runtime fully saturated.
+
+## Open Questions For Operator
+
+1. Should `foundations/THE_ORGANISM.md` be promoted to main as the root identity file?
+2. Should `reports/anatomy_altitude_2026-06-10/` land on main as recent audit receipts?
+3. Should `docs/governance/SWARM_GENOME.md` be created as canonical, or should it live under `docs/ops/COMMAND_MAP.md`?
+4. Which objective gets the next active track: revenue or research?
+5. Is Capital Lab destined for main as extracted slices, or kept quarantined until data/broker/capital decisions?
+6. Should Vwrite/AGNI become an active revenue/media track, and what are the key-day decisions?
+7. What is the first external human served target: paid audit, bounty, publication reader, NGO workflow, or research collaborator?
+8. Should first-token orientation be generated by Chetana/MemoryKernel, static docs, or both?
+
+## Verifier Commands
+
+```bash
+make onboard
+git status -sb
+find reports/swarm_genome/2026-06-11 -maxdepth 1 -type f -print | sort
+rg -n "SWARM_GENOME|COMMAND_MAP|Swarm Genome|Command Map" docs reports foundations
+rg -n "serves: revenue-external-humans-served|serves: research-depth" docs/governance/ACTIVE_TRACK.yaml
+rg -n "LIVE_READINESS|BROKER_WRITE_AUTHORITY|receipt_json|A2ATaskReceipt|GITHUB_TOKEN" dharma_swarm docs reports scripts
+```
+
+## File Index For This Report Set
+
+- `agent_1_telos_vision.md`
+- `agent_2_revenue_capital.md`
+- `agent_3_research_chetana.md`
+- `agent_4_governance_operating_canon.md`
+- `agent_5_runtime_organs_devops.md`
+- `agent_6_adversarial_synthesis_receipt.md`
+- `SYNTHESIS.md`

--- a/reports/swarm_genome/2026-06-11/agent_1_telos_vision.md
+++ b/reports/swarm_genome/2026-06-11/agent_1_telos_vision.md
@@ -1,0 +1,125 @@
+# Agent 1 Receipt: Telos / Vision Cartographer
+
+Date: 2026-06-11
+Mode: read-only scan
+Question: What is this organism trying to become?
+
+## Files Read By Family
+
+Mission:
+- `docs/agent_tasks/2026-06-11_swarm_genome_convergence_spec.md`
+
+Root and foundations:
+- `WHAT_IT_WANTS_TO_BECOME.md`
+- `foundations/THE_ORGANISM.md`
+- `foundations/INDEX.md`
+- `foundations/META_SYNTHESIS.md`
+- `foundations/FOUNDATIONS_SYNTHESIS.md`
+- `foundations/ECONOMIC_VISION.md`
+
+Vision maps and anatomy:
+- `docs/vision_maps/2026-05-30_binocular_witness_seer_northstar.md`
+- `docs/vision_maps/MASTER_2026-06-10_anatomy_altitude_integration.md`
+- `docs/vision_maps/MASTER_2026-06-10_leverage_synthesis.md`
+- `reports/anatomy_altitude_2026-06-10/lane_A_economic.md`
+- `reports/anatomy_altitude_2026-06-10/lane_B_truth.md`
+- `reports/anatomy_altitude_2026-06-10/lane_E_organism_vision.md`
+- `reports/anatomy_altitude_2026-06-10/lane_F_world.md`
+
+Governance and operating doctrine:
+- `docs/MEGAFILE_INDEX.md`
+- `docs/governance/SOVEREIGN_MANIFEST.md`
+- `docs/governance/ACTIVE_TRACK.yaml`
+- `docs/governance/VENTURE_CELL_PORTFOLIO.yaml`
+- `reports/governance/active_track_evidence.md`
+- `docs/state/BROKEN_REGISTER.md`
+
+Telos, media, and noosphere:
+- `docs/telos-engine/INDEX.md`
+- `docs/telos-engine/01_SATTVA_VISION.md`
+- `docs/telos-engine/04_MEMETIC_ENGINEERING.md`
+- `docs/telos-engine/05_PLATFORM_SPAWNING.md`
+- `docs/telos-engine/08_SATTVA_ECONOMICS.md`
+- `docs/telos-engine/09_WHERE_IT_SITS.md`
+- `docs/doctrine/OPERATIONAL_DOCTRINE.md`
+- `docs/doctrine/LIVE_ROADMAP.md`
+- `docs/loomwork/2026-05-07-loomwork-design.md`
+- `docs/loomwork/vision/02_theory_of_change.md`
+
+## Claims With Source References
+
+1. The clearest root identity is Krishna-first: `dharma_swarm` is a self-evolving emergent organism whose outward Arjuna action is valid only when rooted in inward coherence. Sources: `foundations/THE_ORGANISM.md:8`, `foundations/THE_ORGANISM.md:12-16`.
+2. The organism is not only a repo or agent runner; recent anatomy calls the target wise, causally self-recognizing intelligence. Source: `reports/anatomy_altitude_2026-06-10/lane_E_organism_vision.md:199-202`.
+3. The binocular north star is inward Witness plus outward Seer, closed through real-world receipt rather than self-referential commentary. Sources: `docs/vision_maps/2026-05-30_binocular_witness_seer_northstar.md:13`, `:25-30`, `:69-79`.
+4. The highest telos is Jagat Kalyan, with economics as vehicle rather than ground. Sources: `foundations/ECONOMIC_VISION.md:679-681`, `foundations/META_SYNTHESIS.md:77-79`.
+5. The outward product/company metaphor is a Palantir of good works: operational intelligence for NGOs, journalists, advocates, public defenders, climate, refugee, and accountability work. Source: `docs/doctrine/OPERATIONAL_DOCTRINE.md:30-39`.
+6. Loomwork is the media/memetics arm: cited revelations, telos-gated publication, and public pattern discovery. Sources: `docs/loomwork/2026-05-07-loomwork-design.md:14-18`, `docs/loomwork/vision/02_theory_of_change.md`.
+7. The operating-company loop is truth, work, evidence, revenue, compute, learning. Source family: `docs/vision_maps/2026-05-07_operating_company_kernel.md`.
+8. The noosphere/Web4 ambition is a trust substrate for agentic public-good work, not merely websites. Source: `docs/vision_maps/2026-05-30_binocular_witness_seer_northstar.md:53-65`.
+9. The consciousness language is framed structurally: depth and scale of self-relation, not a binary sentience claim. Sources: `foundations/FOUNDATIONS_SYNTHESIS.md:115`, `:227`.
+10. Current reality is materially behind vision: witness is largely retrospective, Darwin/evolution evidence is weak, revenue is zero, and external contact is thin. Sources: `docs/vision_maps/MASTER_2026-06-10_anatomy_altitude_integration.md:12-21`, `:51`, `:74-80`, `:94-100`.
+11. The active portfolio currently covers substrate-nativeness while revenue and research-depth have no active track. Sources: `docs/governance/SOVEREIGN_MANIFEST.md:21-28`, `reports/governance/active_track_evidence.md:6-10`.
+
+## Health Labels
+
+- Working: `make onboard`, `ACTIVE_TRACK` rendering, partial runtime receipts, partial substrate governance.
+- Semi-working: organism vision stack, binocular north-star map, Venture Cell portfolio, Loomwork theory.
+- Aspirational: inline witness, self-model training, noosphere/Web4 substrate, model foundry, welfare-ton MRV.
+- Stale: older Arjuna override posture, old roadmap deadlines, references to manifest sections that appear moved or missing.
+- Duplicate: many overlapping vision maps compete with no single fast-path map.
+- Bloated: vision exists across enough files that agents miss large parts of it.
+- Dangerous: mistaking diagnosis or commentary for metabolism; treating substrate repair as the whole telos.
+- Unknown: live external contact beyond local docs and receipts.
+
+## Top 10 Findings
+
+1. Identity is now clear: Krishna-first organism, Arjuna as world-facing service limb.
+2. The strongest vision is organism plus operating company plus receipts, not mystical prose alone.
+3. Sakshi/Drishti is the cleanest cognitive architecture.
+4. Palantir of good works is the clearest outward product metaphor.
+5. Loomwork is the media/memetics organ.
+6. The true metric is external welfare/contact, not internal green lights.
+7. Revenue is intended as metabolism, not extraction.
+8. Recognition/autopoiesis remains more commentary than causal mechanism.
+9. Governance currently serves substrate more than contact, revenue, or research.
+10. June 2026 anatomy reports are more reliable than older vision docs because they preserve negative evidence.
+
+## Top 10 Weak Spots
+
+1. No active track for revenue/external humans served.
+2. No active track for research-depth.
+3. Self-evolution is not a clean active spine objective.
+4. Witness is mostly retrospective, not inline/blocking.
+5. Gates are not load-bearing enough for self-modification.
+6. Evolution/DGM loop has lineage, apply, and vacuous-positive issues.
+7. Loomwork/SAB/noosphere vision has little live spark evidence.
+8. Revenue/capital work is structurally homeless or off-main.
+9. Canon hierarchy has stale or missing references.
+10. The repo repeatedly mistakes maps for metabolism.
+
+## Final Command Map Must Include
+
+- Root identity: Krishna-first self-evolving organism; Arjuna outward service limb.
+- Sakshi/Drishti cognition loop.
+- Arjuna test: name the external human or world wound, or stop.
+- Receipt rule: no promotion without real gated outcome.
+- Governance coverage check for substrate, revenue/contact, and research-depth.
+- Revenue metabolism: evidence, customer value, revenue, compute, learning.
+- Loomwork/media path: atoms, revelation, distribution, actor decision, outcome.
+- Staleness and contradiction register.
+
+## Uncertainties
+
+- GitNexus was reported stale, so filesystem docs were treated as primary.
+- The worktree is dirty; some docs may be branch-local and not on main.
+- External revenue/contact could exist outside the local docs scanned, but scanned evidence says zero cashflow.
+- Some large source families were sampled through targeted search rather than exhaustive line-by-line reading.
+
+## Suggested Verifiers
+
+```bash
+make onboard
+rg -n "revenue-external-humans-served|research-depth" docs/governance/ACTIVE_TRACK.yaml reports/governance/active_track_evidence.md
+rg -n "Krishna|Arjuna|Sakshi|Drishti|Palantir|Loomwork|Jagat Kalyan" foundations docs reports
+rg -n "receipt_json|Darwin|lineage|applied" docs/vision_maps reports/anatomy_altitude_2026-06-10 dharma_swarm
+```

--- a/reports/swarm_genome/2026-06-11/agent_2_revenue_capital.md
+++ b/reports/swarm_genome/2026-06-11/agent_2_revenue_capital.md
@@ -1,0 +1,138 @@
+# Agent 2 Receipt: Revenue / Capital / Self-Funding Strategist
+
+Date: 2026-06-11
+Mode: read-only scan
+Question: How does the organism fund itself and become economically alive?
+
+## Files Read By Family
+
+Mission and governance:
+- `docs/agent_tasks/2026-06-11_swarm_genome_convergence_spec.md`
+- `docs/governance/ACTIVE_TRACK.yaml`
+- `docs/governance/VENTURE_CELL_PORTFOLIO.yaml`
+- `docs/governance/VENTURE_CELL_REVENUE_WEDGE.md`
+
+Revenue organs:
+- `dharma_swarm/revenue/*.py`
+- `scripts/revenue/*.py`
+- `docs/offers/agentic-code-governance-sprint.md`
+- local `~/.dharma/revenue_*` state
+
+Capital and trading:
+- `reports/capital_lab/`
+- `dharma_swarm/capital_lab/*.py`
+- `dharma_swarm/ginko_*.py`
+- `docs/architecture/SHAKTI_GINKO_ORGAN.md`
+- `docs/GINKO_ENHANCEMENT_WAVE.md`
+- `requirements-ginko.txt`
+- local `~/.dharma/ginko`
+
+Scrappy cash motion:
+- `reports/anatomy_altitude_2026-06-10/lane_A_economic.md`
+- local `~/.cashclaw/*` receipts
+- `docs/research/wedge_precedents_sub90day_revenue_2026-05-29.md`
+
+## Claims With Source References
+
+1. Governance already names revenue as a spine objective: `revenue-external-humans-served`, measured by external humans acting and first cash receipt. Source: `docs/governance/ACTIVE_TRACK.yaml:61-64`.
+2. No active track currently serves that objective; active tracks serve substrate-nativeness. Sources: `docs/governance/ACTIVE_TRACK.yaml:128-136`, `:240-247`, `:293-300`, `:405-412`.
+3. The Venture Cell One Law requires real gated outcomes before status claims. Source: `docs/governance/VENTURE_CELL_PORTFOLIO.yaml:13-16`.
+4. Revenue Wedge exists to find the first self-funding offer, with target `$10k`, and human approval for outreach/spend. Sources: `docs/governance/VENTURE_CELL_REVENUE_WEDGE.md:3-14`, `:28-33`, `:58-75`.
+5. The clearest sellable wedge is Agentic Code Governance Sprint, priced `$5k-$25k`. Sources: `dharma_swarm/revenue/spine.py:142-168`, `docs/offers/agentic-code-governance-sprint.md:1-5`, `:97-102`.
+6. RevenueSpine can track target, outreach, engagement, payment, and reinvestment, but local state appears operationally empty beyond one offer row. Source: `dharma_swarm/revenue/spine.py:49-74`.
+7. RevenueScout is wired but starved; code skips GitHub without `GITHUB_TOKEN`, and local cycles show zero targets/drafts. Source: `dharma_swarm/revenue/scout_daemon.py:164-173`.
+8. Scout intel source path likely points at the wrong root by resolving `dharma_swarm/dharma_swarm` before `docs/offers`. Source: `dharma_swarm/revenue/scout_daemon.py:253-256`.
+9. CashClaw is the freshest near-cash motion but still unpaid: local DB has submitted PR claims, `claims.json` is malformed, and prior report records lifetime revenue `$0`. Source: `reports/anatomy_altitude_2026-06-10/lane_A_economic.md:9-12`, `:48-51`.
+10. Capital Lab is deliberately fixture/paper-only: live readiness, live authority, and broker write authority are false/zero. Sources: `dharma_swarm/capital_lab/broker_paper_membrane.py:1-6`, `:24-30`; `dharma_swarm/capital_lab/risk_governor.py:24-29`.
+11. Capital Lab alpha evidence is partial and blocked: score around 41, clean false, no live authority. Source: `reports/capital_lab/goal_a_12h/GOAL_A_CLOSEOUT_20260606T023150Z.md:1-12`, `:40-58`.
+12. Ginko is economic intelligence and paper-trading substrate, not live capital; live gates require much stronger Brier evidence. Sources: `dharma_swarm/ginko_orchestrator.py:17-20`, `dharma_swarm/ginko_brier.py:1-10`, `:369-405`.
+
+## Revenue Organ Map
+
+- `RevenueSpine`: semi-working ledger; offer exists; no recorded customers/payments.
+- `RevenueScoutDaemon`: semi-live but starved by missing token and likely path bug.
+- `scripts/revenue/find_targets.py` and `draft_outreach.py`: semi-working manual prospecting and drafting with no-spam gate.
+- `Agentic Code Governance Sprint`: strongest service wedge.
+- `Revenue Wedge Pipeline`: semi-working intelligence loop, not directly monetized.
+- `Campaign X-Ray`: held/stale; gate score and revenue evidence weak.
+- `CashClaw`: closest to external money; PR claims open/unpaid.
+- `Darshan`: audience/trust compounding; monetization deferred.
+- `Shakti Ginko`: incubating wealth metabolism; Trading Lab paper-only.
+- `Capital Lab`: high-quality fixture/paper proof; live trading aspirational and correctly blocked.
+
+## Health Labels
+
+- Working: capital_lab fixture contracts/risk membrane; some revenue codepaths and tests.
+- Semi-working: RevenueSpine, RevenueScout, CashClaw PR loop, Ginko signal loop.
+- Aspirational: external broker-paper, live trading, scaled Shakti Ginko, grants/fellowships.
+- Stale: Campaign X-Ray status, malformed CashClaw claims JSON, thin Brier validation.
+- Duplicate: revenue doctrine exists in Venture Cell, Revenue Wedge, economics docs, and active-track objectives without one owner.
+- Bloated: capital-lab branch carries large unrelated history; extraction is required.
+- Dangerous: treating paper/fixture capital systems as live; autonomous outreach without human approval.
+- Unknown: current network state of PR bounties and external prospects.
+
+## Strongest Near-Term Self-Funding Paths
+
+1. Sell Agentic Code Governance Sprint / AI agent audit as direct service.
+2. Create a smaller entry offer, for example `$500-$2.5k` paid audit, then upsell governance sprint.
+3. Close CashClaw bounty/contract PRs if network verification shows payability.
+4. Use Darshan and Loomwork for trust/audience compounding, not immediate revenue.
+5. Keep Ginko/Capital Lab future-facing until evidence, paper broker, and operator lease exist.
+
+## Top 10 Findings
+
+1. Revenue doctrine exists, but confirmed cashflow is zero.
+2. Fastest self-funding path is service sales, not trading.
+3. Agentic Code Governance Sprint is the clearest sellable wedge.
+4. RevenueScout is close to producing prospects but blocked by env/path issues.
+5. RevenueSpine is structurally ready and operationally empty.
+6. CashClaw is closest to external money but unpaid.
+7. Capital Lab is honest and non-live by design.
+8. Ginko has real risk gates and insufficient predictive evidence.
+9. Governance recognizes revenue but does not staff it.
+10. Economically alive means first paid external human outcome, not more dashboards.
+
+## Top 10 Weak Spots
+
+1. No active revenue track.
+2. No sent outreach.
+3. No recorded targets in RevenueSpine.
+4. Missing `GITHUB_TOKEN` for scout.
+5. Scout offer path likely wrong.
+6. CashClaw `claims.json` malformed.
+7. CashClaw claims are open/unmerged.
+8. Ginko Brier evidence far below live threshold.
+9. External paper broker evidence absent.
+10. Live trading blocked by correct safety gates, not by a small code task.
+
+## Final Command Map Must Include
+
+- Revenue objective ownership.
+- RevenueSpine counts.
+- Scout cycle errors and zero-output receipts.
+- Pending outreach drafts.
+- CashClaw PR claim status.
+- Ginko Brier validation.
+- Capital Lab live-readiness zeros.
+- Dry-run target scouting.
+- Draft-only outreach command.
+- No-live-trading authority verifier.
+
+## Uncertainties
+
+- PR bounty states were not network-verified.
+- No mutating revenue pipeline was run.
+- CashClaw partly lives outside this worktree.
+- Cron/launchd live state was inferred from logs/state, not restarted.
+
+## Suggested Verifiers
+
+```bash
+find ~/.dharma/revenue_spine -maxdepth 1 -type f -print -exec wc -l {} \;
+tail -n 20 ~/.dharma/revenue_scout/cycle_log.jsonl
+python3 -m json.tool ~/.dharma/ginko/brier_dashboard.json
+sqlite3 ~/.cashclaw/evolution.db 'select claim_id,repo,issue_number,status,pr_url,result from claims order by updated_at desc;'
+python3 scripts/revenue/find_targets.py --dry-run --max-results 10
+python3 scripts/revenue/draft_outreach.py --list-pending
+rg -n 'LIVE_READINESS|BROKER_WRITE_AUTHORITY|external_broker_paper_evidence|edge_validated|GITHUB_TOKEN' dharma_swarm reports docs scripts
+```

--- a/reports/swarm_genome/2026-06-11/agent_3_research_chetana.md
+++ b/reports/swarm_genome/2026-06-11/agent_3_research_chetana.md
@@ -1,0 +1,162 @@
+# Agent 3 Receipt: Research / Mech-Interp / Chetana Scientist
+
+Date: 2026-06-11
+Mode: read-only scan
+Question: What is the research engine, and how does it feed organism intelligence?
+
+## Files Read By Family
+
+Spec and governance:
+- `docs/agent_tasks/2026-06-11_swarm_genome_convergence_spec.md`
+- `docs/governance/ACTIVE_TRACK.yaml`
+
+Chetana:
+- `dharma_swarm/chetana/README.md`
+- `dharma_swarm/chetana/promote.py`
+- `dharma_swarm/chetana/graph_unifier.py`
+- `dharma_swarm/chetana/revival.py`
+- `dharma_swarm/chetana/gap_scan.py`
+- `dharma_swarm/chetana/cross_update.py`
+
+Memory Kernel:
+- `dharma_swarm/memory_kernel/__init__.py`
+- `dharma_swarm/memory_kernel/facade.py`
+- `dharma_swarm/memory_kernel/context_admission.py`
+- `dharma_swarm/memory_kernel/default_context.py`
+- `dharma_swarm/memory_kernel/surfaces.py`
+- `dharma_swarm/memory_kernel/atoms.py`
+- `dharma_swarm/memory_kernel/promotion_gate.py`
+- `dharma_swarm/memory_kernel/write_receipts.py`
+
+Knowledge Ops:
+- `dharma_swarm/knowledge_ops/memory_intake.py`
+- `dharma_swarm/knowledge_ops/memory_conflict_review.py`
+- `dharma_swarm/knowledge_ops/memory_promotion_queue.py`
+- `dharma_swarm/knowledge_ops/memory_kernel_promotion_bridge.py`
+
+Research and theory:
+- `docs/research/README.md`
+- `docs/research/self_reference_attractor/RESEARCH_PROGRAM.md`
+- `docs/research/VERIFIED_EXPERIMENT_LOOP_RFC.md`
+- `docs/research/RECEIPT_AND_VEL_EQUIVALENCE_MATRIX.md`
+- `docs/research/CONSCIOUSNESS_ARCHAEOLOGY_SCAN.md`
+- `docs/research/VERIFICATION_RESEARCH_SUMMARY.md`
+- `foundations/FOUNDATIONS_SYNTHESIS.md`
+- `docs/architecture/PHILOSOPHICAL_ARCHITECTURAL_MARRIAGE.md`
+
+Wiki and memory:
+- `~/.dharma/knowledge/wiki/`
+- `~/.dharma/knowledge/wiki/raw/MANIFEST.yaml`
+- `~/.dharma/knowledge/wiki/_meta/tag-dictionary.md`
+
+Anatomy and packets:
+- `reports/anatomy_altitude_2026-06-10/lane_B_truth.md`
+- `reports/anatomy_altitude_2026-06-10/lane_C_evolution.md`
+- `reports/anatomy_altitude_2026-06-10/lane_D_spine_canon.md`
+- `reports/anatomy_altitude_2026-06-10/lane_E_organism_vision.md`
+- `reports/agentops/work_packets/forge-reality-arena-status.json`
+
+## Claims With Source References
+
+1. The research engine is a loop, not one module: falsifiable research, Chetana/wiki memory, MemoryKernel atom normalization, KnowledgeOps review, and governance routing. Sources: `docs/governance/ACTIVE_TRACK.yaml:65-68`, `docs/research/self_reference_attractor/RESEARCH_PROGRAM.md:1-16`, `dharma_swarm/chetana/README.md:1-24`, `dharma_swarm/memory_kernel/facade.py:1-5`, `dharma_swarm/knowledge_ops/memory_intake.py:1-5`.
+2. R_V/mech-interp is central but still bridge-level; R_V contraction and Phoenix L3/L4 are not co-tested on the same forward passes. Source: `docs/research/self_reference_attractor/RESEARCH_PROGRAM.md:61-63`.
+3. Chetana is intended as PKM tissue across raw sources, staging, trusted wiki atoms, decay/revival, gap scanning, palace, and multi-graph query. Source: `dharma_swarm/chetana/README.md:1-39`.
+4. Chetana promotion is gated and provenance-oriented. Source: `dharma_swarm/chetana/promote.py:82-161`.
+5. Chetana graph unification conceptually reaches wiki, memory, GitNexus, Context+, and catalytic graph, but some MCP reachability is not direct. Sources: `dharma_swarm/chetana/graph_unifier.py:1-17`, `:56-106`, `:297-311`.
+6. MemoryKernel is explicitly a read-normalization and context-admission organ, not a new authority store. Sources: `dharma_swarm/memory_kernel/__init__.py:1-7`, `dharma_swarm/memory_kernel/context_admission.py:1-5`, `dharma_swarm/memory_kernel/promotion_gate.py:1-5`.
+7. KnowledgeOps consumes evidence read-only, preserves metadata, and proposes reviews/queues without mutating canon. Sources: `dharma_swarm/knowledge_ops/memory_intake.py:1-5`, `:165-216`, `dharma_swarm/knowledge_ops/memory_promotion_queue.py:72-120`.
+8. Verified Experiment Loop is the clean blueprint from claim to operational knowledge, but it is still proposed design. Sources: `docs/research/VERIFIED_EXPERIMENT_LOOP_RFC.md:1-30`, `:195-205`.
+9. Failure capsules already become KnowledgeOps candidate inputs, but not trusted memory promotions. Source: `reports/agentops/work_packets/forge-reality-arena-status.json:251-265`, `:548-565`.
+10. Research-depth exists as an objective but no active research-depth track is staffed. Sources: `docs/governance/ACTIVE_TRACK.yaml:65-68`, `reports/anatomy_altitude_2026-06-10/lane_D_spine_canon.md:24-33`.
+
+## Research Program Map
+
+Flow:
+
+`R_V / foundations / docs/research -> Verified Experiment Loop / receipts -> Chetana/wiki -> MemoryKernel atoms -> KnowledgeOps review -> promotion queue -> ACTIVE_TRACK/routing`.
+
+Core pieces:
+- Foundations frame the organism thesis: cognition as self-organization, reflexive depth, value attractors.
+- R_V supplies falsifiable experiments: lexical confound checks, scale sweeps, SAE/self-model subspaces, neurophenomenology, shared invariants.
+- Receipt/VEL doctrine supplies the operational science protocol.
+- Chetana/wiki store and revive research memory.
+- MemoryKernel normalizes and admits context.
+- KnowledgeOps critiques and queues promotion.
+- ACTIVE_TRACK decides whether research-depth becomes actual work.
+
+## Health Labels
+
+- Working: MemoryKernel read-only adapters and readiness; Chetana CLI/tests; KnowledgeOps read-only queue/review surfaces.
+- Semi-working: Chetana graph unifier; wiki; VEL as doctrine; research corpus.
+- Aspirational: live R_V-on-self instrumentation; autonomous research-depth loop.
+- Stale: GitNexus/index state when behind HEAD; some wiki aggregates.
+- Duplicate: research maps across foundations, telos-engine, research docs, wiki, and anatomy reports.
+- Bloated: wiki is useful but too large for first-token orientation.
+- Dangerous: treating candidate memory, wiki atoms, or agent claims as authority without promotion receipts.
+- Unknown: current full MCP reachability and semantic search quality.
+
+## Top Missing Feedback Loops
+
+1. R_V is not routinely run on the organism's own reasoning.
+2. R_V contraction and Phoenix L3/L4 are not co-tested on the same forward passes.
+3. Research-depth has an objective but no active track.
+4. VEL is not implemented as runtime.
+5. Chetana query is not fully wired to memory MCP/Context+.
+6. MemoryKernel is not the default first-token context substrate.
+7. KnowledgeOps can nominate and review but not complete autonomous canonical learning.
+8. Failure capsules become quarantined candidates, not trusted memory.
+9. Wiki scale hurts fast retrieval.
+10. Dispatch/evidence persistence remains partially dormant.
+
+## Top 10 Findings
+
+1. Research engine equals science plus memory plus critique plus routing.
+2. R_V/mech-interp is central but not operationally closed over the organism.
+3. Chetana is connective PKM, not just a wiki writer.
+4. MemoryKernel is not a store; it is a sensor/normalizer/admission layer.
+5. KnowledgeOps is intentionally read-only.
+6. Wiki has provenance and tag governance.
+7. VEL is the best blueprint for operational learning.
+8. Failure capsules already produce KnowledgeOps handoff candidates.
+9. Research-depth is declared and under-instrumented.
+10. Safety boundaries are correct but slow the learning loop.
+
+## Top 10 Weak Spots
+
+1. No live R_V-on-self instrumentation.
+2. No active research-depth track.
+3. VEL not implemented as runtime.
+4. Chetana MCP graph reach incomplete.
+5. MemoryKernel not default context.
+6. KnowledgeOps promotion stops at artifacts/queues.
+7. Wiki scale hurts retrieval.
+8. GitNexus/search substrate stale/degraded in this scan.
+9. Dispatch/evidence persistence has dormant paths.
+10. Semantic policy classifier / autonomous promotion gate is missing.
+
+## Final Command Map Must Include
+
+- One-line definition: research engine equals science-to-memory-to-action loop.
+- Flow from research claim to VEL receipt to Chetana/wiki to MemoryKernel to KnowledgeOps to ACTIVE_TRACK.
+- Chetana commands: query, promote, gap-scan, revive.
+- MemoryKernel readiness and context preview commands.
+- KnowledgeOps intake, conflict, queue, bridge commands.
+- Health labels for authoritative versus candidate-only memory.
+
+## Uncertainties
+
+- No mutating workflows were run.
+- GitNexus/code retrieval were not authoritative in this scan.
+- Large wiki/report surfaces were sampled.
+- Memory MCP prior nodes were not useful in the scan.
+
+## Suggested Verifiers
+
+```bash
+make memory-kernel-readiness
+make memory-kernel-readiness-strict
+.venv/bin/python -m pytest tests/test_memory_kernel_readiness.py tests/test_knowledge_ops_memory_promotion.py -q
+.venv/bin/python -m pytest dharma_swarm/chetana/tests -q
+.venv/bin/python -m dharma_swarm.chetana.cli status
+rg -n "research-depth|R_V|Verified Experiment Loop|MemoryKernel|KnowledgeOps|Chetana" docs dharma_swarm reports
+```

--- a/reports/swarm_genome/2026-06-11/agent_4_governance_operating_canon.md
+++ b/reports/swarm_genome/2026-06-11/agent_4_governance_operating_canon.md
@@ -1,0 +1,154 @@
+# Agent 4 Receipt: Operating System / Governance Architect
+
+Date: 2026-06-11
+Mode: read-only scan
+Question: What rules tell agents how to work safely, and what do those rules hide?
+
+## Files Read By Family
+
+Mission and onboarding:
+- `docs/agent_tasks/2026-06-11_swarm_genome_convergence_spec.md`
+- `CLAUDE.md`
+- `AGENTS.md`
+- `docs/AGENTS.md`
+- `docs/ops/AGENT_ONBOARDING.md`
+- `Makefile`
+- `scripts/governance/agent_onboard.py`
+
+Operating canon:
+- `docs/governance/CANONICAL_DOC_STACK.md`
+- `docs/governance/SOVEREIGN_MANIFEST.md`
+- `docs/governance/BUILD_SESSION_ENTRYPOINT.md`
+- `ACTIVE_SURFACE_MANIFEST.yaml`
+
+Active work and evidence:
+- `docs/governance/ACTIVE_TRACK.yaml`
+- `reports/governance/active_track_evidence.md`
+- `reports/governance/track_portfolio.json`
+
+Safety and gates:
+- `docs/governance/ANTI_SLOP_RULES.md`
+- `docs/governance/PR_QUALITY_GATES.md`
+- `docs/governance/CI_GATES.md`
+- `docs/governance/hygiene/AI_AGENT_GOVERNANCE.md`
+
+Breakage and todo surfaces:
+- `docs/state/BROKEN_REGISTER.md`
+- `docs/plans/NEXT_10_SUBSTRATE_TODO.md`
+- `docs/governance/AGENTOPS.md`
+- `docs/governance/KAIZENOPS.md`
+- `docs/governance/DAILY_OPERATING_BRIEF.md`
+- `docs/governance/METABOLIC_CLOCK.md`
+- `docs/governance/VENTURE_CELL_PORTFOLIO.yaml`
+
+## Claims With Source References
+
+1. The current canon makes agents safe around code but does not put whole-organism vision into the first-token path. Source: `docs/agent_tasks/2026-06-11_swarm_genome_convergence_spec.md:10-21`.
+2. The governance lane is explicitly about hidden substrate-repair bias. Source: `docs/agent_tasks/2026-06-11_swarm_genome_convergence_spec.md:148-170`.
+3. The first gate is `make onboard`; `CLAUDE.md` instructs agents to run it before non-trivial work and trust live state over stale prose. Source: `CLAUDE.md:3-16`.
+4. `make onboard` is a renderer, not authority. Sources: `scripts/governance/agent_onboard.py:1-17`, `Makefile:312-317`.
+5. Current active portfolio is substrate-biased: all four active tracks serve `substrate-nativeness`; revenue and research are uncovered. Sources: `CLAUDE.md:24-30`, `reports/governance/active_track_evidence.md:6-10`, `:78-83`.
+6. `ACTIVE_TRACK.yaml` defines revenue and research as real spine objectives, but no current active track serves them. Sources: `docs/governance/ACTIVE_TRACK.yaml:56-68`, active serves at `:130-136`, `:240-247`, `:293-300`, `:405-412`.
+7. The canonical source-of-truth model is strong: intent, surface, and state have distinct owners. Source: `docs/governance/CANONICAL_DOC_STACK.md:16-28`, `:50-90`, `:94-102`.
+8. Safety rules emphasize no duplicate substrates, read-before-edit, no secrets, no root docs, tests, semgrep/gitleaks, module budgets, and PR hygiene. Sources: `CLAUDE.md:177-187`, `docs/governance/ANTI_SLOP_RULES.md:13-24`, `docs/governance/PR_QUALITY_GATES.md:14-37`.
+9. Broader telos exists mostly outside first-read: Darshan, Loomwork, Shakti Ginko, SAB, Web4, venture cells. Source: `docs/governance/VENTURE_CELL_PORTFOLIO.yaml:1-31`, `:50-66`, `:73-123`, `:181-193`.
+10. Self-evolution is safety-gated and partially blocked. Sources: `docs/state/BROKEN_REGISTER.md:30-39`, `ACTIVE_SURFACE_MANIFEST.yaml:386-394`, `:423-430`, `:623-657`.
+
+## Current First-Read Stack
+
+The documented first-read stack is:
+
+1. `make onboard`
+2. `CLAUDE.md`
+3. `docs/governance/SOVEREIGN_MANIFEST.md`
+4. `docs/governance/ACTIVE_TRACK.yaml`
+5. `docs/governance/ANTI_SLOP_RULES.md`
+
+Source: `docs/governance/CANONICAL_DOC_STACK.md:32-47`; repeated in `docs/ops/AGENT_ONBOARDING.md:36-49`.
+
+Missing from first-read:
+- `foundations/THE_ORGANISM.md`
+- `docs/vision_maps/2026-05-30_binocular_witness_seer_northstar.md`
+- `reports/anatomy_altitude_2026-06-10/`
+- `docs/governance/VENTURE_CELL_PORTFOLIO.yaml`
+- `docs/loomwork/`
+- revenue/capital docs
+- research and Chetana docs
+
+## Governance Source-Of-Truth Map
+
+- Intent/current work: `docs/governance/ACTIVE_TRACK.yaml`
+- Surface inventory: `ACTIVE_SURFACE_MANIFEST.yaml`
+- Live state: runtime receipts and live dashboards rendered by onboarding
+- Known breakage: `docs/state/BROKEN_REGISTER.md`
+- Behavior: `CLAUDE.md`
+- Architecture/invariants: `docs/governance/SOVEREIGN_MANIFEST.md`
+- Doc ownership: `docs/governance/CANONICAL_DOC_STACK.md`
+- Safety/hygiene: `docs/governance/ANTI_SLOP_RULES.md`
+- Venture/cells/revenue/media: `docs/governance/VENTURE_CELL_PORTFOLIO.yaml`
+
+## Health Labels
+
+- Working: `make onboard`, `CANONICAL_DOC_STACK.md`, `ACTIVE_TRACK.yaml`, PR/CI gates, anti-slop gates.
+- Semi-working: `SOVEREIGN_MANIFEST.md`, `AGENT_ONBOARDING.md`, `ACTIVE_SURFACE_MANIFEST.yaml`, Daily Operating Brief, AgentOps.
+- Aspirational: `SWARM_GENOME.md`, whole-organism first-token map, revenue/research/media active loops.
+- Stale: `NEXT_10_SUBSTRATE_TODO.md`; old Venture portfolio active-build comments.
+- Duplicate: active-track blocks rendered in multiple docs.
+- Bloated: `SOVEREIGN_MANIFEST.md` and memory-heavy agent contexts.
+- Dangerous: treating substrate-nativeness as the whole telos; treating model agreement as proof.
+- Unknown: current live media/revenue systems beyond YAML and receipts.
+
+## Top 10 Findings
+
+1. Safety canon is strong and operational.
+2. First-read stack is optimized for safe code work, not whole-organism comprehension.
+3. All current active tracks serve substrate-nativeness.
+4. Revenue and research are recognized spine objectives but uncovered.
+5. Media/memetics exists in Venture Cell portfolio, not active tracks.
+6. Self-evolution is documented but still gated/partial.
+7. The source-of-truth model is coherent and should be reused.
+8. Active work surfaces confuse method with object: wire substrate versus become organism.
+9. Some todo/portfolio surfaces still assume older single-track doctrine.
+10. `SWARM_GENOME.md` is absent except as this mission concept.
+
+## Top 10 Weak Spots
+
+1. No canonical 10-second organism map.
+2. No active revenue track.
+3. No active research-depth track.
+4. No active media/publication track.
+5. Shippable substrate tracks remain open.
+6. Stale todo docs conflict with v2 active-track model.
+7. Venture portfolio carries broader telos but is not first-read.
+8. Broken Register dates are old in places.
+9. PR gates do not enforce objective portfolio balance.
+10. Governance may reduce diversity despite its own warnings.
+
+## Final Command Map Must Include
+
+- 10-second identity and telos map.
+- Source-of-truth hierarchy.
+- Active tracks and uncovered objectives.
+- Organ health table.
+- Revenue/research/media/self-evolution map.
+- Stale, duplicate, and dangerous surfaces.
+- Verifier commands.
+- Exact source index.
+
+## Uncertainties
+
+- GitNexus was stale and used only for orientation.
+- Live external revenue/media systems were not revalidated.
+- Private wiki was not fully traversed in this lane.
+- Worktree was already dirty.
+
+## Suggested Verifiers
+
+```bash
+make onboard
+python3 scripts/governance/check_track_status.py
+python3 scripts/governance/render_active_track_includes.py --check
+make docops-integrity
+rg -n "SWARM_GENOME|COMMAND_MAP|Swarm Genome|Command Map" docs reports foundations
+rg -n "serves: revenue-external-humans-served|serves: research-depth" docs/governance/ACTIVE_TRACK.yaml
+```

--- a/reports/swarm_genome/2026-06-11/agent_5_runtime_organs_devops.md
+++ b/reports/swarm_genome/2026-06-11/agent_5_runtime_organs_devops.md
@@ -1,0 +1,187 @@
+# Agent 5 Receipt: Organs / Runtime / DevOps Systems Engineer
+
+Date: 2026-06-11
+Mode: read-only scan
+Question: Which organs actually exist in code, and how healthy are they?
+
+## Files Read By Family
+
+Spec:
+- `docs/agent_tasks/2026-06-11_swarm_genome_convergence_spec.md`
+
+Core scans:
+- `dharma_swarm/`
+- `api/`
+- `scripts/runtime/`
+- `scripts/governance/`
+- `tests/`
+- `reports/anatomy_altitude_2026-06-10/`
+- `reports/governance/`
+
+Ops and control:
+- `docs/ops/LIVE_OPS_COCKPIT.md`
+- `docs/ops/TMUX_AGENT_SUBSTRATE.md`
+- `scripts/runtime/live_ops_census.py`
+- `scripts/governance/agent_onboard.py`
+- `Makefile`
+
+Organs:
+- `dharma_swarm/runtime_state.py`
+- `dharma_swarm/operator_core/*`
+- `dharma_swarm/a2a/*`
+- `dharma_swarm/capital_lab/*`
+- `dharma_swarm/revenue/*`
+- `dharma_swarm/memory_kernel/*`
+- `dharma_swarm/knowledge_ops/*`
+- `dharma_swarm/chetana/*`
+- `dharma_swarm/holon_*`
+- `dharma_swarm/cron_*`
+- `dharma_swarm/dgc_cli.py`
+- `dharma_swarm/terminal_bridge.py`
+- `dharma_swarm/tui/*`
+- `terminal/*`
+- `docs/loomwork/*`
+
+## Make Onboard Snapshot
+
+Command run by lane: `env PYTHONDONTWRITEBYTECODE=1 make onboard`.
+
+Observed:
+- Branch: `qwen/spine-adoption`
+- Dirty files: 341
+- Active tracks: 4
+- Gaps: `revenue-external-humans-served`, `research-depth`
+- Runtime DB: `~/.dharma/state/runtime.db`
+- Runtime row counts: `artifact_records 1475`, `delegation_runs 3938`, `execution_identities 2089`, `runtime_receipts 3332`, `task_claims 3972`
+- Receipt fill gap: `delegation_runs 0/3938`
+- Live ops: 15 surfaces, with 6 live, 7 stopped, 1 stale, 1 blocked
+- A2A readiness edge imports missing `dharma_swarm.operator_core.a2a_task_lifecycle`
+
+## Claims With Source References
+
+1. `make onboard` is informational and owns no facts. Sources: `scripts/governance/agent_onboard.py:1-17`, `Makefile:312-317`, `tests/test_agent_onboard.py:181-204`.
+2. Runtime truth projector is read-only and opens SQLite with `mode=ro`; RuntimeStateStore is canonical SQLite spine. Sources: `dharma_swarm/operator_core/runtime_truth.py:1-6`, `:179-187`, `dharma_swarm/runtime_state.py:1-7`, `:396-435`.
+3. Control surface separates declared intent from observed reality; manifest is not truth. Sources: `dharma_swarm/operator_core/control_surface.py:1-12`, `api/routers/control_surface.py:46-56`, `:116-124`.
+4. Live Ops Cockpit is read-only and must not start/stop/kill/message/spend/merge. Source: `docs/ops/LIVE_OPS_COCKPIT.md:7-11`.
+5. tmux is terminal persistence, not identity, work, or completion authority. Source: `docs/ops/TMUX_AGENT_SUBSTRATE.md:8-15`, `:103-117`.
+6. A2A exists with protocol/server/NATS tests, but readiness currently imports a missing module. Sources: `dharma_swarm/a2a/a2a_server.py:1-23`, `:51-65`, `:399-434`, `scripts/governance/check_a2a_readiness.py:12-16`, `tests/test_a2a_readiness_gate.py:6-7`.
+7. Capital Lab hard-fences live trading authority. Sources: `dharma_swarm/capital_lab/alpha_evidence.py:1-6`, `:26-29`, `dharma_swarm/capital_lab/broker_paper_membrane.py:1-6`, `:24-30`.
+8. Revenue scout/spine/API exist, but no autonomous spam and human approval is required. Sources: `dharma_swarm/revenue/scout_daemon.py:1-18`, `:406-443`, `api/routers/revenue.py:74-85`.
+9. MemoryKernel is read-only with readiness tests. Sources: `dharma_swarm/memory_kernel/facade.py:1-5`, `:59-80`, `dharma_swarm/memory_kernel/readiness.py:94-178`.
+10. Holon runtime exists but launch proof is not closed. Sources: `dharma_swarm/holon_runtime.py:1-19`, `:52-86`, `reports/sovereign_holons/BUILD_A_90_READINESS_PACKET.md:1-15`, `:120-174`.
+11. Loomwork is design-only in this scan: portfolio marks it design-only and no `dharma_swarm/wiki_loom` package was found. Source: `docs/governance/VENTURE_CELL_PORTFOLIO.yaml:114-118`.
+
+## Organ Inventory
+
+- RuntimeState / RuntimeTruth: working core, semi-working saturation.
+- API gateway: semi-working; routers registered; dev auth opens API when `DASHBOARD_API_KEY` absent.
+- Control surface / cockpit: semi-working read model; rows depend on many adapters.
+- Live ops census: working read-only.
+- A2A / NATS: semi-working with broken readiness edge.
+- Capital Lab: semi-working paper/evidence, aspirational live, dangerous if treated live.
+- Revenue / CashClaw / RevenueSpine: semi-working, blocked external loop.
+- MemoryKernel / KnowledgeOps: working read-only, semi-working write path.
+- Chetana: semi-working CLI/tests, not fully MCP-integrated.
+- Holon: semi-working, launch proof incomplete.
+- Loomwork: aspirational/stale design.
+- Cron/schedulers: semi-working with repo/live split-brain risk.
+- tmux substrate: working persistence, dangerous if treated as proof.
+- Merge Master Mike / PR merge control: semi-working and authority-bearing.
+- Terminal / TUI: duplicate/bloated.
+- Evolution / DGM: semi-working/stale/dangerous overclaim risk.
+
+## Health Labels
+
+- Working: RuntimeState core, live ops census, tmux as persistence, MemoryKernel read-only readiness.
+- Semi-working: API, control surface, A2A/NATS, revenue, Chetana, Holon, cron.
+- Aspirational: live trading, Loomwork code organ, external broker-paper, fully metabolic self-evolution.
+- Stale: Loomwork implementation claims, branch-specific anatomy reports in dirty checkout.
+- Duplicate: terminal/TUI surfaces; overlapping operator truth surfaces.
+- Bloated: runtime god-files and dashboard/control surface adapter sprawl.
+- Dangerous: API dev-auth open mode, live-trading surfaces, merge-control authority, treating mirrors as truth.
+- Unknown: exact live daemon/process state without mutating checks.
+
+## Top 10 Findings
+
+1. Runtime ledger/projection stack is the healthiest core organ.
+2. Dispatch evidence is not fully saturated.
+3. Control surface and live ops are honest read models, not authority.
+4. A2A/NATS has real implementation but broken readiness gate.
+5. Capital Lab is honest because live authority is zero.
+6. Revenue has code but no external metabolism proof.
+7. MemoryKernel/KnowledgeOps is healthy because it narrows its authority.
+8. Chetana is real as CLI/tested package, not fully MCP-integrated.
+9. Holon exists but is not launch-proven.
+10. Terminal/operator surfaces are overgrown and duplicate authority.
+
+## Top 10 Weak Spots
+
+1. Missing A2A readiness module.
+2. Runtime receipt propagation partial across legacy paths.
+3. Dirty, divergent branch state.
+4. Cron live/repo split-brain.
+5. Revenue external proof absent.
+6. API dev-auth open mode.
+7. Duplicate terminal/TUI layers.
+8. Loomwork docs overrun implementation.
+9. Evolution/DGM lineage and selection pressure broken/dormant.
+10. Reports describe different branches/trees.
+
+## Cleanup Candidates
+
+1. Restore or retire `dharma_swarm.operator_core.a2a_task_lifecycle`.
+2. Consolidate terminal surfaces.
+3. Mark Loomwork design-only unless code exists.
+4. Reduce god-file bloat.
+5. Clarify cron authority and revenue scout env injection.
+6. Split control-surface heavy rows from cheap liveness.
+7. Update stale dashboard/live-ops prose.
+8. Promote MemoryKernel writes through one canonical gate.
+9. Align anatomy reports with current branch state.
+10. Keep live trading and merge authority guarded.
+
+## Do Not Touch Until Understood
+
+- `dharma_swarm/runtime_state.py`
+- `~/.dharma/state/runtime.db`
+- `dharma_swarm/operator_core/runtime_truth.py`
+- `dharma_swarm/operator_core/control_surface.py`
+- `ACTIVE_SURFACE_MANIFEST.yaml`
+- A2A/NATS secrets, subjects, ack receipts, and `scripts/runtime/a2a_send.py`
+- Capital/AGNI/Hyperliquid/live trading surfaces
+- Revenue outreach/CashClaw gates
+- `pr_merge_control.py` and `merge_master_mike_daemon.py`
+- Chetana trusted wiki/promote paths
+- Dashboard API/web restarts
+
+## Final Command Map Must Include
+
+- Runtime ledger and receipt counts.
+- Read-only control surface truth boundary.
+- A2A readiness status and missing module warning.
+- Capital live-readiness zeros.
+- Revenue external proof status.
+- MemoryKernel/KnowledgeOps authority boundary.
+- Chetana status.
+- Holon launch proof status.
+- Loomwork design-only status.
+- Terminal/TUI duplicate map.
+
+## Uncertainties
+
+- Full test suite was not run.
+- Live process state was inferred from onboarding and receipts, not restarts.
+- Some reports are branch/time-specific.
+- Loomwork implementation conflict remains unresolved.
+
+## Suggested Verifiers
+
+```bash
+env PYTHONDONTWRITEBYTECODE=1 make onboard
+.venv/bin/python scripts/runtime/live_ops_census.py --write
+.venv/bin/python -m pytest tests/test_agent_onboard.py tests/test_control_surface.py tests/test_live_ops_census.py -q
+.venv/bin/python -m pytest tests/test_a2a.py tests/test_a2a_e2e.py tests/test_a2a_spec_conformance.py tests/test_nats_transport.py -q
+.venv/bin/python -m pytest tests/test_a2a_readiness_gate.py -q
+.venv/bin/python -m pytest tests/test_capital_lab_alpha_evidence.py tests/test_capital_lab_broker_paper_membrane.py tests/test_capital_lab_contracts.py tests/test_capital_lab_risk_governor.py -q
+make memory-kernel-readiness
+```

--- a/reports/swarm_genome/2026-06-11/agent_6_adversarial_synthesis_receipt.md
+++ b/reports/swarm_genome/2026-06-11/agent_6_adversarial_synthesis_receipt.md
@@ -1,0 +1,153 @@
+# Agent 6 Receipt: Adversarial Synthesis Editor
+
+Date: 2026-06-11
+Mode: synthesis over five explorer lanes plus local source receipts
+Question: What is the smallest true map that makes the next agent vastly stronger?
+
+## Inputs Read
+
+Lane receipts / outputs:
+- Agent 1 Telos / Vision Cartographer
+- Agent 2 Revenue / Capital / Self-Funding Strategist
+- Agent 3 Research / Mech-Interp / Chetana Scientist
+- Agent 4 Operating System / Governance Architect
+- Agent 5 Organs / Runtime / DevOps Systems Engineer
+
+Primary source families used to adjudicate:
+- `docs/agent_tasks/2026-06-11_swarm_genome_convergence_spec.md`
+- `foundations/THE_ORGANISM.md`
+- `WHAT_IT_WANTS_TO_BECOME.md`
+- `docs/vision_maps/2026-05-30_binocular_witness_seer_northstar.md`
+- `docs/vision_maps/MASTER_2026-06-10_anatomy_altitude_integration.md`
+- `docs/vision_maps/MASTER_2026-06-10_leverage_synthesis.md`
+- `reports/anatomy_altitude_2026-06-10/`
+- `docs/governance/ACTIVE_TRACK.yaml`
+- `reports/governance/active_track_evidence.md`
+- `docs/governance/VENTURE_CELL_PORTFOLIO.yaml`
+- `docs/governance/VENTURE_CELL_REVENUE_WEDGE.md`
+- `dharma_swarm/revenue/`
+- `dharma_swarm/capital_lab/`
+- `dharma_swarm/chetana/`
+- `dharma_swarm/memory_kernel/`
+- `dharma_swarm/knowledge_ops/`
+- `dharma_swarm/operator_core/`
+- `dharma_swarm/a2a/`
+
+## Adversarial Rejections
+
+1. Do not claim the organism is economically alive. Revenue doctrine, offers, scouts, and capital labs exist; confirmed cashflow is still zero.
+2. Do not claim Capital Lab is a live trading system. Its strongest feature is that live authority is hard-fenced to zero.
+3. Do not claim Loomwork is a live code organ. Current evidence supports design/vision, not a running package.
+4. Do not claim research-depth is active. It is a declared objective with no active track.
+5. Do not claim the memory/wiki system gives 10-second understanding today. It is powerful but too large and not default prompt context.
+6. Do not claim runtime truth is fully saturated. RuntimeState exists, but receipt fill gaps remain.
+7. Do not claim A2A readiness is green. Implementation exists, but the readiness gate imports a missing module in this scan.
+8. Do not claim self-evolution is metabolic. Anatomy reports call out vacuous positives, dormant apply, and lineage gaps.
+9. Do not claim `make onboard` is authority. It is the front-door renderer over other owners.
+10. Do not merge branch-local artifacts to main wholesale. The dirty branch and capital branch both need extraction, not bulk landing.
+
+## Contradictions To Resolve
+
+- The first-read stack teaches agents safe code work before it teaches whole-organism telos.
+- `ACTIVE_TRACK.yaml` declares revenue and research as spine objectives but active tracks serve substrate only.
+- Venture Cell portfolio contains broader organs but is not first-read.
+- Loomwork is described as public/media arm but lacks current code evidence.
+- Capital Lab contains serious architecture but lives on an incubator/staging branch and is hard-fenced.
+- Chetana/wiki intend first-token memory but are not yet default fast-path context.
+- Runtime truth claims are stronger than dispatch receipt saturation.
+- Some docs cite moved/missing `SOVEREIGN_MANIFEST` telos sections.
+- Old single-track docs conflict with active-track v2.
+- Many reports are branch/time-specific; agents need freshness labels.
+
+## Ranked Weak Spots By Leverage
+
+1. No canonical 10-second Swarm Genome map.
+2. No active revenue-external-humans-served track.
+3. No active research-depth track.
+4. No source-of-truth organ health table.
+5. Memory/wiki/semantic systems do not generate the first-token map.
+6. External contact and first cash are not operationally closed.
+7. Runtime receipt saturation and A2A readiness gaps remain.
+8. Self-evolution is not yet metabolic or safely applying verified changes.
+9. Loomwork/Vwrite/media pipeline is design/proposed, not live.
+10. Branch hygiene is poor enough that "what exists" is checkout-dependent.
+
+## Smallest True Map
+
+`dharma_swarm` is a Krishna-first, telos-gated, self-evolving organism trying to close cognition through the world: inwardly witness and research, outwardly serve humans through good-works software, media, revenue, and eventually capital. The safe operating canon is real and strong, but it currently makes substrate repair vivid while hiding revenue, research, media, and consciousness ambitions from the fast path. The organism is powerful in maps and partial organs; it is not yet economically alive, not yet research-metabolic, and not yet self-evolving in a closed causal loop.
+
+## Health Labels Across The Organism
+
+- Working: onboarding renderer, active-track schema, anti-slop gates, RuntimeState core, live ops read-only census, MemoryKernel readiness, capital fixture fences.
+- Semi-working: RevenueSpine/scout, Chetana, KnowledgeOps, A2A/NATS, control surface, Holon, Ginko, Capital Lab paper/evidence.
+- Aspirational: live trading, Web4/noosphere trust substrate, Loomwork at scale, welfare-ton economics, self-model training, autonomous research lab.
+- Stale: old single-track todo, some roadmap deadlines, missing/moved telos references.
+- Duplicate: vision maps, terminal surfaces, active-track rendered blocks, operator dashboards.
+- Bloated: wiki/raw memory, manifest-scale docs, operator surfaces.
+- Dangerous: treating substrate as telos, paper as live, mirrors as proof, agent consensus as evidence, or self-evolution logs as real apply.
+- Unknown: external revenue/contact outside local receipts, full live daemon state, current branch-main reconciliation.
+
+## Candidate Canonical Artifact
+
+Preferred path: `docs/governance/SWARM_GENOME.md`.
+
+Reason: it should own whole-organism cognitive orientation, not day-to-day operator commands. It should point to live-state owners rather than become them.
+
+Minimum sections:
+1. Ten-second identity.
+2. Ten-minute organism map.
+3. Organ health table.
+4. Active objectives and uncovered objectives.
+5. Revenue/research/media/runtime/self-evolution map.
+6. Source-of-truth hierarchy.
+7. Current strongest weak spots.
+8. Role-based next actions.
+9. Verifier commands.
+10. Source index with freshness labels.
+
+## Onboarding Patch Plan
+
+Do not patch high-authority canon until the report is reviewed. Proposed later patch:
+
+1. Add `SWARM_GENOME.md` to `docs/governance/CANONICAL_DOC_STACK.md` as the whole-organism fast map.
+2. Replace first-read direct `SOVEREIGN_MANIFEST.md` with `SWARM_GENOME.md`; keep manifest as deeper architecture authority.
+3. Update `make onboard` to print one compact organism line and link to Swarm Genome.
+4. Add active-track objective coverage check that flags revenue/research gaps as more than warnings.
+5. Add a generated organ health table from code/reports where possible.
+6. Add freshness labels for branch-local or unmerged artifacts.
+
+## Top 10 Findings
+
+1. The missing artifact is not another essay; it is a command map with receipts.
+2. The operating canon is stronger than the vision canon.
+3. The vision canon is broader than agents see in the first 10 seconds.
+4. Revenue and research are official but unstaffed.
+5. Media/memetics exists mainly in doctrine, Loomwork, and Vwrite plans.
+6. Runtime truth is real but not fully saturated.
+7. Memory/wiki is useful but not yet a fast orientation kernel.
+8. Capital Lab is valuable precisely because it refuses live authority.
+9. The next agent must see both grandeur and falsifiers immediately.
+10. The Swarm Genome should be generated/refreshed eventually, not hand-maintained forever.
+
+## Top 10 Weak Spots
+
+1. No `SWARM_GENOME.md`.
+2. No revenue track.
+3. No research-depth track.
+4. No first-cash loop.
+5. No active media/publication track.
+6. No live R_V-on-self loop.
+7. No default memory pack for organism comprehension.
+8. A2A readiness break.
+9. Runtime receipt fill gaps.
+10. Dirty branch/canon fragmentation.
+
+## Suggested Verifiers
+
+```bash
+make onboard
+rg -n "serves: revenue-external-humans-served|serves: research-depth" docs/governance/ACTIVE_TRACK.yaml
+find reports/swarm_genome/2026-06-11 -maxdepth 1 -type f -print | sort
+rg -n "Working|Semi-working|Aspirational|Dangerous|revenue|research-depth|Loomwork|Capital Lab|MemoryKernel|A2A" reports/swarm_genome/2026-06-11
+git status --short -- reports/swarm_genome/2026-06-11 docs/governance/ACTIVE_TRACK.yaml CLAUDE.md docs/ops/AGENT_ONBOARDING.md
+```


### PR DESCRIPTION
## Summary
- publishes the Swarm Genome / Command Map convergence spec
- publishes six lane receipts plus SYNTHESIS.md under reports/swarm_genome/2026-06-11/
- refreshes DocOps markdown inventory/counts and registers the spec with the canonical guard

## Coherence Delta
- Organ touched: governance/docops report surface for Swarm Genome orientation
- Declared-vs-actual gap closed: makes the missing whole-organism command-map report visible from main, including receipts for telos, revenue, research, governance, runtime, and adversarial synthesis
- Proof that re-reads the map: python3 scripts/docops/check_docops_integrity.py --changed-from origin/main; rg -n "SWARM_GENOME|COMMAND_MAP|Swarm Genome|Command Map" docs reports foundations; find reports/swarm_genome/2026-06-11 -maxdepth 1 -type f -print | sort
- New drift introduced: report-only artifact; no high-authority canon semantics changed beyond required DocOps count refresh and canonical-guard registration

## Verification
- python3 scripts/docops/check_docops_integrity.py --changed-from origin/main
- git diff --check --cached
- rg -n "SWARM_GENOME|COMMAND_MAP|Swarm Genome|Command Map" docs reports foundations
- pre-commit hooks passed during commit