### PR TITLE
chore(docops): re-verify assertions, renew TTL 2026-06-12

### DIFF
--- a/docs/docops/assertions.yaml
+++ b/docs/docops/assertions.yaml
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "verified_at": "2026-06-04",
+  "verified_at": "2026-06-12",
   "ttl_days": 14,
   "assertions": [
     {


### PR DESCRIPTION
## What

Renews the DocOps assertion TTL: verified_at 2026-06-04 -> 2026-06-12 in docs/docops/assertions.yaml. One line, no other changes.

## Verification

- python3 scripts/docops/check_docops_integrity.py run on a fresh worktree at 09a0c0810 (origin/main): exit 0, all 13 assertion metrics match the tree exactly, path guards / canonical guard / auto-sections all green.
- Full pre-commit suite passed on the commit: docops integrity, hygiene integrity, contract tests, uplift guards, manifest check, gitleaks.

## Why

Lanes branched before 2026-06-04 carry verified_at=2026-05-20 and their gate expired 2026-06-03, blocking commits in 3+ lanes. Re-verifying against today's tree and renewing the date is the repo's own renewal flow per docs/docops/DOCOPS_INTEGRITY.md.

## Coherence Delta
- Organ touched: docs/docops/assertions.yaml and the DocOps integrity gate metadata.
- Declared-vs-actual gap closed: renewed the DocOps assertion TTL after re-verifying the assertion metrics against the current tree, unblocking lanes whose local commits were blocked by expired DocOps verification metadata.
- Proof that re-reads the map: PR body records a fresh run of scripts/docops/check_docops_integrity.py plus commit-time pre-commit gates including docops integrity, hygiene integrity, contract tests, uplift guards, manifest check, and gitleaks.
- New drift introduced: none; this is a one-line TTL renewal for already-verified DocOps assertions.

Auto-merge: OFF (operator review).