### PR TITLE
fix(security): close post-574 review blockers

### DIFF
--- a/dharma_swarm/autonomous_agent.py
+++ b/dharma_swarm/autonomous_agent.py
@@ -28,6 +28,7 @@ from pathlib import Path
 from typing import Any
 
 from dharma_swarm.agent_memory import AgentMemoryBank
+from dharma_swarm.model_hierarchy import default_model as canonical_default_model
 from dharma_swarm.models import LLMResponse, Message, MessagePriority, ProviderType
 from dharma_swarm.runtime_provider import (
     create_runtime_provider,
@@ -35,6 +36,7 @@ from dharma_swarm.runtime_provider import (
 )
 
 logger = logging.getLogger(__name__)
+_DEFAULT_AGENT_MODEL = canonical_default_model(ProviderType.ANTHROPIC)
 
 
 # ---------------------------------------------------------------------------
@@ -282,7 +284,7 @@ class AgentIdentity:
     name: str
     role: str
     system_prompt: str
-    model: str = "claude-sonnet-4-20250514"
+    model: str = _DEFAULT_AGENT_MODEL
     provider: str = "anthropic"
     max_turns: int = 25
     allowed_tools: list[str] = field(default_factory=lambda: [
@@ -1249,7 +1251,7 @@ PRESET_AGENTS: dict[str, AgentIdentity] = {
             "verify claims, and produce research insights. You work in the dharma_swarm "
             "ecosystem alongside other agents."
         ),
-        model="claude-sonnet-4-20250514",
+        model=_DEFAULT_AGENT_MODEL,
         allowed_tools=[
             "read_file", "search_files", "search_content", "bash",
             "remember", "recall", "stigmergy_mark", "stigmergy_read", "web_search", "fetch_url",
@@ -1265,7 +1267,7 @@ PRESET_AGENTS: dict[str, AgentIdentity] = {
             "You follow existing patterns, run tests after changes, and keep code clean. "
             "You work in the dharma_swarm ecosystem."
         ),
-        model="claude-sonnet-4-20250514",
+        model=_DEFAULT_AGENT_MODEL,
         allowed_tools=[
             "read_file", "write_file", "bash", "search_files", "search_content",
             "remember", "recall", "stigmergy_mark", "stigmergy_read", "web_search", "fetch_url",
@@ -1281,7 +1283,7 @@ PRESET_AGENTS: dict[str, AgentIdentity] = {
             "opportunities, potential partners, carbon market news, and strategic intelligence. "
             "You save findings to structured files and flag urgent items."
         ),
-        model="claude-sonnet-4-20250514",
+        model=_DEFAULT_AGENT_MODEL,
         allowed_tools=[
             "read_file", "write_file", "bash", "search_files", "search_content",
             "remember", "recall", "stigmergy_mark", "stigmergy_read", "web_search", "fetch_url",
@@ -1297,7 +1299,7 @@ PRESET_AGENTS: dict[str, AgentIdentity] = {
             "and correctness. You find bugs, weak arguments, and potential improvements. "
             "Constructively critical, always specific."
         ),
-        model="claude-sonnet-4-20250514",
+        model=_DEFAULT_AGENT_MODEL,
         allowed_tools=[
             "read_file", "search_files", "search_content", "bash",
             "remember", "recall", "stigmergy_mark", "stigmergy_read", "web_search", "fetch_url",
@@ -1315,7 +1317,7 @@ PRESET_AGENTS: dict[str, AgentIdentity] = {
             "connections, and what wants to emerge. Bhed Gnan — knowing through "
             "separation of the knower from the known."
         ),
-        model="claude-sonnet-4-20250514",
+        model=_DEFAULT_AGENT_MODEL,
         allowed_tools=[
             "read_file", "search_files", "search_content",
             "remember", "recall", "stigmergy_mark", "stigmergy_read", "web_search", "fetch_url",

--- a/dharma_swarm/chetana/cli.py
+++ b/dharma_swarm/chetana/cli.py
@@ -252,7 +252,7 @@ def _cmd_approve(args: argparse.Namespace) -> int:
         try:
             path.unlink()
         except OSError as e:
-            print(f"warning: failed to remove staged file {path}: {e}")
+            print(f"warning: failed to remove staged file <redacted>: {type(e).__name__}")
         print("approved → trusted layer")
     else:
         # Write back in place
@@ -340,8 +340,8 @@ def _cmd_verify(args: argparse.Namespace) -> int:
         rows = buckets[label]
         print(f"- {label:14s}: {len(rows)}")
         if args.show and rows:
-            for r in rows[: args.show]:
-                print(f"    {r}")
+            for idx in range(1, min(len(rows), args.show) + 1):
+                print(f"    <redacted atom path {idx}>")
             if len(rows) > args.show:
                 print(f"    (... {len(rows) - args.show} more)")
     print("\nlegend:")
@@ -359,9 +359,9 @@ def _cmd_status(_args: argparse.Namespace) -> int:
     trusted = list_trusted()
     quarantined = list_quarantine()
     print("# chetana status")
-    print(f"- staged    : {len(staged)} (root: {STAGING_ROOT})")
-    print(f"- trusted   : {len(trusted)} (root: {TRUSTED_DEFAULT})")
-    print(f"- quarantine: {len(quarantined)} (root: {QUARANTINE_ROOT})")
+    print(f"- staged    : {len(staged)}")
+    print(f"- trusted   : {len(trusted)}")
+    print(f"- quarantine: {len(quarantined)}")
     return 0
 
 

--- a/dharma_swarm/chetana/tests/test_e2e_cli.py
+++ b/dharma_swarm/chetana/tests/test_e2e_cli.py
@@ -54,6 +54,7 @@ def test_cli_status_runs_against_empty_home(cli_home: Path):
     assert "staged    : 0" in proc.stdout
     assert "trusted   : 0" in proc.stdout
     assert "quarantine: 0" in proc.stdout
+    assert str(cli_home) not in proc.stdout
 
 
 def test_cli_help_shows_all_subcommands(cli_home: Path):
@@ -90,6 +91,7 @@ def test_cli_ingest_then_status(cli_home: Path):
 
     proc2 = _run(["status"], home=cli_home)
     assert "staged    : 1" in proc2.stdout
+    assert str(cli_home) not in proc2.stdout
 
 
 def test_cli_full_pipeline_ingest_promote_decay_revive(cli_home: Path):
@@ -127,6 +129,12 @@ def test_cli_full_pipeline_ingest_promote_decay_revive(cli_home: Path):
     p3 = _run(["status"], home=cli_home)
     assert "trusted   : 1" in p3.stdout
     assert "staged    : 0" in p3.stdout
+    assert str(cli_home) not in p3.stdout
+
+    verify = _run(["verify", "--show", "1"], home=cli_home)
+    assert verify.returncode == 0, verify.stderr
+    assert str(cli_home) not in verify.stdout
+    assert trusted_paths[0].name not in verify.stdout
 
     # 4. DECAY (no stale yet → 0 stale, no quarantine)
     p4 = _run(["decay"], home=cli_home)

--- a/dharma_swarm/pulse.py
+++ b/dharma_swarm/pulse.py
@@ -28,6 +28,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from dharma_swarm.api_keys import ANTHROPIC_API_KEY_ENV, env_has_value
+from dharma_swarm.claude_cli import (
+    resolve_claude_binary,
+    run_claude_headless as _run_claude_headless_impl,
+)
 from dharma_swarm.context import (
     read_agni_state,
     read_manifest,
@@ -40,10 +45,6 @@ from dharma_swarm.stigmergy import StigmergicMark, StigmergyStore
 from dharma_swarm.subconscious import SubconsciousStream
 from dharma_swarm.thread_manager import ThreadManager
 from dharma_swarm.telos_gates import check_with_reflective_reroute
-from dharma_swarm.claude_cli import (
-    resolve_claude_binary,
-    run_claude_headless as _run_claude_headless_impl,
-)
 from dharma_swarm.runtime_artifacts import append_pulse_log, freshest_pulse_log_path
 
 logger = logging.getLogger(__name__)
@@ -132,7 +133,7 @@ def run_claude_headless(
     returns a SKIP message immediately to avoid blocking the daemon
     process in U state (uninterruptible sleep) on the failed subprocess.
     """
-    if bare and not os.environ.get("ANTHROPIC_API_KEY", "").strip():
+    if bare and not env_has_value(ANTHROPIC_API_KEY_ENV):
         return (
             "SKIP: ANTHROPIC_API_KEY not set — "
             "claude bare mode unavailable. Set ANTHROPIC_API_KEY in .env "

--- a/docs/docops/AUTO_INVENTORY.md
+++ b/docs/docops/AUTO_INVENTORY.md
@@ -8,9 +8,9 @@ Do not hand-edit the generated block.
 |---|---:|
 | Dharma Python modules | 720 |
 | Top-level Dharma Python modules | 399 |
-| Dharma Python LOC | 296,187 |
+| Dharma Python LOC | 296,198 |
 | Test files | 673 |
-| Test function occurrences | 11,299 |
+| Test function occurrences | 11,300 |
 | Markdown files | 987 |
 | Markdown total lines | 234,592 |
 | Bridge files | 26 |

--- a/docs/governance/SOVEREIGN_MANIFEST.md
+++ b/docs/governance/SOVEREIGN_MANIFEST.md
@@ -305,7 +305,7 @@ These are the ground-truth metrics. All other documents citing different numbers
 | Top-level (flat) modules | **399 (58.7%)** | find dharma_swarm -maxdepth 1 -name "*.py" -type f |
 | Total Python LOC | **285,971** | wc -l across dharma_swarm Python modules |
 | Test files | **673** | find tests -name "*.py" -type f |
-| Test functions | **11,299 `def test_` occurrences under tests/** | rg "def test_" tests |
+| Test functions | **11,300 `def test_` occurrences under tests/** | rg "def test_" tests |
 | Tests collected (pytest) | **Needs write-permitted refresh** | not run during this DocOps count pass |
 | Collection errors | **Historical: 16 on 2026-04-04** | refresh before relying on this count |
 | Markdown files | **987** | find . -name "*.md" -type f |

--- a/scripts/runtime/a2a_send.py
+++ b/scripts/runtime/a2a_send.py
@@ -191,6 +191,20 @@ def write_receipt(receipt_dir: Path, receipt: dict[str, Any]) -> Path:
     return path
 
 
+def console_receipt() -> dict[str, Any]:
+    """Return an operator-facing receipt shape without persisted receipt fields."""
+    return {
+        "schema_version": "dharma.a2a.send_console.v1",
+        "packet_id": "<redacted>",
+        "status": "<recorded>",
+        "subject": "<redacted>",
+        "ack_subject": "<redacted>",
+        "reply_subject": "<redacted>",
+        "file": "<redacted>",
+        "receipt_path": "<written>",
+    }
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument("--to", required=True, help="agent lane, e.g. devin, codex, claude")
@@ -231,7 +245,6 @@ def main(argv: list[str] | None = None) -> int:
         "sha256": envelope["sha256"],
         "nats": _redacted_nats_config(config),
     }
-
     if config.missing or not config.endpoint:
         receipt["status"] = STATUS_SECRETS_MISSING
         receipt["missing"] = list(config.missing)
@@ -265,10 +278,10 @@ def main(argv: list[str] | None = None) -> int:
     receipt_path = write_receipt(Path(args.receipt_dir), receipt)
     receipt["receipt_path"] = str(receipt_path)
     if args.json:
-        print(json.dumps(receipt, indent=2, sort_keys=True))
+        print(json.dumps(console_receipt(), indent=2, sort_keys=True))
     else:
-        print(f"{receipt['status']} packet_id={packet_id} subject={envelope['subject']}")
-        print(f"receipt: {receipt_path}")
+        print("a2a_send: <recorded>")
+        print("receipt: <written>")
     if receipt["status"] == STATUS_SECRETS_MISSING:
         return 3
     if receipt["status"] == STATUS_PUBLISH_FAILED:

--- a/tests/test_a2a_send.py
+++ b/tests/test_a2a_send.py
@@ -51,7 +51,11 @@ def test_main_secrets_missing(tmp_path, monkeypatch, capsys):
     )
     assert code == 3
     out = capsys.readouterr().out
-    assert "NATS_SECRETS_MISSING" in out
+    assert "a2a_send: <recorded>" in out
+    assert "packet_id=" not in out
+    assert "subject=" not in out
+    assert str(tmp_path) not in out
+    assert "receipt: <written>" in out
     receipts = list((tmp_path / "r").glob("*.json"))
     assert len(receipts) == 1
     body = json.loads(receipts[0].read_text(encoding="utf-8"))
@@ -63,3 +67,35 @@ def test_main_missing_file(tmp_path):
         ["--to", "devin", "--file", str(tmp_path / "nope.md"), "--receipt-dir", str(tmp_path)]
     )
     assert code == 2
+
+
+def test_main_json_console_redacts_subjects_and_paths(tmp_path, monkeypatch, capsys):
+    for name in list(os.environ):
+        if "NATS" in name:
+            monkeypatch.delenv(name, raising=False)
+    packet = _write_packet(tmp_path)
+    code = a2a_send.main(
+        [
+            "--to",
+            "devin",
+            "--file",
+            str(packet),
+            "--receipt-dir",
+            str(tmp_path / "r"),
+            "--json",
+        ]
+    )
+    assert code == 3
+    console_body = json.loads(capsys.readouterr().out)
+    assert console_body["packet_id"] == "<redacted>"
+    assert console_body["status"] == "<recorded>"
+    assert console_body["subject"] == "<redacted>"
+    assert console_body["ack_subject"] == "<redacted>"
+    assert console_body["reply_subject"] == "<redacted>"
+    assert console_body["file"] == "<redacted>"
+    assert console_body["receipt_path"] == "<written>"
+
+    receipts = list((tmp_path / "r").glob("*.json"))
+    assert len(receipts) == 1
+    stored_body = json.loads(receipts[0].read_text(encoding="utf-8"))
+    assert stored_body["subject"] == "dharma.a2a.devin"

--- a/tests/test_autonomous_agent.py
+++ b/tests/test_autonomous_agent.py
@@ -20,6 +20,7 @@ from dharma_swarm.autonomous_agent import (
     _DANGEROUS_PATTERNS,
     cli_wake,
 )
+from dharma_swarm.model_hierarchy import default_model as canonical_default_model
 from dharma_swarm.models import ProviderType
 
 # Cross-lane drift guard: the TUI-alias model resolver ships on the
@@ -67,7 +68,7 @@ class TestAgentIdentity:
     def test_defaults(self):
         ident = AgentIdentity(name="test", role="general", system_prompt="hi")
         assert ident.name == "test"
-        assert ident.model == "claude-sonnet-4-20250514"
+        assert ident.model == canonical_default_model(ProviderType.ANTHROPIC)
         assert ident.provider == "anthropic"
         assert ident.max_turns == 25
         assert len(ident.allowed_tools) > 0

--- a/tests/test_model_key_routing_guard.py
+++ b/tests/test_model_key_routing_guard.py
@@ -78,8 +78,6 @@ KNOWN_MODEL_LITERAL_DEBT: Counter[tuple[str, str]] = Counter(
         ("dharma_swarm/agent_constitution.py", "claude-sonnet-4-20250514"): 2,
         ("dharma_swarm/assurance/agents.py", "claude-opus-4-20250514"): 1,
         ("dharma_swarm/assurance/agents.py", "claude-sonnet-4-20250514"): 1,
-        ("dharma_swarm/autonomous_agent.py", "claude-sonnet-4-20250514"): 1,
-        ("dharma_swarm/autonomous_agent.py", "claude-sonnet-4-6"): 5,
         ("dharma_swarm/daemon_config.py", "anthropic/claude-sonnet-4"): 1,
         ("dharma_swarm/dharma_context_mcp.py", "meta-llama/llama-3.3-70b-instruct:free"): 1,
         ("dharma_swarm/external_agent_registration.py", "moonshotai/kimi-k2.6"): 1,


### PR DESCRIPTION
## Summary
- route pulse Anthropic key checks through the key registry helper
- move autonomous agent default model literals to the canonical model hierarchy
- redact operator-facing Chetana and A2A console path/subject output while preserving machine receipts
- refresh DocOps count blocks for the added regression coverage

## Coherence Delta
- Organ touched: dharma_swarm/pulse.py, dharma_swarm/autonomous_agent.py, dharma_swarm/chetana/cli.py, scripts/runtime/a2a_send.py, focused security/routing test guards, and DocOps managed counts
- Declared-vs-actual gap closed: closes post-574 review drift where main still contained raw provider-key access, hardcoded autonomous-agent model literals, and operator-facing subject/path disclosure after PR #574 merged
- Proof that re-reads the map: ran focused pytest guard set, reviewer exact pytest command, compileall, DocOps integrity, and commit-time governance hooks
- New drift introduced: none; machine receipts remain full-fidelity while only console output is redacted

## Verification
- pytest -q tests/test_model_key_routing_guard.py tests/test_a2a_send.py dharma_swarm/chetana/tests/test_e2e_cli.py tests/test_autonomous_agent.py
- pytest -q dharma_swarm/chetana/tests tests/test_a2a_send.py tests/test_holon_bridge.py tests/test_holon_runtime.py tests/test_model_key_routing_guard.py
- python3 -m compileall dharma_swarm/chetana scripts/runtime/a2a_send.py api/routers/holon.py dharma_swarm/holon_bridge.py dharma_swarm/holon_runtime.py
- python3 scripts/docops/check_docops_integrity.py --changed-from origin/main --report-json /tmp/main-review-blockers-docops.json
- pre-commit hooks via git commit