### PR TITLE
chore(governance): refresh spine adoption metric [automated]

### DIFF
--- a/reports/governance/spine_adoption_metric.json
+++ b/reports/governance/spine_adoption_metric.json
@@ -1,5 +1,5 @@
 {
-  "audit_sha": "fc2200758ce608042fe5a68a54a08436b304a483",
+  "audit_sha": "ef8e83b19a7be9ab59a57118a710590fbcecef04",
   "classification_rule": "joined requires all joined evidence patterns; adapter-ready requires all adapter evidence patterns when joined is incomplete; quarantine and legacy require explicit source markers; missing means no tracked surface or insufficient evidence.",
   "classification_vocabulary": [
     "joined",
@@ -11,10 +11,8 @@
   "doc_anchor_status": "ok",
   "metric": "spine_adoption_metric",
   "missing_doc_anchors": [],
-  "source_status": "dirty",
-  "source_status_entries": [
-    " M dharma_swarm/ontology.py"
-  ],
+  "source_status": "clean",
+  "source_status_entries": [],
   "summary": {
     "adapter_ready_count": 3,
     "adoption_pct": 93.8,
@@ -1761,5 +1759,5 @@
       "status": "legacy"
     }
   ],
-  "tracked_file_count": 2924
+  "tracked_file_count": 3049
 }


### PR DESCRIPTION
## chore(governance): refresh spine adoption metric [automated]

Automated refresh of `reports/governance/spine_adoption_metric.json` from `tools/spine_adoption_metric.py`.

### Snapshot — 2026-06-11T18:00Z
| Metric | Value |
|--------|-------|
| **adoption_pct** | **93.8%** (target: 95%) |
| joined | 12 / 16 |
| adapter-ready | 3 |
| legacy | 1 |
| missing | 0 |
| quarantine | 0 |

Gap to 95%: **+1.2 pp** — requires 1 more surface to move from `adapter-ready` → `joined`.

### Top saturation targets
1. `tool_registry_dispatch` — add `try_begin_idempotent_side_effect` gate
2. `self_modification_loop` — add `try_begin_idempotent_side_effect` gate on apply path
3. `mcp_tool_access` — wire `ExecutionIdentity`, `RuntimeStateStore`, `record_side_effect`

_This PR was generated with [Oz](https://warp.dev/oz)._
