### PR TITLE
chore(governance): refresh spine adoption metric [automated]

### DIFF
--- a/reports/governance/spine_adoption_metric.json
+++ b/reports/governance/spine_adoption_metric.json
@@ -1,5 +1,5 @@
 {
-  "audit_sha": "fc2200758ce608042fe5a68a54a08436b304a483",
+  "audit_sha": "ef8e83b19a7be9ab59a57118a710590fbcecef04",
   "classification_rule": "joined requires all joined evidence patterns; adapter-ready requires all adapter evidence patterns when joined is incomplete; quarantine and legacy require explicit source markers; missing means no tracked surface or insufficient evidence.",
   "classification_vocabulary": [
     "joined",
@@ -11,10 +11,8 @@
   "doc_anchor_status": "ok",
   "metric": "spine_adoption_metric",
   "missing_doc_anchors": [],
-  "source_status": "dirty",
-  "source_status_entries": [
-    " M dharma_swarm/ontology.py"
-  ],
+  "source_status": "clean",
+  "source_status_entries": [],
   "summary": {
     "adapter_ready_count": 3,
     "adoption_pct": 93.8,
@@ -1761,5 +1759,5 @@
       "status": "legacy"
     }
   ],
-  "tracked_file_count": 2924
+  "tracked_file_count": 3049
 }


### PR DESCRIPTION
## chore(governance): refresh spine adoption metric [automated]

Automated refresh of reports/governance/spine_adoption_metric.json from tools/spine_adoption_metric.py.

### Snapshot — 2026-06-12T00:00Z
| Metric | Value |
|--------|-------|
| adoption_pct | 93.8% (target: 95%) |
| joined | 12 / 16 |
| adapter-ready | 3 |
| legacy | 1 |
| missing | 0 |
| quarantine | 0 |

Gap to 95%: +1.2 pp — requires 1 more surface to move from adapter-ready to joined.

### Changes from previous commit
- source_status: dirty -> clean (ontology.py changes landed)
- tracked_file_count: 2924 -> 3049
- audit_sha refreshed

### Top saturation targets
1. tool_registry_dispatch — add try_begin_idempotent_side_effect gate in tool_registry.py
2. self_modification_loop — add try_begin_idempotent_side_effect gate on apply path in diff_applier.py
3. mcp_tool_access — wire ExecutionIdentity, RuntimeStateStore, record_side_effect into mcp_server.py / dharma_context_mcp.py

Supersedes #580 (same pct, but that snapshot had dirty source_status).

## Coherence Delta
- Organ touched: reports/governance/spine_adoption_metric.json and the spine-adoption governance metric surface.
- Declared-vs-actual gap closed: refreshed the automated spine adoption snapshot from tools/spine_adoption_metric.py after source_status moved from dirty to clean and tracked file count changed, keeping the governance metric aligned with the current tree.
- Proof that re-reads the map: PR body records the generated metric snapshot, audit_sha refresh, source_status clean, and top saturation targets; CI already passed the metric PR's DocOps, test, gitleaks, semgrep, and CodeQL checks except this PR-body gate.
- New drift introduced: none; this is a generated governance metric refresh and explicitly supersedes the older #580 snapshot.